### PR TITLE
Expand typed linting and checkJs coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,9 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 - `npm run lint:yaml` — js-yaml (YAML files)
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`)
 - `npm run lint:shell` — shellcheck (shell scripts)
-- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for Node-side helper code under `spec/utils`
+- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for Node-side spec code under `spec`
 
-ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). Shell-executed files such as `variety.js` and shell plugins intentionally stay on the shared baseline until the project explicitly drops legacy `mongo` shell compatibility.
+ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). The `spec/utils` helper layer now also uses type-aware `typescript-eslint` rules backed by `tsconfig.checkjs.json`. Shell-executed files such as `variety.js` and shell plugins intentionally stay on the shared baseline until the project explicitly drops legacy `mongo` shell compatibility.
 
 The container-based checks, `npm run lint:dockerfile` and `npm run lint:shell`, require a container runtime. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 const babelParser = require('@babel/eslint-parser');
 const globals = require('globals');
 const js = require('@eslint/js');
+const tseslint = require('typescript-eslint');
 
 const commonRules = {
   'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
@@ -50,6 +51,10 @@ const nodeModernizationRules = {
   'prefer-template': 'error',
 };
 
+const typedSpecUtilsRules = {
+  ...tseslint.configs.recommendedTypeChecked[2].rules,
+};
+
 module.exports = [
   js.configs.recommended,
   {
@@ -80,5 +85,19 @@ module.exports = [
     // Keep shell-executed files on the conservative shared ruleset until
     // the repo intentionally drops legacy mongo shell compatibility.
     rules: nodeModernizationRules,
+  },
+  {
+    files: ['spec/utils/**/*.js'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: './tsconfig.checkjs.json',
+        tsconfigRootDir: __dirname,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: typedSpecUtilsRules,
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,10 +51,6 @@ const nodeModernizationRules = {
   'prefer-template': 'error',
 };
 
-const typedSpecUtilsRules = {
-  ...tseslint.configs.recommendedTypeChecked[2].rules,
-};
-
 module.exports = [
   js.configs.recommended,
   {
@@ -86,18 +82,14 @@ module.exports = [
     // the repo intentionally drops legacy mongo shell compatibility.
     rules: nodeModernizationRules,
   },
-  {
+  ...tseslint.config({
     files: ['spec/utils/**/*.js'],
+    extends: [tseslint.configs.recommendedTypeChecked],
     languageOptions: {
-      parser: tseslint.parser,
       parserOptions: {
         project: './tsconfig.checkjs.json',
         tsconfigRootDir: __dirname,
       },
     },
-    plugins: {
-      '@typescript-eslint': tseslint.plugin,
-    },
-    rules: typedSpecUtilsRules,
-  },
+  }),
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@babel/register": "^7.28.6",
         "@eslint/js": "^9.39.4",
         "@prantlf/jsonlint": "^17.0.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^25.5.2",
         "eslint": "^9.39.4",
         "globals": "^17.4.0",
@@ -27,7 +28,8 @@
         "mocha": "^11.7.5",
         "mongodb": "^7.1.1",
         "promisify-child-process": "^5.0.1",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.58.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2199,6 +2201,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2238,6 +2247,301 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/type-utils": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
@@ -5636,6 +5940,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5661,6 +5978,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.0",
+        "@typescript-eslint/parser": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0",
+        "@typescript-eslint/utils": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/register": "^7.28.6",
     "@eslint/js": "^9.39.4",
     "@prantlf/jsonlint": "^17.0.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^25.5.2",
     "eslint": "^9.39.4",
     "globals": "^17.4.0",
@@ -75,6 +76,7 @@
     "mocha": "^11.7.5",
     "mongodb": "^7.1.1",
     "promisify-child-process": "^5.0.1",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.0"
   }
 }

--- a/spec/ParametersParsingTest.js
+++ b/spec/ParametersParsingTest.js
@@ -6,13 +6,19 @@ import sampleData from './assets/SampleData.js';
 const test = new Tester('test', 'users');
 const mongodbPort = Number(process.env.MONGODB_PORT || 27017);
 
+/** @typedef {Record<string, unknown>} ParsedParams */
+
+/**
+ * @param {string} output
+ * @returns {ParsedParams}
+ */
 const parseParams = (output) => {
   return output
     .split('\n') // split by new line
-    .filter(line => line.startsWith('Using')) // take only lines starting with Using
-    .map(line => /^Using\s(\S+)\sof\s(.*)$/.exec(line)) // parse with regular expression
-    .filter(match => match) // filter out non-matching lines
-    .reduce((acc, match) => ({ ...acc, [match[1]]: JSON.parse(match[2]) }), {}); // reduce to params object
+    .filter((line) => line.startsWith('Using')) // take only lines starting with Using
+    .map((line) => /^Using\s(\S+)\sof\s(.*)$/.exec(line)) // parse with regular expression
+    .filter((match) => match !== null) // filter out non-matching lines
+    .reduce((acc, match) => ({ ...acc, [match[1]]: JSON.parse(match[2]) }), /** @type {ParsedParams} */ ({})); // reduce to params object
 };
 
 describe('Parameters parsing', () => {
@@ -62,8 +68,9 @@ describe('Parameters parsing', () => {
       await test.runAnalysis({collection: unknownCollection});
       assert.fail(`Expected runAnalysis to throw an error for unknown collection "${unknownCollection}"`);
     } catch(err) {
-      assert.ok(err.code > 0);
-      assert.ok(err.stdout.includes('The collection specified (--unknown--) in the database specified (test) does not exist or is empty.'));
+      const error = /** @type {NodeJS.ErrnoException & { stdout?: string }} */ (err);
+      assert.ok(typeof error.code === 'number' && error.code > 0);
+      assert.ok(typeof error.stdout === 'string' && error.stdout.includes('The collection specified (--unknown--) in the database specified (test) does not exist or is empty.'));
     }
   });
 
@@ -100,7 +107,14 @@ describe('Parameters parsing', () => {
   });
 
   it('should log BSON values as parseable JSON when tojson is unavailable', async () => {
+    if (!test.coll) {
+      throw new Error('Collection connection is not available.');
+    }
+    /** @type {{ _id: import('mongodb').ObjectId } | null} */
     const doc = await test.coll.findOne({name: 'Tom'});
+    if (!doc) {
+      throw new Error('Expected Tom document to exist.');
+    }
     const output = await execute(
       'test',
       null,

--- a/spec/PersistenceTest.js
+++ b/spec/PersistenceTest.js
@@ -2,6 +2,8 @@ import assert from 'assert';
 import Tester from './utils/Tester.js';
 import sampleData from './assets/SampleData.js';
 
+/** @typedef {import('./utils/JsonValidator.js').VarietyResultRow} VarietyResultRow */
+
 const test = new Tester('test', 'users');
 
 describe('Persistence of results', () => {
@@ -12,7 +14,9 @@ describe('Persistence of results', () => {
   it('should persist results into varietyResults DB', async () => {
     await test.runAnalysis({collection:'users', persistResults: true}, true);
     const db = await test.getDb('varietyResults');
-    const arr = await db.collection('usersKeys').find().toArray();
+    /** @type {import('mongodb').Collection<VarietyResultRow>} */
+    const resultsCollection = db.collection('usersKeys');
+    const arr = await resultsCollection.find().toArray();
     assert.equal(arr.length, 7);
     const keys = arr.map(it => it._id.key);
     assert.deepEqual(keys, ['_id', 'name', 'bio', 'birthday', 'pets', 'someBinData', 'someWeirdLegacyKey']);

--- a/spec/assets/csvplugin.js
+++ b/spec/assets/csvplugin.js
@@ -1,3 +1,14 @@
+/**
+ * @typedef {import('../utils/JsonValidator.js').VarietyResultRow} VarietyResultRow
+ * @typedef {{ delimiter?: string }} CsvPluginContext
+ * @typedef {{ delimiter?: string }} CsvPluginConfig
+ */
+
+/**
+ * @this {CsvPluginContext}
+ * @param {VarietyResultRow[]} varietyResults
+ * @returns {string}
+ */
 var getCsv = function(varietyResults) {
   var delimiter = this.delimiter || '|';
   var headers = ['key', 'types', 'occurrences', 'percents'];
@@ -8,6 +19,10 @@ var getCsv = function(varietyResults) {
   return table.concat(rows).join('\n');
 };
 
+/**
+ * @this {CsvPluginContext}
+ * @param {CsvPluginConfig} pluginConfig
+ */
 var setConfig = function(pluginConfig) {
   this.delimiter = pluginConfig.delimiter;
 };

--- a/spec/utils/JsonValidator.js
+++ b/spec/utils/JsonValidator.js
@@ -25,12 +25,13 @@ export default class JsonValidator {
   }
 
   /**
-   * @param {string} key
-   * @param {number} totalOccurrences
-   * @param {number} percentContaining
-   * @param {Record<string, number>} types
-   */
-  validate(key, totalOccurrences, percentContaining, types) {
+ * @param {string} key
+ * @param {number} totalOccurrences
+ * @param {number} percentContaining
+ * @param {Record<string, number>} types
+ * @param {unknown} [lastValue]
+  */
+  validate(key, totalOccurrences, percentContaining, types, lastValue) {
     const row = this.results.find((item) => item._id.key === key);
     if(typeof row === 'undefined') {
       throw new Error(`Key '${key}' not present in results. Known keys are: [${this.results.map((item) => item._id.key).join(',')}].`);
@@ -38,6 +39,9 @@ export default class JsonValidator {
     equal(row.totalOccurrences, totalOccurrences, `TotalOccurrences of key ${key} does not match`);
     equal(row.percentContaining, percentContaining, `PercentContaining of key ${key} does not match`);
     deepEqual(row.value.types, types, `Types of key ${key} do not match`);
+    if (arguments.length === 5) {
+      deepEqual(row.lastValue, lastValue, `LastValue of key ${key} does not match`);
+    }
   }
 
   /**

--- a/spec/utils/JsonValidator.js
+++ b/spec/utils/JsonValidator.js
@@ -25,11 +25,11 @@ export default class JsonValidator {
   }
 
   /**
- * @param {string} key
- * @param {number} totalOccurrences
- * @param {number} percentContaining
- * @param {Record<string, number>} types
- * @param {unknown} [lastValue]
+   * @param {string} key
+   * @param {number} totalOccurrences
+   * @param {number} percentContaining
+   * @param {Record<string, number>} types
+   * @param {unknown} [lastValue]
   */
   validate(key, totalOccurrences, percentContaining, types, lastValue) {
     const row = this.results.find((item) => item._id.key === key);

--- a/spec/utils/Tester.js
+++ b/spec/utils/Tester.js
@@ -84,12 +84,12 @@ export default class Tester {
 
   /**
    * @param {AnalysisOptions} options
-   * @param {boolean} [quiet=false]
+   * @param {boolean} [quiet=true]
    */
   async runJsonAnalysis(options, quiet) {
     const analysisOptions = { ...options, outputFormat: 'json' };
     /** @type {unknown} */
-    const parsedResults = JSON.parse(await this.runAnalysis(analysisOptions, quiet));
+    const parsedResults = JSON.parse(await this.runAnalysis(analysisOptions, typeof quiet === 'undefined' ? true : quiet));
     if (!Array.isArray(parsedResults)) {
       throw new Error('Expected JSON analysis output to be an array.');
     }

--- a/spec/utils/Tester.js
+++ b/spec/utils/Tester.js
@@ -11,6 +11,7 @@ import JsonValidator from './JsonValidator.js';
  * @typedef {import('mongodb').MongoClient} MongoClientType
  * @typedef {import('mongodb').Collection<MongoDocument>} MongoCollection
  * @typedef {Record<string, unknown> & { outputFormat?: string }} AnalysisOptions
+ * @typedef {import('./JsonValidator.js').VarietyResultRow} VarietyResultRow
  */
 
 const mongodbPort = Number(process.env.MONGODB_PORT || 27017);
@@ -83,11 +84,17 @@ export default class Tester {
 
   /**
    * @param {AnalysisOptions} options
+   * @param {boolean} [quiet=false]
    */
-  async runJsonAnalysis(options) {
+  async runJsonAnalysis(options, quiet) {
     const analysisOptions = { ...options, outputFormat: 'json' };
-    const result = await this.runAnalysis(analysisOptions, true);
-    return new JsonValidator(/** @type {JsonValidator['results']} */ (JSON.parse(result)));
+    /** @type {unknown} */
+    const parsedResults = JSON.parse(await this.runAnalysis(analysisOptions, quiet));
+    if (!Array.isArray(parsedResults)) {
+      throw new Error('Expected JSON analysis output to be an array.');
+    }
+    const typedResults = /** @type {VarietyResultRow[]} */ (parsedResults);
+    return new JsonValidator(typedResults);
   }
 
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -12,11 +12,12 @@
     "strict": true,
     "target": "ES2022",
     "types": [
-      "node"
+      "node",
+      "mocha"
     ]
   },
   "include": [
-    "spec/utils/**/*.js",
-    "spec/utils/**/*.d.ts"
+    "spec/**/*.js",
+    "spec/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary

Add type-aware ESLint coverage for `spec/utils` and widen the existing `checkJs` pass from the helper layer to the full `spec/` tree.

## What changed

- add local `typescript-eslint` and `@types/mocha` dev dependencies
- add a type-aware ESLint block for `spec/utils/**/*.js` backed by `tsconfig.checkjs.json`
- widen `tsconfig.checkjs.json` from `spec/utils` to all of `spec` and add Mocha types
- tighten helper and test JSDoc/types so the wider `checkJs` run passes cleanly
- annotate the sample CSV plugin so it can stay inside the widened typecheck surface
- update the README to describe the broader `typecheck` scope and the new typed linting on `spec/utils`

## Why

This combines the next two modernization steps in the planned sequence: introducing typed linting where the helper layer already had strong JSDoc, then widening `checkJs` to the rest of the spec code so more of the Node-side JavaScript gets static coverage.

## Impact

The repo now gets type-aware ESLint feedback for `spec/utils` and `tsc --checkJs` coverage across the full `spec/` tree. That raises the floor for test/helper code without crossing into the shell-executed runtime files yet.

## Validation

- `npm run lint`
- `npm run typecheck`
- `./node_modules/.bin/markdownlint README.md`
- `npm run test:mocha`

## Test notes

`npm run test:mocha` is blocked in this sandbox because localhost MongoDB connections fail with `connect EPERM` to `127.0.0.1:27017` / `::1:27017`, so I treated that as an environment limitation rather than a change-specific regression signal.
