### PR TITLE
Fix of ReferenceError: JSON is not defined

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -52,7 +52,7 @@ if (db[collection].count() == 0) {
 }
 
 if (typeof query === "undefined") { var query = {}; }
-print("Using query of " + JSON.stringify(query));
+print("Using query of " + tojson(query));
 
 if (typeof limit === "undefined") { var limit = db[collection].find(query).count(); }
 print("Using limit of " + limit);


### PR DESCRIPTION
Runing the example on my machine:
mongo db --eval "var collection = 'collection'" variety.js

Fails with:
MongoDB shell version: 2.2.1
connecting to: db_name
Variety: A MongoDB Schema Analyzer
Version 1.2.3, released 01 September 2013
Wed Nov 20 11:30:49 ReferenceError: JSON is not defined variety.js:55
failed to load: variety.js

Apparently this was due to JSON object being uknown for some reason. Proposed change fixes it for me.

Thanks for the very handy tool.
