### PR TITLE
Drop legacy mongo shell; require mongosh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ So, let's see what we've got here:
 
 _(`test` is the database containing the collection we are analyzing.)_
 
-These examples use `mongosh`. If your environment still ships the legacy `mongo`
-shell instead, substitute that executable in the commands below.
+These examples use `mongosh`, which is required to run Variety.
 
 Hmm. Looks like everybody has a `name` and `_id`. Most, but not all have a `bio`.
 
@@ -281,7 +280,7 @@ Variety expects keys to be well formed, not having any `.`s in them (MongoDB 2.4
     $ mongosh test --quiet --eval "var collection = 'users', arrayEscape = 'YY'" variety.js
 
 ### Command Line Interface ###
-This package ships a small `bin/variety` wrapper (published as the package's `variety` executable) that chooses `mongosh` when available and falls back to the legacy `mongo` shell.
+This package ships a small `bin/variety` wrapper (published as the package's `variety` executable) that invokes `mongosh`.
 
 Example:
 ```
@@ -307,7 +306,7 @@ A MongoDB collection does not enforce a predefined schema like a relational data
 
 ##### Dependencies #####
 
-At runtime, Variety itself depends only on MongoDB plus a MongoDB shell (`mongosh` is preferred; the legacy `mongo` shell still works where available). Development and testing add local npm dev dependencies.
+At runtime, Variety itself depends only on MongoDB plus `mongosh`. Development and testing add local npm dev dependencies.
 
 ##### Development, Hacking #####
 This project is NPM based and provides standard NPM functionality. As an additional (not required) dependency, [Docker](https://www.docker.com/) or [Podman](https://podman.io/) can be installed to test against different MongoDB versions.
@@ -334,7 +333,7 @@ npm run test:docker
 The script downloads one of [the official MongoDB images](https://hub.docker.com/_/mongo/) (based on your provided version),
 starts the database, executes the test suite against it (inside the container) and stops the DB.
 
-The Docker harness prefers `mongosh` when it is available and falls back to the legacy `mongo` shell for older images.
+The Docker harness uses `mongosh`.
 
 Dockerized tests default to MongoDB 8.0 on Node.js 22. You can override `MONGODB_VERSION` and `NODEJS_VERSION` when you want to try another supported combination:
 
@@ -358,7 +357,7 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 - `npm run lint:shell` — shellcheck (shell scripts)
 - `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for Node-side spec code under `spec`
 
-ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). The `spec/utils` helper layer now also uses type-aware `typescript-eslint` rules backed by `tsconfig.checkjs.json`. Both ESLint and `npm run test:mocha` now rely on native Node parsing for repo code, with `spec/package.json` marking the test tree as ESM while the root package remains CommonJS. Shell-executed files such as `variety.js` and shell plugins intentionally stay on the shared baseline until the project explicitly drops legacy `mongo` shell compatibility.
+ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). The `spec/utils` helper layer now also uses type-aware `typescript-eslint` rules backed by `tsconfig.checkjs.json`. Both ESLint and `npm run test:mocha` now rely on native Node parsing for repo code, with `spec/package.json` marking the test tree as ESM while the root package remains CommonJS. Shell-executed files such as `variety.js` and shell plugins currently stay on the shared baseline; a follow-on change can opt them into the modernization ruleset now that the legacy `mongo` shell is no longer supported.
 
 The container-based checks, `npm run lint:dockerfile` and `npm run lint:shell`, require a container runtime. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed.
 

--- a/bin/variety
+++ b/bin/variety
@@ -7,14 +7,11 @@ set -e
 # executes, e.g.:
 # mongosh test --eval "var collection = 'users', limit = 1" ./variety.js
 
-if command -v mongosh >/dev/null 2>&1; then
-  MONGO_SHELL=mongosh
-elif command -v mongo >/dev/null 2>&1; then
-  MONGO_SHELL=mongo
-else
-  echo 'Error: neither mongosh nor mongo found in PATH' >&2
+if ! command -v mongosh >/dev/null 2>&1; then
+  echo 'Error: mongosh not found in PATH' >&2
   exit 127
 fi
+MONGO_SHELL=mongosh
 
 VARIETYJS_DIR=${VARIETYJS_DIR:-.}
 VARIETY_SCRIPT="$VARIETYJS_DIR/variety.js"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,8 +80,6 @@ module.exports = [
   {
     files: ['eslint.config.js', 'spec/**/*.js'],
     ignores: ['spec/assets/**/*.js'],
-    // Keep shell-executed files on the conservative shared ruleset until
-    // the repo intentionally drops legacy mongo shell compatibility.
     rules: nodeModernizationRules,
   },
   ...tseslint.config({

--- a/spec/utils/MongoShell.js
+++ b/spec/utils/MongoShell.js
@@ -11,34 +11,11 @@ import { execFile } from 'promisify-child-process';
  * }} MongoShellCredentials
  */
 
-/** @type {Promise<string> | undefined} */
-let mongoShellCommandPromise;
-
 /**
  * @param {string | Buffer | undefined} value
  * @returns {string}
  */
 const toOutputText = (value) => value ? String(value) : '';
-
-/**
- * @returns {Promise<string>}
- */
-const findMongoShellCommand = async () => {
-  if (!mongoShellCommandPromise) {
-    mongoShellCommandPromise = execFile('sh', ['-lc', `
-      if command -v mongosh >/dev/null 2>&1; then
-        printf mongosh
-      elif command -v mongo >/dev/null 2>&1; then
-        printf mongo
-      else
-        printf 'Neither mongosh nor mongo is available in PATH.' >&2
-        exit 127
-      fi
-    `]).then((result) => toOutputText(result.stdout).trim());
-  }
-
-  return mongoShellCommandPromise;
-};
 
 /**
  * @param {string | undefined} database
@@ -50,7 +27,6 @@ const findMongoShellCommand = async () => {
  * @returns {Promise<string>}
  */
 export default async (database, credentials, args, script, quiet, port) => {
-  const command = await findMongoShellCommand();
   /** @type {string[]} */
   const commandArgs = [];
 
@@ -83,13 +59,13 @@ export default async (database, credentials, args, script, quiet, port) => {
   }
 
   try {
-    const result = await execFile(command, commandArgs);
+    const result = await execFile('mongosh', commandArgs);
     return toOutputText(result.stdout).trim();
   } catch (error) {
     /** @type {Error & { stderr?: string | Buffer, stdout?: string | Buffer }} */
     const execError = /** @type {Error & { stderr?: string | Buffer, stdout?: string | Buffer }} */ (error);
 
-    // mongosh reports thrown script errors on stderr; keep the legacy stdout
+    // mongosh reports thrown script errors on stderr; keep the stdout
     // contract that the specs already assert against.
     if (execError.stderr) {
       execError.stdout = [toOutputText(execError.stdout), toOutputText(execError.stderr)]


### PR DESCRIPTION
## Why

The legacy `mongo` shell has been end-of-life for years:

| Event | Date |
|---|---|
| `mongo` **deprecated** | MongoDB 5.0 (July 2021) |
| `mongo` **removed** from server distribution | MongoDB 6.0 (July 2022) |
| MongoDB 4.x (last version to ship `mongo`) **EOL** | February 2024 |
| MongoDB current stable | **8.x** (as of 2026) |

MongoDB 6.0+ does not ship `mongo` at all. The only users who would have it are on MongoDB 4.x, which has been unsupported for over two years. The practical overlap of "using variety.js" + "on EOL MongoDB" + "hasn't installed `mongosh` separately" is vanishingly small.

Additionally, `mongo` and `mongosh` are not fully equivalent: they differ in BSON type handling (e.g. `mongosh` promotes BSON `Double` and `Int32` to plain JS numbers — already noted in `DatatypeRecognitionTest.js`). Keeping the fallback means silently running a different code path with different semantics and zero test coverage.

## What changed

- **`bin/variety`** — removed the `elif command -v mongo` branch; the script now errors immediately with a clear message if `mongosh` is not in `PATH`
- **`spec/utils/MongoShell.js`** — removed the runtime shell-detection function (`findMongoShellCommand`) and its memoising promise; replaced with a direct `execFile('mongosh', …)` call
- **`eslint.config.js`** — removed the now-obsolete comment that deferred applying `nodeModernizationRules` to shell-executed files pending this drop
- **`README.md`** — updated all five spots that described `mongo` as a fallback or still-viable option; added a note that `variety.js` and plugins can now be opted into the modernization ruleset in a follow-on PR

## What's not in this PR

- Opting `variety.js` and shell plugins into `nodeModernizationRules` — that's a straightforward follow-on now that the blocker is removed
- A CI matrix leg that ever exercised the `mongo` path — there was none; the fallback was dead code in testing

## Test plan

- [ ] Pre-commit hooks (ESLint, shellcheck, tsc) pass — verified locally
- [ ] `npm run test:docker` against MongoDB 7.0 and 8.0 (both ship `mongosh` only)
- [ ] Confirm `bin/variety` exits 127 with a clear error when `mongosh` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)