### PR TITLE
#69 - fixed wrong percentage indications in unnamed objects inside arrays

### DIFF
--- a/test/src/test/java/com/github/variety/test/SampleData.java
+++ b/test/src/test/java/com/github/variety/test/SampleData.java
@@ -23,7 +23,7 @@ class SampleData {
             "| name               | String       | 5           | 100      |\n" +
             "| bio                | String       | 3           | 60       |\n" +
             "| birthday           | String       | 2           | 40       |\n" +
-            "| pets               | String,Array | 2           | 40       |\n" +
+            "| pets               | Array,String | 2           | 40       |\n" +
             "| someBinData        | BinData-old  | 1           | 20       |\n" +
             "| someWeirdLegacyKey | String       | 1           | 20       |\n" +
             "+------------------------------------------------------------+";

--- a/test/src/test/java/com/github/variety/test/UnnamedObjectsAnalysisTest.java
+++ b/test/src/test/java/com/github/variety/test/UnnamedObjectsAnalysisTest.java
@@ -9,6 +9,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /**
  * Test, how variety handles objects, that are not named (for example objects inside array).
  * It addresses behavior described in issue https://github.com/variety/variety/issues/29
@@ -20,8 +22,14 @@ public class UnnamedObjectsAnalysisTest {
     @Before
     public void setUp() throws Exception {
         this.variety = new Variety("test", "users");
-        variety.getSourceCollection().insert((DBObject) JSON.parse("{title:'Article 1', comments:[{author:'John', body:'it works', visible:true }]}"));
-        variety.getSourceCollection().insert((DBObject) JSON.parse("{title:'Article 2', comments:[{author:'Tom', body:'thanks'}]}"));
+        variety.getSourceCollection().insert(Arrays.asList(
+                createDbObj("{title:'Article 1', comments:[{author:'John', body:'it works', visible:true }]}"),
+                createDbObj("{title:'Article 2', comments:[{author:'Tom', body:'thanks'}, {author:'Mark', body:1}]}")
+        ));
+    }
+
+    private DBObject createDbObj(final String json) {
+        return (DBObject) JSON.parse(json);
     }
 
     @After
@@ -42,7 +50,7 @@ public class UnnamedObjectsAnalysisTest {
 
         // unnamed objects are prefixed with .XX key
         analysis.validate("comments.XX.author", 2, 100, "String");
-        analysis.validate("comments.XX.body", 2, 100, "String");
+        analysis.validate("comments.XX.body", 2, 100, "String", "Number");
         analysis.validate("comments.XX.visible", 1, 50, "Boolean");
     }
 }


### PR DESCRIPTION
The analysis of documents now runs in two steps. 

First there are aggregated keys and types of one document. If there are two or more same keys (due to unnamed objects inside arrays, containing .XX.), they are merged into one item. This prevents counting the key multiple times for one document.

Complete results are then aggregation of this pre-merged document fingerprints. 

Also, the array of types is now alphabetically ordered to remove randomness (and failing tests). 