### PR TITLE
Add tests for the bin/variety wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 npm run test:mocha
 ```
 
-The test suite under `spec/` runs as native ESM through its own `spec/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior.
+The test suite under `spec/` runs as native ESM through its own `spec/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. That Mocha lane also includes a focused `bin/variety` wrapper spec that stubs `mongosh` and `mongo`, so wrapper argument handling can be validated without a live MongoDB shell install.
 
 If you have Docker or Podman installed and don't want to test against your own MongoDB instance,
 you can execute tests against dockerized MongoDB:

--- a/spec/BinWrapperTest.js
+++ b/spec/BinWrapperTest.js
@@ -1,0 +1,165 @@
+import assert from 'assert';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execFile } from 'promisify-child-process';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const binVarietyPath = fileURLToPath(new URL('../bin/variety', import.meta.url));
+
+/**
+ * @typedef {{
+ *   command: string,
+ *   args: string[],
+ * }} ShellInvocation
+ */
+
+/**
+ * @param {string} shellDir
+ * @param {string} shellName
+ */
+const createFakeShell = async (shellDir, shellName) => {
+  const shellPath = path.join(shellDir, shellName);
+  await writeFile(shellPath, `#!/bin/bash
+set -e
+: "\${FAKE_SHELL_ARGS_FILE:?}"
+{
+  printf '%s\n' "\${0##*/}"
+  printf '%s\n' "$@"
+} > "$FAKE_SHELL_ARGS_FILE"
+printf 'fake shell ran\n'
+`);
+  await chmod(shellPath, 0o755);
+};
+
+/**
+ * @param {string} recordPath
+ * @returns {Promise<ShellInvocation>}
+ */
+const readInvocation = async (recordPath) => {
+  const recordedArgs = (await readFile(recordPath, 'utf8'))
+    .split('\n')
+    .filter((line) => line.length > 0);
+
+  const [command, ...args] = recordedArgs;
+  if (!command) {
+    throw new Error('Expected fake shell to record a command.');
+  }
+
+  return { command, args };
+};
+
+/**
+ * @param {{
+ *   shells?: string[],
+ *   env?: NodeJS.ProcessEnv,
+ * }} [options]
+ */
+const runBinVariety = async (options = {}) => {
+  const shellNames = options.shells || ['mongosh'];
+  const env = options.env || {};
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), 'variety-bin-wrapper-'));
+  const recordPath = path.join(fixtureDir, 'invocation.txt');
+
+  try {
+    for (const shellName of shellNames) {
+      await createFakeShell(fixtureDir, shellName);
+    }
+
+    const result = await execFile('/bin/bash', [binVarietyPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ...env,
+        FAKE_SHELL_ARGS_FILE: recordPath,
+        PATH: fixtureDir,
+      },
+    });
+
+    return {
+      stderr: String(result.stderr || ''),
+      stdout: String(result.stdout || ''),
+      invocation: await readInvocation(recordPath),
+    };
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+};
+
+describe('bin/variety wrapper', () => {
+  it('prefers mongosh and forwards DB plus eval arguments', async () => {
+    const { invocation, stdout, stderr } = await runBinVariety({
+      shells: ['mongosh', 'mongo'],
+      env: {
+        DB: 'testdb',
+        EVAL_CMDS: 'var collection = \'users\', limit = 1',
+      },
+    });
+
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: ['testdb', '--eval', 'var collection = \'users\', limit = 1', './variety.js'],
+    });
+    assert.equal(stdout.includes('fake shell ran'), true);
+    assert.equal(stderr, '');
+  });
+
+  it('falls back to mongo and honors VARIETYJS_DIR', async () => {
+    const varietyDir = '/tmp/custom-variety-dir';
+    const { invocation } = await runBinVariety({
+      shells: ['mongo'],
+      env: {
+        VARIETYJS_DIR: varietyDir,
+      },
+    });
+
+    assert.deepEqual(invocation, {
+      command: 'mongo',
+      args: [`${varietyDir}/variety.js`],
+    });
+  });
+
+  it('removes matching outer double quotes from EVAL_CMDS', async () => {
+    const { invocation } = await runBinVariety({
+      env: {
+        EVAL_CMDS: '"var collection = \'users\', limit = 2"',
+      },
+    });
+
+    assert.deepEqual(invocation.args, ['--eval', 'var collection = \'users\', limit = 2', './variety.js']);
+  });
+
+  it('removes matching outer single quotes from EVAL_CMDS', async () => {
+    const { invocation } = await runBinVariety({
+      env: {
+        EVAL_CMDS: '\'var collection = "users", limit = 2\'',
+      },
+    });
+
+    assert.deepEqual(invocation.args, ['--eval', 'var collection = "users", limit = 2', './variety.js']);
+  });
+
+  it('preserves unmatched outer quotes in EVAL_CMDS', async () => {
+    const evalCommands = '"var collection = \'users\'';
+    const { invocation } = await runBinVariety({
+      env: {
+        EVAL_CMDS: evalCommands,
+      },
+    });
+
+    assert.deepEqual(invocation.args, ['--eval', evalCommands, './variety.js']);
+  });
+
+  it('fails with exit 127 when neither shell is available', async () => {
+    await assert.rejects(
+      () => runBinVariety({ shells: [] }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 127);
+        assert.match(String(error.stderr || ''), /neither mongosh nor mongo found in PATH/);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Add a lightweight but real Mocha suite for `bin/variety`.

## What changed
- add `spec/BinWrapperTest.js`
- cover shell selection (`mongosh` preferred, `mongo` fallback)
- cover argument forwarding for `DB`, `EVAL_CMDS`, and `VARIETYJS_DIR`
- cover quote normalization for `EVAL_CMDS`
- cover the exit-127 error path when no Mongo shell is available
- document in `README.md` that the direct Mocha lane includes wrapper coverage via stubbed shells

## Why
`bin/variety` had user-facing wrapper behavior but no focused test coverage. This adds a barebones suite that exercises the wrapper logic without requiring a live MongoDB shell install.

## Validation
- `npm run lint`
- `npm run lint:markdown`
- `npm run typecheck`
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 spec/BinWrapperTest.js`
