### PR TITLE
Math.max.apply replaced by reduce - RangeError (#93) fixed.

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -281,7 +281,7 @@ if($outputFormat === 'json') {
       return res !== null ? res[1].length : 1;
     };
 
-  var maxDigits = Math.max.apply(null, varietyResults.map(function(value){return significantDigits(value.percentContaining);}));
+  var maxDigits = varietyResults.map(function(value){return significantDigits(value.percentContaining);}).reduce(function(acc,val){return acc>val?acc:val;});
 
   varietyResults.forEach(function(key) {
     table.push([key._id.key, key.value.types.toString(), key.totalOccurrences.toString(), key.percentContaining.toFixed(maxDigits).toString()]);


### PR DESCRIPTION
For big arrays (~10⁷ elements), Math.max produces the following error:

> RangeError: Maximum call stack size exceeded

(source: [stackoverflow.com](http://stackoverflow.com/a/13440842))
