### PR TITLE
Test compactArrayTypes label for nested arrays

### DIFF
--- a/spec/ShowArrayElementsTest.js
+++ b/spec/ShowArrayElementsTest.js
@@ -56,3 +56,27 @@ describe('showArrayElements option', () => {
   });
 
 });
+
+// Nested-array sample: Alice has a homogeneous matrix (all Number rows),
+// Bob has a mixed matrix (one Number row, one String row).
+const nestedSampleData = [
+  { name: 'Alice', matrix: [[1, 2], [3, 4]] },
+  { name: 'Bob',   matrix: [[5, 6], ['a', 'b']] }
+];
+
+describe('compactArrayTypes with nested arrays', () => {
+
+  beforeEach(() => test.init(nestedSampleData));
+  afterEach(() => test.cleanUp());
+
+  it('should label nested array element types recursively', async () => {
+    const results = await test.runJsonAnalysis({collection: 'users', compactArrayTypes: true}, true);
+    results.validateResultsCount(3);
+    results.validate('_id',    2, 100.0, {ObjectId: 2});
+    results.validate('name',   2, 100.0, {String: 2});
+    // Alice's matrix rows are all Number → Array(Array(Number))
+    // Bob's matrix rows are Number and String → Array(Array(Number)|Array(String))
+    results.validate('matrix', 2, 100.0, {'Array(Array(Number))': 1, 'Array(Array(Number)|Array(String))': 1});
+  });
+
+});


### PR DESCRIPTION
## Summary

- Add a regression test for `compactArrayTypes` behavior on fields containing arrays-of-arrays

## Context

During review of #214, I flagged that nested arrays (arrays-of-arrays) with `compactArrayTypes` enabled were an untested edge case — `varietyTypeOf` is recursive, so a field like `matrix: [[1,2],[3,4]]` should produce `Array(Array(Number))` rather than just `Array`. This PR locks in that behavior with a test.

## What the test covers

Two documents with a `matrix` field:
- Alice: `[[1, 2], [3, 4]]` — homogeneous rows → `Array(Array(Number))`
- Bob: `[[5, 6], ['a', 'b']]` — mixed-type rows → `Array(Array(Number)|Array(String))`

The test confirms that the recursive `varietyTypeOf` call correctly propagates compact labels through multiple levels of nesting, and that the intermediate `.XX` keys (`matrix.XX`, `matrix.XX.XX`) are still suppressed when `showArrayElements` is false.

## Validation

- `env MONGODB_VERSION=8.0 NODEJS_VERSION=22 npm run test:docker` — 35 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)