### PR TITLE
Bump version to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "variety",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "variety",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "bin": {
         "variety": "bin/variety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "variety",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A MongoDB schema analyzer",
   "keywords": [
     "MongoDB",

--- a/variety.js
+++ b/variety.js
@@ -60,7 +60,7 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
   };
 
   log('Variety: A MongoDB Schema Analyzer');
-  log('Version 1.5.1, released 02 October 2017');
+  log('Version 1.5.2, released 30 September 2025');
 
   var dbs = [];
   var emptyDbs = [];


### PR DESCRIPTION
## Summary

- Updates `variety.js`, `package.json`, and `package-lock.json` to declare version `1.5.2`
- Release date in `variety.js` set to 30 September 2025, matching the date of the [v1.5.2 tag](https://github.com/variety/variety/releases/tag/v1.5.2)

## Why this commit is late

The `v1.5.2` tag was applied retroactively to commit `7ba4eab` (30 September 2025), which contained only tooling/packaging/docs changes and a copyright year update — no change to the core library behaviour. At the time, git tags were used as the sole version authority and no corresponding in-source bump commit was made.

This PR brings the declared version in the source files into alignment with that tag, closing the gap between what the tag says and what the code says.

## Test plan

- [x] Pre-commit hooks (ESLint, jsonlint, markdownlint, shellcheck, tsc) pass cleanly
- [x] Verify `variety.js` logs `Version 1.5.2, released 30 September 2025` on startup
- [x] Verify `npm version` reports `1.5.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)