### PR TITLE
Show type of array values

### DIFF
--- a/variety.js
+++ b/variety.js
@@ -152,7 +152,11 @@ Released by Maypop Inc, © 2012-2018, under the MIT License. */
       return typeofThing[0].toUpperCase() + typeofThing.slice(1);
     } else {
       if (thing && thing.constructor === Array) {
-        return 'Array';
+        if (thing.length > 0) {
+          return 'Array-' + varietyTypeOf(thing[0]);
+        } else {
+          return 'EmptyArray';
+        }
       } else if (thing === null) {
         return 'null';
       } else if (thing instanceof Date) {


### PR DESCRIPTION
This is a bit of a placeholder, but the gist is that it would be helpful to show the types of array elements.
I suspect this might be better handled by showing the top-level type as simply `Array` as is done currently, and then show something like `foo.XX` with the type of each element.