### PR TITLE
Add support for external results database

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,8 @@
     "outputFormat": true,
     "persistResults": true,
     "plugins": true,
-    "slaveOk" : true
+    "slaveOk" : true,
+    "connect": true
   },
   "latedef": true,
   "singleGroups": true,

--- a/README.markdown
+++ b/README.markdown
@@ -161,12 +161,12 @@ If the source collection's name is ```users```, Variety will store results in co
 
     $ mongo test --quiet --eval "var collection = 'users', persistResults=true" variety.js
 
-To persist to an alternate Mongo database, you may specify the following parameters:
+To persist to an alternate MongoDB database, you may specify the following parameters:
 
   * `resultsDatabase` - The database to store Variety results in. Accepts either a database name or a `host[:port]/database` URL.
   * `resultsCollection` - Collection to store Variety results in. **WARNING:** This collection is dropped before results are inserted.
-  * `resultsUser` - Mongo username for results database
-  * `resultsPass` - Mongo password for results database
+  * `resultsUser` - MongoDB username for results database
+  * `resultsPass` - MongoDB password for results database
 
 ```
 $ mongo test --quiet --eval "var collection = 'users', persistResults=true, resultsDatabase='db.example.com/variety' variety.js

--- a/README.markdown
+++ b/README.markdown
@@ -155,11 +155,22 @@ by setting the ```slaveOk``` property to ```true```:
     $ mongo secondary.replicaset.member:31337/somedb --eval "var collection = 'users', slaveOk = true" variety.js
 
 ### Save Results in MongoDB For Future Use ###
-By default, Variety prints results only to standard output and does not store them in MongoDB itself. If you want to persist them automatically in database for later usage, you can set the parameter ```persistResults```.
+By default, Variety prints results only to standard output and does not store them in MongoDB itself. If you want to persist them automatically in MongoDB for later usage, you can set the parameter ```persistResults```.
 Variety then stores result documents in database ```varietyResults``` and the collection name is derived from the source collection's name.
 If the source collection's name is ```users```, Variety will store results in collection ```usersKeys``` under ```varietyResults``` database.
 
     $ mongo test --quiet --eval "var collection = 'users', persistResults=true" variety.js
+
+To persist to an alternate Mongo database, you may specify the following parameters:
+
+  * `resultsDatabase` - The database to store Variety results in. Accepts either a database name or a `host[:port]/database` URL.
+  * `resultsCollection` - Collection to store Variety results in. **WARNING:** This collection is dropped before results are inserted.
+  * `resultsUser` - Mongo username for results database
+  * `resultsPass` - Mongo password for results database
+
+```
+$ mongo test --quiet --eval "var collection = 'users', persistResults=true, resultsDatabase='db.example.com/variety' variety.js
+```
 
 ### Command Line Interface
 Variety itself is command line friendly, as shown on examples above.

--- a/variety.js
+++ b/variety.js
@@ -77,6 +77,10 @@ var readConfig = function(configProvider) {
   read('sort', {_id: -1});
   read('outputFormat', 'ascii');
   read('persistResults', false);
+  read('resultsDatabase', 'varietyResults');
+  read('resultsCollection', collection + 'Keys');
+  read('resultsUser', null);
+  read('resultsPass', null);
   return config;
 };
 
@@ -297,11 +301,23 @@ var varietyResults = convertResults(interimResults, cursor.size())
   .sort(comparator);
 
 if(config.persistResults) {
-  var resultsDB = db.getMongo().getDB('varietyResults');
-  var resultsCollectionName = collection + 'Keys';
+  var resultsDB;
+  var resultsCollectionName = config.resultsCollection;
+
+  if (config.resultsDatabase.indexOf('/') === -1) {
+    // Local database; don't reconnect
+    resultsDB = db.getMongo().getDB(config.resultsDatabase);
+  } else {
+    // Remote database, establish new connection
+    resultsDB = connect(config.resultsDatabase);
+  }
+
+  if (config.resultsUser != null && config.resultsPass != null) {
+    resultsDB.auth(config.resultsUser, config.resultsPass);
+  }
 
   // replace results collection
-  log('creating results collection: '+resultsCollectionName);
+  log('replacing results collection: '+ resultsCollectionName);
   resultsDB[resultsCollectionName].drop();
   resultsDB[resultsCollectionName].insert(varietyResults);
 }

--- a/variety.js
+++ b/variety.js
@@ -312,7 +312,7 @@ if(config.persistResults) {
     resultsDB = connect(config.resultsDatabase);
   }
 
-  if (config.resultsUser != null && config.resultsPass != null) {
+  if (config.resultsUser !== null && config.resultsPass !== null) {
     resultsDB.auth(config.resultsUser, config.resultsPass);
   }
 


### PR DESCRIPTION
Introduces new options for defining an external database for persisting Variety results.

 * `resultsDatabase` - The database to store Variety results in. Accepts either a database name or a `host[:port]/database` URL.
 * `resultsCollection` - Collection to store Variety results in
 * `resultsUser` - Mongo username for results database
 * `resultsPass` - Mongo password for results database