### PR TITLE
add rounding percents

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -71,6 +71,7 @@ var readConfig = function(configProvider) {
   read('sort', {_id: -1});
   read('outputFormat', 'ascii');
   read('persistResults', false);
+  read('round', false);
   return config;
 };
 
@@ -236,11 +237,15 @@ var convertResults = function(interimResults, documentsCount) {
   //now convert the interimResults into the proper format
   for(var key in interimResults) {
     var entry = interimResults[key];
+    var percents = entry.totalOccurrences * 100 / documentsCount;
+    if(config.round){
+        percents = Math.round(percents*2)/2;
+    }
     varietyResults.push({
         '_id': {'key':key},
         'value': {'types':getKeys(entry.types)},
         'totalOccurrences': entry.totalOccurrences,
-        'percentContaining': entry.totalOccurrences * 100 / documentsCount
+        'percentContaining': percents
     });
   }
   return varietyResults;


### PR DESCRIPTION
Hi!
I just added rounding of percentages in the output table. It would be useful if, we have many numbers after the dot in the `percents` column . Example:

```
+-------------------------------------------------------------------------------+
| key                        | types        | occurrences | percents            |
| -------------------------- | ------------ | ----------- | ------------------- |
| _id                        | ObjectId     |          11 | 100.000000000000000 |
| name                       | String       |          10 |  90.909090909090907 |
| bio                        | String       |           3 |  27.272727272727273 |
```

After applying 

```
mongo test --eval "var collection = 'users',round=true" variety.js
```

The table will look like:

```
--------------------------------------------------------------------+
| key                        | types        | occurrences | percents |
| -------------------------- | ------------ | ----------- | -------- |
| _id                        | ObjectId     |          11 |    100.0 |
| name                       | String       |          10 |     91.0 |
| bio                        | String       |           3 |     27.5 |
```

What do you think about this?
