### PR TITLE
ES6 and ES7 features in tests (import, export, async & await)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
- "presets": ["es2015" ]
+ "presets": ["es2015", "stage-0"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "parser": "babel-eslint",
     "env": {
         "mongo": true,
         "node": true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "node_modules/.bin/eslint variety.js spec",
     "lint:fix": "node_modules/.bin/eslint variety.js spec --fix",
-    "test": "node_modules/.bin/mocha --compilers js:babel-core/register --recursive --reporter spec --timeout 15000 spec",
+    "test": "node_modules/.bin/mocha --compilers js:babel-core/register --require babel-polyfill  --recursive --reporter spec --timeout 15000 spec",
     "test:docker": "./test.sh",
     "travis-ci": "npm run lint && npm run test:docker"
   },
@@ -30,11 +30,13 @@
   "homepage": "https://github.com/variety/variety#readme",
   "devDependencies": {
     "babel-core": "^6.7.2",
+    "babel-eslint": "^6.0.2",
+    "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.5.0",
     "child-process-promise": "^1.1.0",
     "eslint": "^2.4.0",
     "mocha": "^2.4.5",
-    "mongodb": "^2.1.7",
-    "q": "^1.4.1"
+    "mongodb": "^2.1.7"
   }
 }

--- a/spec/BasicAnalysisTest.js
+++ b/spec/BasicAnalysisTest.js
@@ -1,34 +1,29 @@
-const assert = require('assert');
-const Tester = require('./utils/Tester.js');
+import assert from 'assert';
+import Tester from './utils/Tester.js';
 const test = new Tester('test', 'users');
 
