### PR TITLE
Added option for logging keys and types as they occur

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -148,6 +148,11 @@ Variety can also read that option and mute unnecessary output. This is useful in
 
     $ mongo test --quiet --eval "var collection = 'users', sort = { updated_at : -1 }" variety.js
 
+#### Log Keys and Types As They Arrive Option ####
+Sometimes you want to see the keys and types come in as it happens.  Maybe you have a large dataset and want accurate results, but you also are impatent and want to see something now.  Or maybe you have a large mangled dataset with crazy keys (that probably shouldn't be keys) and variety is going out of memory.  This option will show you the keys and types as they come in and help you identify problems with your dataset without needing the variety script to finish.  
+
+    $ mongo test --eval "var collection = 'users', sort = { updated_at : -1 }, logKeysContinuously = true" variety.js
+
 #### Secondary Reads ####
 Analyzing a large collection on a busy replica set primary could take a lot longer than if you read from a secondary. To do so, we have to tell MongoDB it's okay to perform secondary reads
 by setting the ```slaveOk``` property to ```true```:

--- a/variety.js
+++ b/variety.js
@@ -232,7 +232,7 @@ var mergeDocument = function(docResult, interimResults) {
         } else {
           existing.types[type] = 1;
           if (config.logKeysContinuously) {
-            log('Found new key type "' + key + '" type "' + type '"');
+            log('Found new key type "' + key + '" type "' + type + '"');
           }
         }
       }
@@ -242,7 +242,7 @@ var mergeDocument = function(docResult, interimResults) {
       for (var newType in docResult[key]) {
         types[newType] = 1;
         if (config.logKeysContinuously) {
-          log('Found new key type "' + key + '" type "' + newType '"');
+          log('Found new key type "' + key + '" type "' + newType + '"');
         }
       }
       interimResults[key] = {'types': types,'totalOccurrences':1};

--- a/variety.js
+++ b/variety.js
@@ -81,6 +81,7 @@ var readConfig = function(configProvider) {
   read('resultsCollection', collection + 'Keys');
   read('resultsUser', null);
   read('resultsPass', null);
+  read('logKeysContinuously', false);
   return config;
 };
 
@@ -230,6 +231,9 @@ var mergeDocument = function(docResult, interimResults) {
           existing.types[type] = existing.types[type] + 1;
         } else {
           existing.types[type] = 1;
+          if (config.logKeysContinuously) {
+            log('Found new key type "' + key + '" type "' + type '"');
+          }
         }
       }
       existing.totalOccurrences = existing.totalOccurrences + 1;
@@ -237,6 +241,9 @@ var mergeDocument = function(docResult, interimResults) {
       var types = {};
       for (var newType in docResult[key]) {
         types[newType] = 1;
+        if (config.logKeysContinuously) {
+          log('Found new key type "' + key + '" type "' + newType '"');
+        }
       }
       interimResults[key] = {'types': types,'totalOccurrences':1};
     }


### PR DESCRIPTION
Logs new keys as they occur.  For faster results when going through large datasets and for debugging large mangled databases where the keys are convoluted and will cause the script to go out of memory.  

Prints logs in the following format: `Found new key type "{{keystring.XX.keystring}}" type "{{Type}}"`