### PR TITLE
Add MongoDB 5.0 to CI matrix to test legacy mongo shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: ['7.0', '8.0']
+        mongodb-version: ['5.0', '7.0', '8.0']
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ MONGODB_VERSION=8.0 npm run test:docker
 MONGODB_VERSION=8.0 NODEJS_VERSION=24 npm run test:docker
 ```
 
-GitHub Actions runs the supported MongoDB matrix (`7.0`, `8.0`) on Node.js 22, plus a single Node.js 24 smoke test against MongoDB 8.0. MongoDB 6.0+ no longer ships the legacy `mongo` shell, and MongoDB 7.0+ rejects the old `mongod --nojournal` flag, so the test harness now targets `mongosh` and modern `mongod` defaults.
+GitHub Actions runs a MongoDB matrix on Node.js 22: `5.0` (which ships only the legacy `mongo` shell, exercising that code path), `7.0`, and `8.0` (both of which ship only `mongosh`). A single Node.js 24 smoke test also runs against MongoDB 8.0. MongoDB 6.0+ no longer ships the legacy `mongo` shell, so `5.0` is the newest version available for `mongo`-shell coverage.
 
 ##### Linting #####
 


### PR DESCRIPTION
## Summary

- Adds `5.0` to the CI test matrix alongside `7.0` and `8.0`
- `mongo:5.0` ships only the legacy `mongo` shell (SpiderMonkey); `mongo:6.0+` ships only `mongosh` — so this lane naturally exercises the `mongo` fallback path already present in `MongoShell.js`
- Runs the full existing test suite (not just a smoke test) through the legacy shell, giving thorough coverage of both shells
- Updates the README paragraph about CI to reflect the new matrix and explain which shell each lane uses

No logic changes were needed: `variety.js` already targets the ES6+/MongoDB 4.4+ compatibility floor, and `MongoShell.js` already detects and prefers `mongosh` but falls back to `mongo`.

## Test plan

- [ ] Verify "Test (Node 22, MongoDB 5.0)" CI lane passes (exercises `mongo` shell)
- [ ] Verify existing "Test (Node 22, MongoDB 7.0)" and "Test (Node 22, MongoDB 8.0)" lanes still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)