### PR TITLE
Add support for quite additional information 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -169,9 +169,11 @@ Default format is ```ascii```. You can select the type of format with property `
 
 #### Quiet Option ####
 Both MongoDB and Variety output some additional information to standard output. If you want to remove this info, you can use ```--quiet``` option provided to ```mongo``` executable.
-Variety can also read that option and mute unnecessary output. This is useful in connection with ```outputFormat=json```. You would then receive only JSON, without any other characters around it.
+Variety can also read that option and mute unnecessary output.  You can remove this info also using ```quiet=true``` provided to Variety.
+This is useful in connection with ```outputFormat=json```. You would then receive only JSON, without any other characters around it.
 
     $ mongo test --quiet --eval "var collection = 'users', sort = { updated_at : -1 }" variety.js
+    $ mongo test --eval "var collection = 'users', sort = { updated_at : -1 }, quiet = true" variety.js
 
 #### Log Keys and Types As They Arrive Option ####
 Sometimes you want to see the keys and types come in as it happens.  Maybe you have a large dataset and want accurate results, but you also are impatient and want to see something now.  Or maybe you have a large mangled dataset with crazy keys (that probably shouldn't be keys) and Variety is going out of memory.  This option will show you the keys and types as they come in and help you identify problems with your dataset without needing the Variety script to finish.  

--- a/variety.js
+++ b/variety.js
@@ -12,8 +12,9 @@ Released by Maypop Inc, © 2012-2018, under the MIT License. */
 (function () {
   'use strict'; // wraps everything for which we can use strict mode -JC
 
+  var quiet = typeof this["quiet"] !== 'undefined' ? this["quiet"] : false;
   var log = function(message) {
-    if(!__quiet) { // mongo shell param, coming from https://github.com/mongodb/mongo/blob/5fc306543cd3ba2637e5cb0662cc375f36868b28/src/mongo/shell/dbshell.cpp#L624
+    if(!__quiet&&!quiet) { // mongo shell param, coming from https://github.com/mongodb/mongo/blob/5fc306543cd3ba2637e5cb0662cc375f36868b28/src/mongo/shell/dbshell.cpp#L624
       print(message);
     }
   };


### PR DESCRIPTION
using property 'quiet' inside Variety in addition to standard --quiet. If you are inside mongo and load Variety it's useful to change quit status indipendently from shell command