### PR TITLE
Expand typecheck coverage to eslint.config.js; fix deprecated tseslint.config() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 - `npm run lint:yaml` — js-yaml (YAML files)
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`)
 - `npm run lint:shell` — shellcheck (shell scripts)
-- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for Node-side spec code under `spec`
+- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `eslint.config.js` and Node-side spec code under `spec`
 
 ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). The `spec/utils` helper layer now also uses type-aware `typescript-eslint` rules backed by `tsconfig.checkjs.json`. Both ESLint and `npm run test:mocha` now rely on native Node parsing for repo code, with `spec/package.json` marking the test tree as ESM while the root package remains CommonJS. Shell-executed files such as `variety.js` and shell plugins intentionally stay on the shared baseline until the project explicitly drops legacy `mongo` shell compatibility.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 const globals = require('globals');
 const js = require('@eslint/js');
 const tseslint = require('typescript-eslint');
+const { defineConfig } = require('eslint/config');
 
 const commonRules = {
   'brace-style': [2, '1tbs', { 'allowSingleLine': true }],
@@ -84,7 +85,7 @@ module.exports = [
     // the repo intentionally drops legacy mongo shell compatibility.
     rules: nodeModernizationRules,
   },
-  ...tseslint.config({
+  ...defineConfig({
     files: ['spec/utils/**/*.js'],
     extends: [tseslint.configs.recommendedTypeChecked],
     languageOptions: {

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -17,6 +17,7 @@
     ]
   },
   "include": [
+    "eslint.config.js",
     "spec/**/*.js",
     "spec/**/*.d.ts"
   ]


### PR DESCRIPTION
## Summary

- Add `eslint.config.js` to the `include` array in `tsconfig.checkjs.json` so `npm run typecheck` covers the ESLint configuration file in addition to `spec/`.
- This expansion immediately revealed a `ts(6387)` deprecation: `tseslint.config()` is deprecated in favour of ESLint core's `defineConfig()` (available since `eslint` v9.22.0 via `@eslint/config-helpers`).
- Replace `...tseslint.config({…})` with `...defineConfig({…})` imported from `eslint/config`. The call shape is identical (single object with `files`, `extends`, and `languageOptions`), so the effective ruleset is unchanged.
- Update `README.md` to reflect that `npm run typecheck` now also validates `eslint.config.js`.

## Test plan

- [x] `npm run typecheck` passes cleanly after both changes
- [x] `npm run lint` passes cleanly (ESLint config still valid)
- [x] README lint (`npm run lint:markdown`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)