### PR TITLE
Clarify README linting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ GitHub Actions runs a MongoDB matrix on Node.js 22: `5.0` (which ships only the 
 
 ## Linting
 
+Variety keeps its repository checks split into a few layers so it is clear which tool is complaining and why.
+
+### Pre-commit Hooks
+
 Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and installed automatically on `npm install`. Each commit runs all of the following, and is blocked if any fail:
 
 - `npm run verify:build` — verifies `variety.js` matches what `build.js` would produce from `src/`
@@ -381,9 +385,33 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 - `npm run lint:shell` — shellcheck (shell scripts)
 - `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `.eslint.config.js`, `build.js`, and Node-side spec code under `spec`
 
-ESLint applies a shared baseline of formatting and safety rules across the repo. That shared baseline now also bans repo-specific legacy patterns such as `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops. Node-side JavaScript such as `.eslint.config.js`, the test suite, and `spec/utils` also opts into a stricter modernization set (`const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects). The `spec` test tree now also uses type-aware `typescript-eslint` rules backed by `.tsconfig.checkjs.json`, while shell-executed fixtures under `spec/assets` stay on the shared baseline. That `checkJs` pass also enables stricter TypeScript flags such as `noImplicitReturns`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`, and `exactOptionalPropertyTypes`. Both ESLint and `npm run test:mocha` now rely on native Node parsing for repo code, with `spec/package.json` marking the test tree as ESM while the root package remains CommonJS. `variety.js` (and its sources under `src/`) opts into a subset of those rules (`no-var`, `prefer-const`, `prefer-template`, `object-shorthand`, and `no-throw-literal`) — the rules that are safe for the ES6+ JavaScript supported by the legacy `mongo` shell since MongoDB 4.4. `prefer-object-has-own` is intentionally excluded: `Object.hasOwn()` is not guaranteed in the legacy `mongo` shell, and all `hasOwnProperty.call()` usages have been replaced by `Object.keys()` / `in` anyway.
+### ESLint Rulesets
 
-The container-based checks, `npm run lint:dockerfile` and `npm run lint:shell`, require a container runtime. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed.
+#### Shared Baseline
+
+`npm run lint` applies a shared baseline of formatting and safety rules across the repo. That baseline also bans a few repo-specific legacy patterns, including `Function('return this')`, `indexOf(...)` presence checks, and unguarded `for...in` loops.
+
+#### Node-side Modernization
+
+Node-side JavaScript such as `.eslint.config.js`, `build.js`, and the test suite under `spec/` (excluding shell-executed fixtures under `spec/assets/`) opts into a stricter modernization set: `const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects.
+
+#### Legacy Shell Compatibility
+
+`variety.js` and its sources under `src/` use the subset of those rules that is safe for the ES6+ JavaScript supported by the legacy `mongo` shell since MongoDB 4.4: `no-var`, `prefer-const`, `prefer-template`, `object-shorthand`, and `no-throw-literal`. `prefer-object-has-own` is intentionally excluded there because `Object.hasOwn()` is not guaranteed in that runtime, and all `hasOwnProperty.call()` usages have been replaced by `Object.keys()` / `in`.
+
+### Typed Checks For Node-side Code
+
+#### Checked Files
+
+`npm run typecheck` runs TypeScript `checkJs` over `.eslint.config.js`, `build.js`, and the Node-side spec code via `.tsconfig.checkjs.json`. The `spec` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `spec/assets` stay on the shared baseline.
+
+#### Extra Strictness
+
+That pass enables stricter flags such as `noImplicitReturns`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`, and `exactOptionalPropertyTypes`. Both ESLint and `npm run test:mocha` now rely on native Node parsing for repo code, with `spec/package.json` marking the test tree as ESM while the repository root remains CommonJS so the CLI entrypoint and config files keep their current behavior.
+
+### Container-backed Linters
+
+`npm run lint:dockerfile` and `npm run lint:shell` run inside containers. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed.
 
 ## Reporting Issues / Contributing
 


### PR DESCRIPTION
## What changed
- reorganized the README's Linting section into smaller subsections
- kept the pre-commit hook checklist intact
- separated ESLint policy, typed Node-side checks, and container-backed linters into their own explanations

## Why
The existing section mixed the pre-commit workflow, ruleset details, and runtime requirements into one dense block. Breaking it up makes it easier to scan and easier to update when one part changes.

## Impact
- contributors can see more quickly which checks run automatically on commit
- the ESLint and typecheck scope is easier to understand
- Docker/Podman requirements are called out in their own place

## Validation
- npm run lint:markdown
- npm run lint