-const sampleData = require('./assets/SampleData');
-const expectedAscii = require('./assets/ExpectedAscii');
+import sampleData from './assets/SampleData';
+import expectedAscii  from './assets/ExpectedAscii';
 
 describe('Basic Analysis', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should return ASCII results', () => {
-    return test.runAnalysis({collection:'users'}, true).then(output => {
-      assert.equal(output, expectedAscii);
-    });
+  it('should return ASCII results', async () => {
+    const output = await test.runAnalysis({collection:'users'}, true);
+    assert.equal(output, expectedAscii);
   });
 
-  it('should return JSON results', () => {
-    return test.runJsonAnalysis({collection:'users'}, true)
-      .then(results => {
-
-        results.validateResultsCount(7);
-
-        results.validate('_id', 5, 100.0, {ObjectId: 5});
-        results.validate('name', 5, 100.0, {String: 5});
-        results.validate('bio', 3, 60.0, {String: 3});
-        results.validate('birthday', 2,  40.0, {Date: 2});
-        results.validate('pets', 2,  40.0, {String: 1, Array: 1});
-        results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
-        results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
-      });
+  it('should return JSON results', async () => {
+    const results = await test.runJsonAnalysis({collection:'users'}, true);
+    results.validateResultsCount(7);
+    results.validate('_id', 5, 100.0, {ObjectId: 5});
+    results.validate('name', 5, 100.0, {String: 5});
+    results.validate('bio', 3, 60.0, {String: 3});
+    results.validate('birthday', 2,  40.0, {Date: 2});
+    results.validate('pets', 2,  40.0, {String: 1, Array: 1});
+    results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
+    results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
   });
 });

--- a/spec/ContinuousLoggingTest.js
+++ b/spec/ContinuousLoggingTest.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
-const Tester = require('./utils/Tester.js');
-const test = new Tester('test', 'users');
+import assert from 'assert';
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
 
-const sampleData = require('./assets/SampleData');
+const test = new Tester('test', 'users');
 
 const pattern = /^Found new key type "(.{1,})" type "(.{1,})"$/g;
 const expectedLines = [
@@ -19,21 +19,20 @@ const expectedLines = [
 
 
 
-describe('Continuous logging', () => {
+describe('Continuous logging', async () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should log every new key', () => {
-    return test.runAnalysis({collection:'users', logKeysContinuously:true}).then(output => {
-      var filteredOutput = output
-        .split('\n')
-        .filter(line => line.match(pattern));
-      assert.equal(filteredOutput.length, expectedLines.length);
-      expectedLines.forEach(expectedLine => {
-        const found = filteredOutput.indexOf(expectedLine) > -1;
-        assert.ok(found, `Expected line '${expectedLine}' not found in Variety output`);
-      });
+  it('should log every new key', async () => {
+    const output = await test.runAnalysis({collection:'users', logKeysContinuously:true});
+    var filteredOutput = output
+      .split('\n')
+      .filter(line => line.match(pattern));
+    assert.equal(filteredOutput.length, expectedLines.length);
+    expectedLines.forEach(expectedLine => {
+      const found = filteredOutput.indexOf(expectedLine) > -1;
+      assert.ok(found, `Expected line '${expectedLine}' not found in Variety output`);
     });
   });
 });

--- a/spec/DatatypeRecognitionTest.js
+++ b/spec/DatatypeRecognitionTest.js
@@ -1,5 +1,5 @@
-const Binary = require('mongodb').Binary;
-const Tester = require('./utils/Tester.js');
+import { Binary } from 'mongodb';
+import Tester from './utils/Tester.js';
 const test = new Tester('test', 'users');
 
 const crazyObject = {
@@ -18,17 +18,15 @@ describe('Data type recognition', () => {
   beforeEach(() => test.init([crazyObject]));
   afterEach(() => test.cleanUp());
 
-  it('should recognize all supported data types', () => {
-    return test.runJsonAnalysis({collection:'users'}, true)
-      .then(results => {
-        results.validate('_id', 1, 100.0, {ObjectId: 1});
-        results.validate('key_string', 1, 100.0, {String: 1});
-        results.validate('key_number', 1, 100.0, {Number: 1});
-        results.validate('key_date', 1, 100.0, {Date: 1});
-        results.validate('key_binData-generic', 1, 100.0, {'BinData-generic': 1});
-        results.validate('key_array', 1, 100.0, {Array: 1});
-        results.validate('key_object', 1, 100.0, {Object: 1});
-        results.validate('key_null', 1, 100.0, {null: 1}); // TODO: why has 'null' first letter lowercase, unlike all other types?
-      });
+  it('should recognize all supported data types', async () => {
+    const results = await test.runJsonAnalysis({collection:'users'}, true);
+    results.validate('_id', 1, 100.0, {ObjectId: 1});
+    results.validate('key_string', 1, 100.0, {String: 1});
+    results.validate('key_number', 1, 100.0, {Number: 1});
+    results.validate('key_date', 1, 100.0, {Date: 1});
+    results.validate('key_binData-generic', 1, 100.0, {'BinData-generic': 1});
+    results.validate('key_array', 1, 100.0, {Array: 1});
+    results.validate('key_object', 1, 100.0, {Object: 1});
+    results.validate('key_null', 1, 100.0, {null: 1}); // TODO: why has 'null' first letter lowercase, unlike all other types?
   });
 });

--- a/spec/LimitResultsAnalysisTest.js
+++ b/spec/LimitResultsAnalysisTest.js
@@ -1,35 +1,34 @@
-const Tester = require('./utils/Tester.js');
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
+
 const test = new Tester('test', 'users');
-const sampleData = require('./assets/SampleData');
 
 describe('Limited results count analysis', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should analyze only first item', () => {
+  it('should analyze only first item', async () => {
     // limit=1 without other params selects the last inserted document (see sampleData)
     // it should equals {name: "Jim", someBinData: new BinData(2,"1234")}
-    return test.runJsonAnalysis({collection:'users', limit:1}).then(results => {
-      results.validate('_id', 1, 100.0, {ObjectId:1});
-      results.validate('name', 1, 100.0, {String:1});
-      results.validate('someBinData', 1, 100.0, {'BinData-generic':1});
-    });
+    const results = await test.runJsonAnalysis({collection:'users', limit:1});
+    results.validate('_id', 1, 100.0, {ObjectId:1});
+    results.validate('name', 1, 100.0, {String:1});
+    results.validate('someBinData', 1, 100.0, {'BinData-generic':1});
   });
 
-  it('should analyze all and compute real percentages', () => {
-    return test.runJsonAnalysis({collection:'users', limit:10}).then(results => {
+  it('should analyze all and compute real percentages', async () => {
+    const results = await test.runJsonAnalysis({collection:'users', limit:10});
       // limit is set to higher number, that the actual number of documents in collection
       // analysis should compute percentages based on the real number of documents, not on the
       // number provided in the limit var.
-      results.validateResultsCount(7);
-      results.validate('_id', 5, 100.0, {ObjectId: 5});
-      results.validate('name', 5, 100.0, {String: 5});
-      results.validate('bio', 3, 60.0, {String: 3});
-      results.validate('birthday', 2,  40.0, {Date: 2});
-      results.validate('pets', 2,  40.0, {String: 1, Array: 1});
-      results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
-      results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
-    });
+    results.validateResultsCount(7);
+    results.validate('_id', 5, 100.0, {ObjectId: 5});
+    results.validate('name', 5, 100.0, {String: 5});
+    results.validate('bio', 3, 60.0, {String: 3});
+    results.validate('birthday', 2,  40.0, {Date: 2});
+    results.validate('pets', 2,  40.0, {String: 1, Array: 1});
+    results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
+    results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
   });
 });

--- a/spec/MaxDepthAnalysisTest.js
+++ b/spec/MaxDepthAnalysisTest.js
@@ -1,4 +1,4 @@
-const Tester = require('./utils/Tester.js');
+import Tester from './utils/Tester.js';
 const test = new Tester('test', 'users');
 
 describe('Max-depth-limited analysis', () => {
@@ -6,32 +6,30 @@ describe('Max-depth-limited analysis', () => {
   beforeEach(() => test.init([{name:'Walter', someNestedObject:{a:{b:{c:{d:{e:1}}}}}}]));
   afterEach(() => test.cleanUp());
 
-  it('should return all keys', () => {
-    return test.runJsonAnalysis({collection:'users'}).then(results => {
+  it('should return all keys', async () => {
+    const results = await test.runJsonAnalysis({collection:'users'});
 
-      results.validateResultsCount(8);
+    results.validateResultsCount(8);
 
-      results.validate('_id', 1, 100.0, {ObjectId:1});
-      results.validate('name', 1, 100.0, {String:1});
-      results.validate('someNestedObject', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a.b', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a.b.c', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a.b.c.d', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a.b.c.d.e', 1, 100.0, {Number:1});
-    });
+    results.validate('_id', 1, 100.0, {ObjectId:1});
+    results.validate('name', 1, 100.0, {String:1});
+    results.validate('someNestedObject', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a.b', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a.b.c', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a.b.c.d', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a.b.c.d.e', 1, 100.0, {Number:1});
   });
 
-  it('should return only first 3 levels', () => {
-    return test.runJsonAnalysis({collection:'users', maxDepth:3}).then(results => {
+  it('should return only first 3 levels', async () => {
+    const results = await test.runJsonAnalysis({collection:'users', maxDepth:3});
 
-      results.validateResultsCount(5);
+    results.validateResultsCount(5);
 
-      results.validate('_id', 1, 100.0, {ObjectId:1});
-      results.validate('name', 1, 100.0, {String:1});
-      results.validate('someNestedObject', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a', 1, 100.0, {Object:1});
-      results.validate('someNestedObject.a.b', 1, 100.0, {Object:1});
-    });
+    results.validate('_id', 1, 100.0, {ObjectId:1});
+    results.validate('name', 1, 100.0, {String:1});
+    results.validate('someNestedObject', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a', 1, 100.0, {Object:1});
+    results.validate('someNestedObject.a.b', 1, 100.0, {Object:1});
   });
 });

--- a/spec/ParametersParsingTest.js
+++ b/spec/ParametersParsingTest.js
@@ -1,7 +1,8 @@
-const assert = require('assert');
-const Tester = require('./utils/Tester.js');
+import assert from 'assert';
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
+
 const test = new Tester('test', 'users');
-const sampleData = require('./assets/SampleData');
 
 const parseParams = (output) => {
   return output
@@ -16,26 +17,24 @@ describe('Parameters parsing', () => {
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should parse default params', () => {
-    return test.runAnalysis({collection:'users'})
-      .then(parseParams)
-      .then(params => {
-        assert.equal(params.collection, 'users');
-        assert.deepEqual(params.query, {});
-        assert.equal(params.limit, 5);
-        assert.equal(params.maxDepth, 99);
-        assert.deepEqual(params.sort, {'_id':-1});
-        assert.equal(params.outputFormat, 'ascii');
-        assert.equal(params.persistResults, false);
-        assert.equal(params.resultsDatabase, 'varietyResults');
-        assert.equal(params.resultsCollection, 'usersKeys');
-        assert.equal(params.resultsUser, null);
-        assert.equal(params.resultsPass, null);
-        assert.deepEqual(params.plugins, []);
-      });
+  it('should parse default params', async () => {
+    const results = await test.runAnalysis({collection:'users'});
+    const params = parseParams(results);
+    assert.equal(params.collection, 'users');
+    assert.deepEqual(params.query, {});
+    assert.equal(params.limit, 5);
+    assert.equal(params.maxDepth, 99);
+    assert.deepEqual(params.sort, {'_id':-1});
+    assert.equal(params.outputFormat, 'ascii');
+    assert.equal(params.persistResults, false);
+    assert.equal(params.resultsDatabase, 'varietyResults');
+    assert.equal(params.resultsCollection, 'usersKeys');
+    assert.equal(params.resultsUser, null);
+    assert.equal(params.resultsPass, null);
+    assert.deepEqual(params.plugins, []);
   });
 
-  it('should parse restricted results', () => {
+  it('should parse restricted results', async () => {
 
     const criteria = {
       collection:'users',
@@ -45,23 +44,22 @@ describe('Parameters parsing', () => {
       limit: 2
     };
 
-    return test.runAnalysis(criteria)
-      .then(parseParams)
-      .then(params => {
-        assert.equal(params.limit, 2);
-        assert.equal(params.maxDepth, 5);
-        assert.deepEqual(params.sort, {name:1});
-        assert.deepEqual(params.query, {name:'Harry'});
-      });
+    const results = await test.runAnalysis(criteria);
+    const params = parseParams(results);
+    assert.equal(params.limit, 2);
+    assert.equal(params.maxDepth, 5);
+    assert.deepEqual(params.sort, {name:1});
+    assert.deepEqual(params.query, {name:'Harry'});
   });
 
-  it('should recognize unknown collection', () => {
-    return test.runAnalysis({collection:'--unknown--'})
-      .then(() => {throw new Error('Should fail and be handled in catch branch');})
-      .catch(err => {
-        assert.ok(err.code > 0);
-        assert.ok(err.stdout.indexOf('The collection specified (--unknown--) in the database specified (test) does not exist or is empty.') > -1);
-      });
+  it('should recognize unknown collection', async () => {
+    try {
+      await test.runAnalysis({collection:'--unknown--'});
+      throw new Error('Should fail and be handled in catch branch');
+    } catch(err) {
+      assert.ok(err.code > 0);
+      assert.ok(err.stdout.indexOf('The collection specified (--unknown--) in the database specified (test) does not exist or is empty.') > -1);
+    }
   });
 
 });

--- a/spec/PersistenceTest.js
+++ b/spec/PersistenceTest.js
@@ -1,23 +1,20 @@
-const assert = require('assert');
-const Tester = require('./utils/Tester.js');
+import assert from 'assert';
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
 
 const test = new Tester('test', 'users');
-
-const sampleData = require('./assets/SampleData');
 
 describe('Persistence of results', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should persist results into varietyResults DB', () => {
-    return test.runAnalysis({collection:'users', persistResults: true}, true)
-      .then(() => test.getDb('varietyResults'))
-      .then((db) => db.collection('usersKeys').find().toArray())
-      .then((arr) => {
-        assert.equal(arr.length, 7);
-        let keys = arr.map(it => it._id.key);
-        assert.deepEqual(keys, ['_id', 'name', 'bio', 'birthday', 'pets', 'someBinData', 'someWeirdLegacyKey']);
-      });
+  it('should persist results into varietyResults DB', async () => {
+    await test.runAnalysis({collection:'users', persistResults: true}, true);
+    const db = await test.getDb('varietyResults');
+    const arr = await db.collection('usersKeys').find().toArray();
+    assert.equal(arr.length, 7);
+    const keys = arr.map(it => it._id.key);
+    assert.deepEqual(keys, ['_id', 'name', 'bio', 'birthday', 'pets', 'someBinData', 'someWeirdLegacyKey']);
   });
 });

--- a/spec/PluginTest.js
+++ b/spec/PluginTest.js
@@ -1,9 +1,9 @@
-const assert = require('assert');
-const Tester = require('./utils/Tester.js');
-const path = require('path');
-const test = new Tester('test', 'users');
+import assert from 'assert';
+import Tester from './utils/Tester.js';
+import { resolve, join } from 'path';
+import sampleData from './assets/SampleData';
 
-const sampleData = require('./assets/SampleData');
+const test = new Tester('test', 'users');
 
 const expectedOutput = `
 key|types|occurrences|percents
@@ -16,24 +16,22 @@ someBinData|BinData-generic|1|20
 someWeirdLegacyKey|String|1|20
 `.trim();
 
-const getPluginPath = () => path.resolve(path.join(__dirname , 'assets', 'csvplugin.js'));
+const getPluginPath = () => resolve(join(__dirname , 'assets', 'csvplugin.js'));
 
 describe('Plugins', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should load plugin and modify output', () => {
-    return test.runAnalysis({collection:'users', plugins: getPluginPath()}, true).then(output => {
-      assert.equal(output, expectedOutput);
-    });
+  it('should load plugin and modify output', async () => {
+    const output = await test.runAnalysis({collection:'users', plugins: getPluginPath()}, true);
+    assert.equal(output, expectedOutput);
   });
 
-  it('should read additional plugin params', () => {
-    return test.runAnalysis({collection:'users', plugins: getPluginPath() + '|delimiter=;'}, true).then(output => {
-      const expectedWithSeparator = expectedOutput.replace(/\|/g, ';');
-      assert.equal(output, expectedWithSeparator);
-    });
+  it('should read additional plugin params', async () => {
+    const output = await test.runAnalysis({collection:'users', plugins: getPluginPath() + '|delimiter=;'}, true);
+    const expectedWithSeparator = expectedOutput.replace(/\|/g, ';');
+    assert.equal(output, expectedWithSeparator);
   });
 
 });

--- a/spec/QueryLimitedAnalysisTest.js
+++ b/spec/QueryLimitedAnalysisTest.js
@@ -1,21 +1,19 @@
-const Tester = require('./utils/Tester.js');
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
 const test = new Tester('test', 'users');
-
-const sampleData = require('./assets/SampleData');
 
 describe('Query-limited analysis', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should return only filtered values', () => {
-    return test.runJsonAnalysis({collection:'users', query:{birthday:{$exists: true}}}).then(results => {
-      results.validateResultsCount(5);
-      results.validate('_id', 2, 100.0, {ObjectId: 2});
-      results.validate('birthday', 2, 100.0, {Date: 2});
-      results.validate('name', 2, 100.0, {String: 2});
-      results.validate('bio', 1, 50.0, {String: 1});
-      results.validate('pets', 1, 50.0, {String: 1});
-    });
+  it('should return only filtered values', async () => {
+    const results = await test.runJsonAnalysis({collection:'users', query:{birthday:{$exists: true}}});
+    results.validateResultsCount(5);
+    results.validate('_id', 2, 100.0, {ObjectId: 2});
+    results.validate('birthday', 2, 100.0, {Date: 2});
+    results.validate('name', 2, 100.0, {String: 2});
+    results.validate('bio', 1, 50.0, {String: 1});
+    results.validate('pets', 1, 50.0, {String: 1});
   });
 });

--- a/spec/SortedAnalysisTest.js
+++ b/spec/SortedAnalysisTest.js
@@ -1,27 +1,26 @@
-const Tester = require('./utils/Tester.js');
-const test = new Tester('test', 'users');
+import Tester from './utils/Tester.js';
+import sampleData from './assets/SampleData';
 
-const sampleData = require('./assets/SampleData');
+const test = new Tester('test', 'users');
 
 describe('Sorted-data analysis', () => {
 
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should not exclude any results', () => {
-    return test.runJsonAnalysis({collection:'users', sort:{name:-1}}).then(results => {
-      results.validateResultsCount(7);
-      results.validate('_id', 5, 100.0, {ObjectId: 5});
-      results.validate('name', 5, 100.0, {String: 5});
-      results.validate('bio', 3, 60.0, {String: 3});
-      results.validate('birthday', 2,  40.0, {Date: 2});
-      results.validate('pets', 2,  40.0, {String: 1, Array: 1});
-      results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
-      results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
-    });
+  it('should not exclude any results', async () => {
+    const results = await test.runJsonAnalysis({collection:'users', sort:{name:-1}});
+    results.validateResultsCount(7);
+    results.validate('_id', 5, 100.0, {ObjectId: 5});
+    results.validate('name', 5, 100.0, {String: 5});
+    results.validate('bio', 3, 60.0, {String: 3});
+    results.validate('birthday', 2,  40.0, {Date: 2});
+    results.validate('pets', 2,  40.0, {String: 1, Array: 1});
+    results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
+    results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1});
   });
 
-  it('should sort and apply limit', () => {
+  it('should sort and apply limit', async () => {
     const criteria = {
       collection:'users',
       sort:{name:-1},
@@ -32,13 +31,12 @@ describe('Sorted-data analysis', () => {
     // Together with applying limit 1, Tom is the only result in analysis. That gives us chance to assume keys and verify
     // that ordering is correct.
     // {name: "Tom", bio: "A nice guy.", pets: ["monkey", "fish"], someWeirdLegacyKey: "I like Ike!"}
-    return test.runJsonAnalysis(criteria).then(results => {
-      results.validateResultsCount(5);
-      results.validate('_id', 1, 100.0, {ObjectId: 1});
-      results.validate('name', 1, 100.0, {String: 1});
-      results.validate('bio', 1, 100.0, {String: 1});
-      results.validate('pets', 1, 100.0, {Array: 1});
-      results.validate('someWeirdLegacyKey', 1, 100.0, {String: 1});
-    });
+    const results = await test.runJsonAnalysis(criteria);
+    results.validateResultsCount(5);
+    results.validate('_id', 1, 100.0, {ObjectId: 1});
+    results.validate('name', 1, 100.0, {String: 1});
+    results.validate('bio', 1, 100.0, {String: 1});
+    results.validate('pets', 1, 100.0, {Array: 1});
+    results.validate('someWeirdLegacyKey', 1, 100.0, {String: 1});
   });
 });

--- a/spec/UnnamedObjectsAnalysisTest.js
+++ b/spec/UnnamedObjectsAnalysisTest.js
@@ -1,4 +1,4 @@
-const Tester = require('./utils/Tester.js');
+import Tester from './utils/Tester.js';
 const test = new Tester('test', 'users');
 
 const sampleData = [
@@ -14,18 +14,17 @@ describe('Unnamed object analysis', () => {
   beforeEach(() => test.init(sampleData));
   afterEach(() => test.cleanUp());
 
-  it('should handle keys of unnamed object', () => {
-    return test.runJsonAnalysis({collection:'users'}, true)
-      .then(results => {
-        results.validateResultsCount(6);
-        results.validate('_id', 2, 100.0, {ObjectId: 2});
-        results.validate('title', 2, 100.0, {String: 2});
-        results.validate('comments', 2, 100.0, {Array: 2});
+  it('should handle keys of unnamed object', async () => {
+    const results = await test.runJsonAnalysis({collection:'users'}, true);
 
-        // unnamed objects are prefixed with .XX key
-        results.validate('comments.XX.author', 2, 100.0, {String: 2});
-        results.validate('comments.XX.body', 2, 100.0, {String: 2, Number:1});
-        results.validate('comments.XX.visible', 1, 50.0, {Boolean: 1});
-      });
+    results.validateResultsCount(6);
+    results.validate('_id', 2, 100.0, {ObjectId: 2});
+    results.validate('title', 2, 100.0, {String: 2});
+    results.validate('comments', 2, 100.0, {Array: 2});
+
+    // unnamed objects are prefixed with .XX key
+    results.validate('comments.XX.author', 2, 100.0, {String: 2});
+    results.validate('comments.XX.body', 2, 100.0, {String: 2, Number:1});
+    results.validate('comments.XX.visible', 1, 50.0, {Boolean: 1});
   });
 });

--- a/spec/assets/ExpectedAscii.js
+++ b/spec/assets/ExpectedAscii.js
@@ -1,4 +1,4 @@
-module.exports =`
+export default `
 
 +--------------------------------------------------------------------+
 | key                | types                | occurrences | percents |

--- a/spec/assets/SampleData.js
+++ b/spec/assets/SampleData.js
@@ -1,6 +1,6 @@
-var Binary = require('mongodb').Binary;
+import { Binary } from 'mongodb';
 
-module.exports = [{
+export default [{
   'name': 'Tom',
   'bio': 'A nice guy.',
   'pets': ['monkey', 'fish'],

--- a/spec/utils/JsonValidator.js
+++ b/spec/utils/JsonValidator.js
@@ -1,25 +1,23 @@
 'use strict';
 
-const assert = require('assert');
+import { equal, deepEqual }  from 'assert';
 
-class JsonValidator {
+export default class JsonValidator {
   constructor(results) {
     this.results = results;
   }
 
   validate(key, totalOccurrences, percentContaining, types) {
-    let row = this.results.filter(item => item._id.key === key)[0];
+    const row = this.results.filter(item => item._id.key === key)[0];
     if(typeof row === 'undefined') {
       throw new Error(`Key '${key}' is not present in results`);
     }
-    assert.equal(row.totalOccurrences, totalOccurrences, `TotalOccurrences of key ${key} does not match`);
-    assert.equal(row.percentContaining, percentContaining, `PercentContaining of key ${key} does not match`);
-    assert.deepEqual(row.value.types, types, `Types of key ${key} do not match`);
+    equal(row.totalOccurrences, totalOccurrences, `TotalOccurrences of key ${key} does not match`);
+    equal(row.percentContaining, percentContaining, `PercentContaining of key ${key} does not match`);
+    deepEqual(row.value.types, types, `Types of key ${key} do not match`);
   }
 
   validateResultsCount(count) {
-    assert.equal(this.results.length, count, 'Total count of results does not match expected count.');
+    equal(this.results.length, count, 'Total count of results does not match expected count.');
   }
 }
-
-module.exports = JsonValidator;

--- a/spec/utils/MongoShell.js
+++ b/spec/utils/MongoShell.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const exec = require('child-process-promise').exec;
+import { exec } from 'child-process-promise';
 
-const execute = (database, credentials, args, script, quiet, port) => {
-  let commands = ['mongo'];
+export default async (database, credentials, args, script, quiet, port) => {
+  const commands = ['mongo'];
 
   commands.push('--port');
   commands.push(port);
@@ -33,10 +33,6 @@ const execute = (database, credentials, args, script, quiet, port) => {
     commands.push(script);
   }
 
-  return exec(commands.join(' '))
-    .then(result => result.stdout.trim());
-};
-
-module.exports = {
-  execute:execute
+  const result = await exec(commands.join(' '));
+  return result.stdout.trim();
 };


### PR DESCRIPTION
Let's bring in some ES6 and ES7 goodies to make the tests even easier to read, understand and write. The promises boilerplate replaced by async / await and requires replaced by ES6 imports / exports.

What do you think? Step in the right direction or nonsense? 