### PR TITLE
Test for #119 - Keys that start with a digit are translated to XX

### DIFF
--- a/spec/UnnamedObjectsAnalysisTest.js
+++ b/spec/UnnamedObjectsAnalysisTest.js
@@ -2,7 +2,7 @@ import Tester from './utils/Tester.js';
 const test = new Tester('test', 'users');
 
 const sampleData = [
-  {title:'Article 1', comments:[{author:'John', body:'it works', visible:true }]},
+  {title:'Article 1', comments:[{author:'John', body:'it works', visible:true, '123key': '123value' }]},
   {title:'Article 2', comments:[{author:'Tom', body:'thanks'}, {author:'Mark', body:1}]}
 ];
 
@@ -16,8 +16,7 @@ describe('Unnamed object analysis', () => {
 
   it('should handle keys of unnamed object', async () => {
     const results = await test.runJsonAnalysis({collection:'users'}, true);
-
-    results.validateResultsCount(6);
+    results.validateResultsCount(7);
     results.validate('_id', 2, 100.0, {ObjectId: 2});
     results.validate('title', 2, 100.0, {String: 2});
     results.validate('comments', 2, 100.0, {Array: 2});
@@ -26,5 +25,6 @@ describe('Unnamed object analysis', () => {
     results.validate('comments.XX.author', 2, 100.0, {String: 2});
     results.validate('comments.XX.body', 2, 100.0, {String: 2, Number:1});
     results.validate('comments.XX.visible', 1, 50.0, {Boolean: 1});
+    results.validate('comments.XX.123key', 1, 50.0, {String: 1});
   });
 });

--- a/spec/utils/JsonValidator.js
+++ b/spec/utils/JsonValidator.js
@@ -10,7 +10,7 @@ export default class JsonValidator {
   validate(key, totalOccurrences, percentContaining, types) {
     const row = this.results.filter(item => item._id.key === key)[0];
     if(typeof row === 'undefined') {
-      throw new Error(`Key '${key}' is not present in results`);
+      throw new Error(`Key '${key}' not present in results. Known keys are: [${this.results.map(item => item._id.key).join(',')}].`);
     }
     equal(row.totalOccurrences, totalOccurrences, `TotalOccurrences of key ${key} does not match`);
     equal(row.percentContaining, percentContaining, `PercentContaining of key ${key} does not match`);


### PR DESCRIPTION
To verify incorrect behaviour of Variety, when key starts with number, as described in https://github.com/variety/variety/issues/119

When analysing collection
```js
[
  {title:'Article 1', comments:[{author:'John', body:'it works', visible:true, '123key': '123value' }]},
  {title:'Article 2', comments:[{author:'Tom', body:'thanks'}, {author:'Mark', body:1}]}
]
```

The ```123key``` is recorded currently as ```XXkey```. Following error is produced by the test:

```
Error: Key 'comments.XX.123key' not present in results. Known keys are: [_id,comments,comments.XX.author,comments.XX.body,title,comments.XX.XXkey,comments.XX.visible].
```