### PR TITLE
Fix JSDoc closing delimiter indentation in JsonValidator.validate()

### DIFF
--- a/spec/utils/JsonValidator.js
+++ b/spec/utils/JsonValidator.js
@@ -30,7 +30,7 @@ export default class JsonValidator {
    * @param {number} percentContaining
    * @param {Record<string, number>} types
    * @param {unknown} [lastValue]
-  */
+   */
   validate(key, totalOccurrences, percentContaining, types, lastValue) {
     const row = this.results.find((item) => item._id.key === key);
     if(typeof row === 'undefined') {


### PR DESCRIPTION
## Summary

- Fix misaligned `*/` on the `validate()` JSDoc block in `spec/utils/JsonValidator.js`

## Context

During review of #218, two issues were flagged:

1. **Index-based preset access** (`tseslint.configs.recommendedTypeChecked[2].rules`) — brittle dependency on internal array ordering. This was resolved within #218 itself via the "Harden typed lint config composition" commit, which switched to `...tseslint.config({ extends: [tseslint.configs.recommendedTypeChecked] })`.

2. **JSDoc indentation** — the closing `*/` on the `validate()` block was indented with two spaces instead of three, breaking alignment with the `* @param` lines above it. This PR fixes that.

## Change

`spec/utils/JsonValidator.js` line 33: `  */` → `   */`

🤖 Generated with [Claude Code](https://claude.com/claude-code)