### PR TITLE
Work with authentication

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -14,6 +14,12 @@ print("Version 1.2.1, released 29 July 2012")
 
 var dbs = new Array();
 var emptyDbs = new Array();
+
+if (typeof db_name === "string") {
+  db = db.getMongo().getDB( db_name );
+}
+
+
 db.adminCommand('listDatabases').databases.forEach(function(d){
   if(db.getSisterDB(d.name).getCollectionNames().length > 0) {
     dbs.push(d.name);


### PR DESCRIPTION
When authentication is turned on you must log into the admin DB first.

```
mongo -u USER -p PASS admin --eval "var collection = 'COL' " variety.js
```

This does not work because variety will look for the collection in the admin DB.  You also cannot log into the DB with the collection because variety runs admin commands.

The following code will read from a db_name variable if it exists and set the script to use that DB:

```
mongo -u USER-p PASS admin --eval "var collection = 'COL', db_name='DB_NAME'" variety.js
```
