### PR TITLE
Remove admin database access requirement (hopefully solved by #61)

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -18,31 +18,8 @@ var log = function(message) {
 log('Variety: A MongoDB Schema Analyzer');
 log('Version 1.4.1, released 14 Oct 2014');
 
-var dbs = [];
-var emptyDbs = [];
-
 if (typeof db_name === 'string') {
   db = db.getMongo().getDB( db_name );
-}
-
-
-db.adminCommand('listDatabases').databases.forEach(function(d){
-  if(db.getSisterDB(d.name).getCollectionNames().length > 0) {
-    dbs.push(d.name);
-  }
-  if(db.getSisterDB(d.name).getCollectionNames().length === 0) {
-    emptyDbs.push(d.name);
-  }
-});
-
-if (emptyDbs.indexOf(db.getName()) !== -1) {
-  throw 'The database specified ('+ db +') is empty.\n'+ 
-        'Possible database options are: ' + dbs.join(', ') + '.';
-}
-
-if (dbs.indexOf(db.getName()) === -1) {
-  throw 'The database specified ('+ db +') does not exist.\n'+ 
-        'Possible database options are: ' + dbs.join(', ') + '.';
 }
 
 var collNames = db.getCollectionNames().join(', ');


### PR DESCRIPTION
Hi @JamesCropcho, @smgardner59,

I needed to do a bit more to get variety working with a user that only had access to the target db:
```
mongo -u USER -p PASS TARGET_DB --eval "var collection = 'COLLECTION'" variety.js
```

This fixes #40 at the expense of error reporting when the specified database is empty or does not exist.
Lines 29-46 needed to be removed because they rely on an admin function. This also deprecates lines  21 and 22. Code review requested, because I just did this as a quick fix.