### PR TITLE
Evolve bin/variety towards being a real CLI

### DIFF
--- a/.eslint.config.js
+++ b/.eslint.config.js
@@ -55,7 +55,7 @@ module.exports = [
   { ignores: ['.claude/'] },
   js.configs.recommended,
   {
-    files: ['**/*.js'],
+    files: ['**/*.js', 'bin/variety'],
     languageOptions: {
       sourceType: 'script',
       globals: {
@@ -79,7 +79,7 @@ module.exports = [
     },
   },
   {
-    files: ['.eslint.config.js', 'build.js', 'spec/**/*.js'],
+    files: ['.eslint.config.js', 'bin/variety', 'build.js', 'lib/**/*.js', 'spec/**/*.js'],
     ignores: ['spec/assets/**/*.js'],
     rules: nodeModernizationRules,
   },

--- a/.tsconfig.checkjs.json
+++ b/.tsconfig.checkjs.json
@@ -21,6 +21,8 @@
     ]
   },
   "include": [
+    "bin/variety",
+    "lib/**/*.js",
     ".eslint.config.js",
     "build.js",
     "spec/**/*.js",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 - `npm run lint:yaml` — js-yaml (YAML files)
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`)
 - `npm run lint:shell` — shellcheck (shell scripts)
-- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `.eslint.config.js`, `build.js`, and Node-side spec code under `spec`
+- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `bin/variety`, `lib/**/*.js`, `.eslint.config.js`, `build.js`, and Node-side spec code under `spec`
 
 ### ESLint Rulesets
 
@@ -100,7 +100,7 @@ Node-side JavaScript such as `bin/variety`, `lib/**/*.js`, `.eslint.config.js`, 
 
 #### Checked Files
 
-`npm run typecheck` runs TypeScript `checkJs` over `.eslint.config.js`, `build.js`, and the Node-side spec code via `.tsconfig.checkjs.json`. The `spec` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `spec/assets` stay on the shared baseline.
+`npm run typecheck` runs TypeScript `checkJs` over the published Node CLI surface (`bin/variety` plus `lib/**/*.js`), `.eslint.config.js`, `build.js`, and the Node-side spec code via `.tsconfig.checkjs.json`. The `spec` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `spec/assets` stay on the shared baseline.
 
 #### Extra Strictness
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 - `src/interface.js` — the shell-facing layer that reads shell globals
   (`collection`, `plugins`, `slaveOk`, etc.), loads plugins, and hands
   dependencies to `impl.run()`.
-- `bin/variety` — the published Node entrypoint that implements the first-party
+- `bin/variety` — the published Node entrypoint that implements the main
   CLI surface.
 - `lib/cli*.js`, `lib/mongo-shell.js` — Node-side CLI parsing, compatibility
   handling, and Mongo shell invocation helpers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 - `src/interface.js` — the shell-facing layer that reads shell globals
   (`collection`, `plugins`, `slaveOk`, etc.), loads plugins, and hands
   dependencies to `impl.run()`.
+- `bin/variety` — the published Node entrypoint that implements the first-party
+  CLI surface.
+- `lib/cli*.js`, `lib/mongo-shell.js` — Node-side CLI parsing, compatibility
+  handling, and Mongo shell invocation helpers.
 
 `build.js` concatenates those two files under a generated-file banner. Edit the sources in `src/`, then run:
 
@@ -37,7 +41,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 npm run test:mocha
 ```
 
-The test suite under `spec/` runs as native ESM through its own `spec/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. That Mocha lane also includes a focused `bin/variety` wrapper spec that stubs `mongosh` and `mongo`, so wrapper argument handling can be validated without a live MongoDB shell install.
+The test suite under `spec/` runs as native ESM through its own `spec/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. That Mocha lane also includes focused CLI specs that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install.
 
 If you have Docker or Podman installed and don't want to test against your own MongoDB instance,
 you can execute tests against dockerized MongoDB:
@@ -86,7 +90,7 @@ Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and i
 
 #### Node-side Modernization
 
-Node-side JavaScript such as `.eslint.config.js`, `build.js`, and the test suite under `spec/` (excluding shell-executed fixtures under `spec/assets/`) opts into a stricter modernization set: `const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects.
+Node-side JavaScript such as `bin/variety`, `lib/**/*.js`, `.eslint.config.js`, `build.js`, and the test suite under `spec/` (excluding shell-executed fixtures under `spec/assets/`) opts into a stricter modernization set: `const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects.
 
 #### Legacy Shell Compatibility
 
@@ -104,7 +108,7 @@ That pass enables stricter flags such as `noImplicitReturns`, `noUncheckedIndexe
 
 ### Container-backed Linters
 
-`npm run lint:dockerfile` and `npm run lint:shell` run inside containers. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed.
+`npm run lint:dockerfile` and `npm run lint:shell` run inside containers. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed. `npm run lint:shell` now covers the remaining shell scripts (`docker/init.sh` and `spec/bin/test-on-docker.sh`), while the published `bin/variety` entrypoint is linted as Node-side JavaScript.
 
 ## Reporting Issues / Contributing
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Variety expects keys to be well formed, not having any `.`s in them (MongoDB 2.4
     $ mongosh test --quiet --eval "var collection = 'users', arrayEscape = 'YY'" variety.js
 
 ## Command Line Interface
-This NPM package publishes a first-party `variety` executable that resolves the bundled `variety.js`, prefers `mongosh` when available, and falls back to the legacy `mongo` shell.
+This NPM package publishes a built-in `variety` executable that resolves the bundled `variety.js`, prefers `mongosh` when available, and falls back to the legacy `mongo` shell.
 
 The primary interface is:
 

--- a/README.md
+++ b/README.md
@@ -281,28 +281,55 @@ Variety expects keys to be well formed, not having any `.`s in them (MongoDB 2.4
     $ mongosh test --quiet --eval "var collection = 'users', arrayEscape = 'YY'" variety.js
 
 ## Command Line Interface
-This NPM package ships a small `bin/variety` wrapper (published as the npm package's `variety` executable) that chooses `mongosh` when available and falls back to the legacy `mongo` shell.
+This NPM package publishes a first-party `variety` executable that resolves the bundled `variety.js`, prefers `mongosh` when available, and falls back to the legacy `mongo` shell.
 
-The wrapper is controlled by three environment variables:
+The primary interface is:
+
+```bash
+variety DB/COLLECTION [options]
+```
+
+Examples:
+
+```bash
+variety test/users
+```
+
+```bash
+variety test/users --outputFormat json --quiet
+```
+
+```bash
+variety logs/webserver --limit 100 --maxDepth 3 --sort '{"created":-1}'
+```
+
+```bash
+variety test/users --query '{"bio":{"$exists":true}}' --host localhost --port 27017
+```
+
+Structured flags such as `--query` and `--sort` accept strict JSON. Connection flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationDatabase`, and `--quiet` are passed through to the Mongo shell. `--eval` remains available as an escape hatch when you need to append raw JavaScript assignments.
+
+When you invoke `variety` with no CLI arguments, the documented compatibility environment variables remain supported:
 
 | Variable | Description |
 | --- | --- |
 | `DB` | MongoDB database name to pass to the shell |
 | `EVAL_CMDS` | JavaScript assignments forwarded via `--eval` (e.g. `var collection = 'users', limit = 100`) |
-| `VARIETYJS_DIR` | Directory containing `variety.js`; defaults to `.` |
+| `VARIETYJS_DIR` | Directory containing `variety.js`; when omitted, the CLI uses the bundled script |
 
 Examples:
 
 ```bash
-DB=test EVAL_CMDS="var collection = 'users', outputFormat='json'" VARIETYJS_DIR=. bin/variety
+DB=test EVAL_CMDS="var collection = 'users', outputFormat='json'" variety
 ```
 
 ```bash
-DB=test EVAL_CMDS="var collection = 'users', maxDepth = 3, limit = 500" VARIETYJS_DIR=. bin/variety
+DB=test EVAL_CMDS="var collection = 'users', maxDepth = 3, limit = 500" variety
 ```
 
-Note: `variety-cli`, a formerly available companion project that offered higher-level argument
-parsing, has been archived and is no longer maintained.
+Direct `mongosh ... variety.js` usage remains supported and is still useful when you want the most transparent low-level invocation for debugging or advanced shell work.
+
+Note: `variety-cli`, a formerly available companion project that offered higher-level argument parsing, has been archived and is no longer maintained.
 
 ## "But my dad told me MongoDB is a schemaless database!"
 
@@ -312,7 +339,7 @@ A MongoDB collection does not enforce a predefined schema like a relational data
 
 ## Dependencies
 
-At runtime, Variety itself depends only on MongoDB plus a MongoDB shell (`mongosh` is preferred; the legacy `mongo` shell still works where available).
+The packaged `variety` executable runs on Node.js and a MongoDB shell (`mongosh` is preferred; the legacy `mongo` shell still works where available). If you run Variety directly as `mongosh ... variety.js`, the shell path still depends only on MongoDB plus a MongoDB shell.
 
 ## Contributing
 

--- a/bin/variety
+++ b/bin/variety
@@ -1,47 +1,6 @@
-#! /usr/bin/env bash
-set -e
+#!/usr/bin/env node
+'use strict';
 
-### SAMPLE USAGE:
-#
-# DB=test EVAL_CMDS="var collection = 'users', limit = 1" VARIETYJS_DIR=. bin/variety
-# executes, e.g.:
-# mongosh test --eval "var collection = 'users', limit = 1" ./variety.js
+const { main } = require('../lib/cli');
 
-if command -v mongosh >/dev/null 2>&1; then
-  MONGO_SHELL=mongosh
-elif command -v mongo >/dev/null 2>&1; then
-  MONGO_SHELL=mongo
-else
-  echo 'Error: neither mongosh nor mongo found in PATH' >&2
-  exit 127
-fi
-
-VARIETYJS_DIR=${VARIETYJS_DIR:-.}
-VARIETY_SCRIPT="$VARIETYJS_DIR/variety.js"
-
-if [ "${#EVAL_CMDS}" -ge 2 ]; then
-  first_char=${EVAL_CMDS%"${EVAL_CMDS#?}"}
-  last_char=${EVAL_CMDS#"${EVAL_CMDS%?}"}
-  if { [ "$first_char" = '"' ] && [ "$last_char" = '"' ]; } || \
-     { [ "$first_char" = "'" ] && [ "$last_char" = "'" ]; }; then
-    EVAL_CMDS=${EVAL_CMDS#?}
-    EVAL_CMDS=${EVAL_CMDS%?}
-  fi
-fi
-
-CMD=("$MONGO_SHELL")
-
-if [ -n "$DB" ]; then
-  CMD+=("$DB")
-fi
-
-if [ -n "$EVAL_CMDS" ]; then
-  CMD+=(--eval "$EVAL_CMDS")
-fi
-
-CMD+=("$VARIETY_SCRIPT")
-
-echo
-printf '%q ' "${CMD[@]}"
-echo
-"${CMD[@]}"
+process.exitCode = main(process.argv.slice(2), process.env, process.stdout, process.stderr);

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,9 +1,73 @@
-// @ts-nocheck
 'use strict';
 
 const path = require('path');
 
+/**
+ * @typedef {{
+ *   authenticationDatabase?: string,
+ *   host?: string,
+ *   password?: string,
+ *   port?: number,
+ *   quiet?: boolean,
+ *   username?: string,
+ * }} ShellOptions
+ */
+
+/**
+ * @typedef {{
+ *   limit?: number,
+ *   maxDepth?: number,
+ *   outputFormat?: string,
+ *   query?: Record<string, unknown>,
+ *   sort?: Record<string, unknown>,
+ * }} VarietyOptions
+ */
+
+/**
+ * @typedef {{
+ *   collection: string,
+ *   database: string,
+ * }} TargetSelection
+ */
+
+/**
+ * @typedef {{
+ *   extraEval: string[],
+ *   help?: boolean,
+ *   shellOptions: ShellOptions,
+ *   target: TargetSelection | null,
+ *   varietyOptions: VarietyOptions,
+ *   version?: boolean,
+ * }} ParsedCliArguments
+ */
+
+/** @typedef {{ mode: 'help' }} HelpExecutionPlan */
+/** @typedef {{ mode: 'version' }} VersionExecutionPlan */
+
+/**
+ * @typedef {{
+ *   database: string,
+ *   evalCode: string,
+ *   mode: 'cli' | 'compatibility',
+ *   scriptPath: string,
+ *   shellOptions: ShellOptions,
+ * }} RunnableExecutionPlan
+ */
+
+/** @typedef {HelpExecutionPlan | VersionExecutionPlan | RunnableExecutionPlan} ExecutionPlan */
+
+/**
+ * @typedef {{
+ *   nextIndex: number,
+ *   value: string,
+ * }} ReadOptionValueResult
+ */
+
 class CliUsageError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} [exitCode=2]
+   */
   constructor(message, exitCode = 2) {
     super(message);
     this.name = 'CliUsageError';
@@ -12,33 +76,53 @@ class CliUsageError extends Error {
 }
 
 const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
+/** @type {Array<keyof VarietyOptions>} */
 const TARGET_OPTION_NAMES = ['query', 'sort', 'limit', 'maxDepth', 'outputFormat'];
+/** @type {Record<string, string>} */
 const FLAG_ALIASES = {
   'authentication-database': 'authenticationDatabase',
   'max-depth': 'maxDepth',
   'output-format': 'outputFormat',
 };
 
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {boolean}
+ */
 const hasCompatibilityEnv = (env) => {
   return COMPATIBILITY_ENV_KEYS.some((key) => typeof env[key] !== 'undefined');
 };
 
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
 const resolveCompatibilityScriptPath = (env) => {
-  if (env.VARIETYJS_DIR) {
-    return path.join(env.VARIETYJS_DIR, 'variety.js');
+  const varietyJsDir = env['VARIETYJS_DIR'];
+  if (varietyJsDir) {
+    return path.join(varietyJsDir, 'variety.js');
   }
 
   return './variety.js';
 };
 
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
 const resolveCliScriptPath = (env) => {
-  if (env.VARIETYJS_DIR) {
-    return path.join(env.VARIETYJS_DIR, 'variety.js');
+  const varietyJsDir = env['VARIETYJS_DIR'];
+  if (varietyJsDir) {
+    return path.join(varietyJsDir, 'variety.js');
   }
 
   return path.resolve(__dirname, '..', 'variety.js');
 };
 
+/**
+ * @param {string | undefined} value
+ * @returns {string}
+ */
 const stripMatchingOuterQuotes = (value) => {
   if (typeof value !== 'string' || value.length < 2) {
     return value || '';
@@ -53,9 +137,14 @@ const stripMatchingOuterQuotes = (value) => {
   return value;
 };
 
-const parsePositiveInteger = (optionName, rawValue) => {
+/**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {number}
+ */
+const parseNonNegativeInteger = (optionName, rawValue) => {
   if (!/^\d+$/.test(rawValue)) {
-    throw new CliUsageError(`--${optionName} must be an integer, received ${JSON.stringify(rawValue)}.`);
+    throw new CliUsageError(`--${optionName} must be a non-negative integer, received ${JSON.stringify(rawValue)}.`);
   }
 
   const numericValue = Number(rawValue);
@@ -66,6 +155,25 @@ const parsePositiveInteger = (optionName, rawValue) => {
   return numericValue;
 };
 
+/**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {number}
+ */
+const parsePositiveInteger = (optionName, rawValue) => {
+  const numericValue = parseNonNegativeInteger(optionName, rawValue);
+  if (numericValue < 1) {
+    throw new CliUsageError(`--${optionName} must be a positive integer, received ${JSON.stringify(rawValue)}.`);
+  }
+
+  return numericValue;
+};
+
+/**
+ * @param {string} optionName
+ * @param {string | undefined} rawValue
+ * @returns {boolean}
+ */
 const parseBooleanValue = (optionName, rawValue) => {
   if (typeof rawValue === 'undefined') {
     return true;
@@ -82,29 +190,43 @@ const parseBooleanValue = (optionName, rawValue) => {
   throw new CliUsageError(`--${optionName} accepts only true or false when given a value.`);
 };
 
+/**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {Record<string, unknown>}
+ */
 const parseJsonObject = (optionName, rawValue) => {
+  /** @type {unknown} */
   let parsedValue;
 
   try {
     parsedValue = JSON.parse(rawValue);
   } catch (error) {
-    throw new CliUsageError(`--${optionName} must be strict JSON. ${error.message}`);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new CliUsageError(`--${optionName} must be strict JSON. ${errorMessage}`);
   }
 
   if (!parsedValue || Array.isArray(parsedValue) || typeof parsedValue !== 'object') {
     throw new CliUsageError(`--${optionName} must be a JSON object.`);
   }
 
-  return parsedValue;
+  return /** @type {Record<string, unknown>} */ (parsedValue);
 };
 
+/**
+ * @param {string[]} argv
+ * @param {number} currentIndex
+ * @param {string | undefined} inlineValue
+ * @param {string} optionName
+ * @returns {ReadOptionValueResult}
+ */
 const readOptionValue = (argv, currentIndex, inlineValue, optionName) => {
   if (typeof inlineValue !== 'undefined') {
     return { nextIndex: currentIndex, value: inlineValue };
   }
 
   const nextValue = argv[currentIndex + 1];
-  if (typeof nextValue === 'undefined' || nextValue.startsWith('--')) {
+  if (typeof nextValue !== 'string' || nextValue.startsWith('--')) {
     throw new CliUsageError(`--${optionName} requires a value.`);
   }
 
@@ -114,6 +236,10 @@ const readOptionValue = (argv, currentIndex, inlineValue, optionName) => {
   };
 };
 
+/**
+ * @param {string} rawTarget
+ * @returns {TargetSelection}
+ */
 const parseTarget = (rawTarget) => {
   const separatorIndex = rawTarget.indexOf('/');
   if (separatorIndex <= 0 || separatorIndex === rawTarget.length - 1) {
@@ -126,7 +252,12 @@ const parseTarget = (rawTarget) => {
   };
 };
 
+/**
+ * @param {string[]} argv
+ * @returns {ParsedCliArguments}
+ */
 const parseCliArguments = (argv) => {
+  /** @type {ParsedCliArguments} */
   const parsed = {
     extraEval: [],
     shellOptions: {},
@@ -136,6 +267,9 @@ const parseCliArguments = (argv) => {
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
+    if (typeof argument !== 'string') {
+      throw new CliUsageError(`Unexpected missing CLI argument at index ${index}.`);
+    }
 
     if (!argument.startsWith('--')) {
       if (parsed.target !== null) {
@@ -147,6 +281,9 @@ const parseCliArguments = (argv) => {
     }
 
     const [rawOptionName, inlineValue] = argument.slice(2).split('=', 2);
+    if (typeof rawOptionName !== 'string' || rawOptionName.length === 0) {
+      throw new CliUsageError(`Unknown option ${JSON.stringify(argument)}.`);
+    }
     const optionName = FLAG_ALIASES[rawOptionName] || rawOptionName;
 
     switch (optionName) {
@@ -159,18 +296,28 @@ const parseCliArguments = (argv) => {
     case 'quiet':
       parsed.shellOptions.quiet = parseBooleanValue(optionName, inlineValue);
       break;
-    case 'query':
+    case 'query': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.query = parseJsonObject(optionName, result.value);
+      break;
+    }
     case 'sort': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
-      parsed.varietyOptions[optionName] = parseJsonObject(optionName, result.value);
+      parsed.varietyOptions.sort = parseJsonObject(optionName, result.value);
       break;
     }
-    case 'limit':
+    case 'limit': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.limit = parseNonNegativeInteger(optionName, result.value);
+      break;
+    }
     case 'maxDepth': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
-      parsed.varietyOptions[optionName] = parsePositiveInteger(optionName, result.value);
+      parsed.varietyOptions.maxDepth = parseNonNegativeInteger(optionName, result.value);
       break;
     }
     case 'outputFormat': {
@@ -179,13 +326,28 @@ const parseCliArguments = (argv) => {
       parsed.varietyOptions.outputFormat = result.value;
       break;
     }
-    case 'host':
-    case 'username':
-    case 'password':
+    case 'host': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions.host = result.value;
+      break;
+    }
+    case 'username': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions.username = result.value;
+      break;
+    }
+    case 'password': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions.password = result.value;
+      break;
+    }
     case 'authenticationDatabase': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
-      parsed.shellOptions[optionName] = result.value;
+      parsed.shellOptions.authenticationDatabase = result.value;
       break;
     }
     case 'port': {
@@ -212,10 +374,19 @@ const parseCliArguments = (argv) => {
   return parsed;
 };
 
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @returns {string}
+ */
 const renderVarAssignment = (name, value) => {
   return `var ${name} = ${JSON.stringify(value)}`;
 };
 
+/**
+ * @param {ParsedCliArguments} parsedCliArguments
+ * @returns {string}
+ */
 const buildEvalCode = (parsedCliArguments) => {
   if (parsedCliArguments.target === null) {
     return '';
@@ -231,16 +402,25 @@ const buildEvalCode = (parsedCliArguments) => {
   return statements.concat(parsedCliArguments.extraEval).join('; ');
 };
 
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {RunnableExecutionPlan}
+ */
 const createCompatibilityPlan = (env) => {
   return {
-    database: env.DB || '',
-    evalCode: stripMatchingOuterQuotes(env.EVAL_CMDS || ''),
+    database: env['DB'] || '',
+    evalCode: stripMatchingOuterQuotes(env['EVAL_CMDS'] || ''),
     mode: 'compatibility',
     scriptPath: resolveCompatibilityScriptPath(env),
     shellOptions: {},
   };
 };
 
+/**
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {ExecutionPlan}
+ */
 const createCliPlan = (argv, env) => {
   const parsedCliArguments = parseCliArguments(argv);
   if (parsedCliArguments.help) {
@@ -249,6 +429,10 @@ const createCliPlan = (argv, env) => {
 
   if (parsedCliArguments.version) {
     return { mode: 'version' };
+  }
+
+  if (parsedCliArguments.target === null) {
+    throw new CliUsageError('Missing required DB/COLLECTION target.');
   }
 
   return {
@@ -260,6 +444,11 @@ const createCliPlan = (argv, env) => {
   };
 };
 
+/**
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {ExecutionPlan}
+ */
 const createExecutionPlan = (argv, env) => {
   if (argv.length === 0) {
     if (hasCompatibilityEnv(env)) {
@@ -272,6 +461,9 @@ const createExecutionPlan = (argv, env) => {
   return createCliPlan(argv, env);
 };
 
+/**
+ * @returns {string}
+ */
 const formatUsage = () => {
   return [
     'Usage:',

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,0 +1,310 @@
+// @ts-nocheck
+'use strict';
+
+const path = require('path');
+
+class CliUsageError extends Error {
+  constructor(message, exitCode = 2) {
+    super(message);
+    this.name = 'CliUsageError';
+    this.exitCode = exitCode;
+  }
+}
+
+const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
+const TARGET_OPTION_NAMES = ['query', 'sort', 'limit', 'maxDepth', 'outputFormat'];
+const FLAG_ALIASES = {
+  'authentication-database': 'authenticationDatabase',
+  'max-depth': 'maxDepth',
+  'output-format': 'outputFormat',
+};
+
+const hasCompatibilityEnv = (env) => {
+  return COMPATIBILITY_ENV_KEYS.some((key) => typeof env[key] !== 'undefined');
+};
+
+const resolveCompatibilityScriptPath = (env) => {
+  if (env.VARIETYJS_DIR) {
+    return path.join(env.VARIETYJS_DIR, 'variety.js');
+  }
+
+  return './variety.js';
+};
+
+const resolveCliScriptPath = (env) => {
+  if (env.VARIETYJS_DIR) {
+    return path.join(env.VARIETYJS_DIR, 'variety.js');
+  }
+
+  return path.resolve(__dirname, '..', 'variety.js');
+};
+
+const stripMatchingOuterQuotes = (value) => {
+  if (typeof value !== 'string' || value.length < 2) {
+    return value || '';
+  }
+
+  const firstChar = value[0];
+  const lastChar = value[value.length - 1];
+  if ((firstChar === '"' || firstChar === '\'') && firstChar === lastChar) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+};
+
+const parsePositiveInteger = (optionName, rawValue) => {
+  if (!/^\d+$/.test(rawValue)) {
+    throw new CliUsageError(`--${optionName} must be an integer, received ${JSON.stringify(rawValue)}.`);
+  }
+
+  const numericValue = Number(rawValue);
+  if (!Number.isSafeInteger(numericValue)) {
+    throw new CliUsageError(`--${optionName} is too large: ${rawValue}.`);
+  }
+
+  return numericValue;
+};
+
+const parseBooleanValue = (optionName, rawValue) => {
+  if (typeof rawValue === 'undefined') {
+    return true;
+  }
+
+  if (rawValue === 'true') {
+    return true;
+  }
+
+  if (rawValue === 'false') {
+    return false;
+  }
+
+  throw new CliUsageError(`--${optionName} accepts only true or false when given a value.`);
+};
+
+const parseJsonObject = (optionName, rawValue) => {
+  let parsedValue;
+
+  try {
+    parsedValue = JSON.parse(rawValue);
+  } catch (error) {
+    throw new CliUsageError(`--${optionName} must be strict JSON. ${error.message}`);
+  }
+
+  if (!parsedValue || Array.isArray(parsedValue) || typeof parsedValue !== 'object') {
+    throw new CliUsageError(`--${optionName} must be a JSON object.`);
+  }
+
+  return parsedValue;
+};
+
+const readOptionValue = (argv, currentIndex, inlineValue, optionName) => {
+  if (typeof inlineValue !== 'undefined') {
+    return { nextIndex: currentIndex, value: inlineValue };
+  }
+
+  const nextValue = argv[currentIndex + 1];
+  if (typeof nextValue === 'undefined' || nextValue.startsWith('--')) {
+    throw new CliUsageError(`--${optionName} requires a value.`);
+  }
+
+  return {
+    nextIndex: currentIndex + 1,
+    value: nextValue,
+  };
+};
+
+const parseTarget = (rawTarget) => {
+  const separatorIndex = rawTarget.indexOf('/');
+  if (separatorIndex <= 0 || separatorIndex === rawTarget.length - 1) {
+    throw new CliUsageError('Expected DB/COLLECTION as the positional target.');
+  }
+
+  return {
+    collection: rawTarget.slice(separatorIndex + 1),
+    database: rawTarget.slice(0, separatorIndex),
+  };
+};
+
+const parseCliArguments = (argv) => {
+  const parsed = {
+    extraEval: [],
+    shellOptions: {},
+    target: null,
+    varietyOptions: {},
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (!argument.startsWith('--')) {
+      if (parsed.target !== null) {
+        throw new CliUsageError(`Unexpected extra positional argument ${JSON.stringify(argument)}.`);
+      }
+
+      parsed.target = parseTarget(argument);
+      continue;
+    }
+
+    const [rawOptionName, inlineValue] = argument.slice(2).split('=', 2);
+    const optionName = FLAG_ALIASES[rawOptionName] || rawOptionName;
+
+    switch (optionName) {
+    case 'help':
+      parsed.help = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'version':
+      parsed.version = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'quiet':
+      parsed.shellOptions.quiet = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'query':
+    case 'sort': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions[optionName] = parseJsonObject(optionName, result.value);
+      break;
+    }
+    case 'limit':
+    case 'maxDepth': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions[optionName] = parsePositiveInteger(optionName, result.value);
+      break;
+    }
+    case 'outputFormat': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.outputFormat = result.value;
+      break;
+    }
+    case 'host':
+    case 'username':
+    case 'password':
+    case 'authenticationDatabase': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions[optionName] = result.value;
+      break;
+    }
+    case 'port': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions.port = parsePositiveInteger(optionName, result.value);
+      break;
+    }
+    case 'eval': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.extraEval.push(result.value);
+      break;
+    }
+    default:
+      throw new CliUsageError(`Unknown option --${rawOptionName}.`);
+    }
+  }
+
+  if (!parsed.help && !parsed.version && parsed.target === null) {
+    throw new CliUsageError('Missing required DB/COLLECTION target.');
+  }
+
+  return parsed;
+};
+
+const renderVarAssignment = (name, value) => {
+  return `var ${name} = ${JSON.stringify(value)}`;
+};
+
+const buildEvalCode = (parsedCliArguments) => {
+  if (parsedCliArguments.target === null) {
+    return '';
+  }
+
+  const statements = [renderVarAssignment('collection', parsedCliArguments.target.collection)];
+  TARGET_OPTION_NAMES.forEach((name) => {
+    if (Object.hasOwn(parsedCliArguments.varietyOptions, name)) {
+      statements.push(renderVarAssignment(name, parsedCliArguments.varietyOptions[name]));
+    }
+  });
+
+  return statements.concat(parsedCliArguments.extraEval).join('; ');
+};
+
+const createCompatibilityPlan = (env) => {
+  return {
+    database: env.DB || '',
+    evalCode: stripMatchingOuterQuotes(env.EVAL_CMDS || ''),
+    mode: 'compatibility',
+    scriptPath: resolveCompatibilityScriptPath(env),
+    shellOptions: {},
+  };
+};
+
+const createCliPlan = (argv, env) => {
+  const parsedCliArguments = parseCliArguments(argv);
+  if (parsedCliArguments.help) {
+    return { mode: 'help' };
+  }
+
+  if (parsedCliArguments.version) {
+    return { mode: 'version' };
+  }
+
+  return {
+    database: parsedCliArguments.target.database,
+    evalCode: buildEvalCode(parsedCliArguments),
+    mode: 'cli',
+    scriptPath: resolveCliScriptPath(env),
+    shellOptions: parsedCliArguments.shellOptions,
+  };
+};
+
+const createExecutionPlan = (argv, env) => {
+  if (argv.length === 0) {
+    if (hasCompatibilityEnv(env)) {
+      return createCompatibilityPlan(env);
+    }
+
+    throw new CliUsageError('Missing required DB/COLLECTION target.');
+  }
+
+  return createCliPlan(argv, env);
+};
+
+const formatUsage = () => {
+  return [
+    'Usage:',
+    '  variety DB/COLLECTION [options]',
+    '  DB=test EVAL_CMDS=\'var collection = "users"\' variety',
+    '',
+    'Options:',
+    '  --query <json>                   Strict JSON query object',
+    '  --sort <json>                    Strict JSON sort object',
+    '  --limit <number>                 Limit documents analyzed',
+    '  --maxDepth <number>              Maximum traversal depth',
+    '  --outputFormat <value>           Output format, e.g. ascii or json',
+    '  --quiet                          Pass --quiet through to the Mongo shell',
+    '  --host <value>                   Mongo shell host',
+    '  --port <number>                  Mongo shell port',
+    '  --username <value>               MongoDB username',
+    '  --password <value>               MongoDB password',
+    '  --authenticationDatabase <value> Authentication database',
+    '  --eval <javascript>              Extra JavaScript appended after CLI assignments',
+    '  --help                           Show this help',
+    '  --version                        Show the Variety package version',
+    '',
+    'With no CLI arguments, the documented DB / EVAL_CMDS / VARIETYJS_DIR',
+    'environment variables remain supported for backwards compatibility.',
+  ].join('\n');
+};
+
+module.exports = {
+  CliUsageError,
+  buildEvalCode,
+  createExecutionPlan,
+  formatUsage,
+  hasCompatibilityEnv,
+  parseCliArguments,
+  stripMatchingOuterQuotes,
+};

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,0 +1,47 @@
+// @ts-nocheck
+'use strict';
+
+const fs = require('fs');
+const packageMetadata = require('../package.json');
+const { CliUsageError, createExecutionPlan, formatUsage } = require('./cli-options');
+const { CliRuntimeError, buildShellInvocation, runShellInvocation } = require('./mongo-shell');
+
+const writeLine = (stream, message) => {
+  fs.writeSync(stream.fd, `${message}\n`);
+};
+
+const main = (argv = process.argv.slice(2), env = process.env, stdout = process.stdout, stderr = process.stderr) => {
+  try {
+    const executionPlan = createExecutionPlan(argv, env);
+
+    if (executionPlan.mode === 'help') {
+      writeLine(stdout, formatUsage());
+      return 0;
+    }
+
+    if (executionPlan.mode === 'version') {
+      writeLine(stdout, packageMetadata.version);
+      return 0;
+    }
+
+    return runShellInvocation(buildShellInvocation(executionPlan, env), env);
+  } catch (error) {
+    if (error instanceof CliUsageError) {
+      writeLine(stderr, `Error: ${error.message}`);
+      writeLine(stderr, '');
+      writeLine(stderr, formatUsage());
+      return error.exitCode;
+    }
+
+    if (error instanceof CliRuntimeError) {
+      writeLine(stderr, error.message);
+      return error.exitCode;
+    }
+
+    throw error;
+  }
+};
+
+module.exports = {
+  main,
+};

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,15 +1,34 @@
-// @ts-nocheck
 'use strict';
 
 const fs = require('fs');
-const packageMetadata = require('../package.json');
-const { CliUsageError, createExecutionPlan, formatUsage } = require('./cli-options');
-const { CliRuntimeError, buildShellInvocation, runShellInvocation } = require('./mongo-shell');
+const path = require('path');
+/** @typedef {{ fd: number }} FdWritableStream */
+/** @typedef {{ version: string }} PackageMetadata */
+const rawPackageMetadata = /** @type {unknown} */ (
+  JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
+);
+const packageMetadata = /** @type {PackageMetadata} */ (rawPackageMetadata);
+const cliOptions = /** @type {typeof import('./cli-options.js')} */ (require('./cli-options'));
+const mongoShell = /** @type {typeof import('./mongo-shell.js')} */ (require('./mongo-shell'));
+const { CliUsageError, createExecutionPlan, formatUsage } = cliOptions;
+const { CliRuntimeError, buildShellInvocation, runShellInvocation } = mongoShell;
 
+/**
+ * @param {FdWritableStream} stream
+ * @param {string} message
+ * @returns {void}
+ */
 const writeLine = (stream, message) => {
   fs.writeSync(stream.fd, `${message}\n`);
 };
 
+/**
+ * @param {string[]} [argv=process.argv.slice(2)]
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @param {FdWritableStream} [stdout=process.stdout]
+ * @param {FdWritableStream} [stderr=process.stderr]
+ * @returns {number}
+ */
 const main = (argv = process.argv.slice(2), env = process.env, stdout = process.stdout, stderr = process.stderr) => {
   try {
     const executionPlan = createExecutionPlan(argv, env);
@@ -38,7 +57,11 @@ const main = (argv = process.argv.slice(2), env = process.env, stdout = process.
       return error.exitCode;
     }
 
-    throw error;
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error(String(error), { cause: error });
   }
 };
 

--- a/lib/mongo-shell.js
+++ b/lib/mongo-shell.js
@@ -1,11 +1,41 @@
-// @ts-nocheck
 'use strict';
 
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * @typedef {{
+ *   authenticationDatabase?: string,
+ *   host?: string,
+ *   password?: string,
+ *   port?: number,
+ *   quiet?: boolean,
+ *   username?: string,
+ * }} ShellOptions
+ */
+
+/**
+ * @typedef {{
+ *   database: string,
+ *   evalCode: string,
+ *   scriptPath: string,
+ *   shellOptions?: ShellOptions,
+ * }} ShellExecutionPlan
+ */
+
+/**
+ * @typedef {{
+ *   args: string[],
+ *   command: string,
+ * }} ShellInvocation
+ */
+
 class CliRuntimeError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} [exitCode=1]
+   */
   constructor(message, exitCode = 1) {
     super(message);
     this.name = 'CliRuntimeError';
@@ -13,6 +43,10 @@ class CliRuntimeError extends Error {
   }
 }
 
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
 const isExecutable = (filePath) => {
   try {
     fs.accessSync(filePath, fs.constants.X_OK);
@@ -22,6 +56,11 @@ const isExecutable = (filePath) => {
   }
 };
 
+/**
+ * @param {string} commandName
+ * @param {string} envPath
+ * @returns {string | null}
+ */
 const findCommandOnPath = (commandName, envPath) => {
   if (!envPath) {
     return null;
@@ -34,13 +73,18 @@ const findCommandOnPath = (commandName, envPath) => {
     .find((candidatePath) => isExecutable(candidatePath)) || null;
 };
 
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string}
+ */
 const selectMongoShell = (env) => {
-  const mongoshPath = findCommandOnPath('mongosh', env.PATH || '');
+  const envPath = env['PATH'] || '';
+  const mongoshPath = findCommandOnPath('mongosh', envPath);
   if (mongoshPath) {
     return mongoshPath;
   }
 
-  const mongoPath = findCommandOnPath('mongo', env.PATH || '');
+  const mongoPath = findCommandOnPath('mongo', envPath);
   if (mongoPath) {
     return mongoPath;
   }
@@ -48,9 +92,15 @@ const selectMongoShell = (env) => {
   throw new CliRuntimeError('Error: neither mongosh nor mongo found in PATH', 127);
 };
 
+/**
+ * @param {ShellExecutionPlan} plan
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {ShellInvocation}
+ */
 const buildShellInvocation = (plan, env) => {
   const command = selectMongoShell(env);
   const args = [];
+  /** @type {ShellOptions} */
   const shellOptions = plan.shellOptions || {};
 
   if (shellOptions.host) {
@@ -90,6 +140,11 @@ const buildShellInvocation = (plan, env) => {
   return { args, command };
 };
 
+/**
+ * @param {ShellInvocation} invocation
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {number}
+ */
 const runShellInvocation = (invocation, env) => {
   const result = spawnSync(invocation.command, invocation.args, {
     env,
@@ -97,7 +152,8 @@ const runShellInvocation = (invocation, env) => {
   });
 
   if (result.error) {
-    throw new CliRuntimeError(result.error.message);
+    const errorMessage = result.error instanceof Error ? result.error.message : String(result.error);
+    throw new CliRuntimeError(errorMessage);
   }
 
   return typeof result.status === 'number' ? result.status : 1;

--- a/lib/mongo-shell.js
+++ b/lib/mongo-shell.js
@@ -1,0 +1,112 @@
+// @ts-nocheck
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+class CliRuntimeError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.name = 'CliRuntimeError';
+    this.exitCode = exitCode;
+  }
+}
+
+const isExecutable = (filePath) => {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const findCommandOnPath = (commandName, envPath) => {
+  if (!envPath) {
+    return null;
+  }
+
+  return envPath
+    .split(path.delimiter)
+    .filter((directory) => directory.length > 0)
+    .map((directory) => path.join(directory, commandName))
+    .find((candidatePath) => isExecutable(candidatePath)) || null;
+};
+
+const selectMongoShell = (env) => {
+  const mongoshPath = findCommandOnPath('mongosh', env.PATH || '');
+  if (mongoshPath) {
+    return mongoshPath;
+  }
+
+  const mongoPath = findCommandOnPath('mongo', env.PATH || '');
+  if (mongoPath) {
+    return mongoPath;
+  }
+
+  throw new CliRuntimeError('Error: neither mongosh nor mongo found in PATH', 127);
+};
+
+const buildShellInvocation = (plan, env) => {
+  const command = selectMongoShell(env);
+  const args = [];
+  const shellOptions = plan.shellOptions || {};
+
+  if (shellOptions.host) {
+    args.push('--host', shellOptions.host);
+  }
+
+  if (typeof shellOptions.port === 'number') {
+    args.push('--port', String(shellOptions.port));
+  }
+
+  if (plan.database) {
+    args.push(plan.database);
+  }
+
+  if (shellOptions.quiet === true) {
+    args.push('--quiet');
+  }
+
+  if (shellOptions.username) {
+    args.push('--username', shellOptions.username);
+  }
+
+  if (shellOptions.password) {
+    args.push('--password', shellOptions.password);
+  }
+
+  if (shellOptions.authenticationDatabase) {
+    args.push('--authenticationDatabase', shellOptions.authenticationDatabase);
+  }
+
+  if (plan.evalCode) {
+    args.push('--eval', plan.evalCode);
+  }
+
+  args.push(plan.scriptPath);
+
+  return { args, command };
+};
+
+const runShellInvocation = (invocation, env) => {
+  const result = spawnSync(invocation.command, invocation.args, {
+    env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw new CliRuntimeError(result.error.message);
+  }
+
+  return typeof result.status === 'number' ? result.status : 1;
+};
+
+module.exports = {
+  CliRuntimeError,
+  buildShellInvocation,
+  findCommandOnPath,
+  runShellInvocation,
+  selectMongoShell,
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   ],
   "files": [
     "variety.js",
-    "bin/variety"
+    "bin/variety",
+    "lib/"
   ],
   "main": "variety.js",
   "bin": "./bin/variety",
@@ -52,7 +53,7 @@
     "lint:markdown": "./node_modules/.bin/markdownlint '**/*.md' '**/*.markdown' --ignore node_modules",
     "lint:yaml": "find . \\( -name '*.yml' -o -name '*.yaml' \\) -not -path '*/node_modules/*' -not -path './.git/*' -print0 | xargs -0 -n1 ./node_modules/.bin/js-yaml > /dev/null",
     "lint:dockerfile": "RUNNER=$(command -v docker 2>/dev/null || command -v podman 2>/dev/null) && $RUNNER run --rm -i ghcr.io/hadolint/hadolint < docker/Dockerfile.template",
-    "lint:shell": "RUNNER=$(command -v docker 2>/dev/null || command -v podman 2>/dev/null) && $RUNNER run --rm -v \"${PWD}:/mnt:z\" docker.io/koalaman/shellcheck:stable /mnt/bin/variety /mnt/docker/init.sh /mnt/spec/bin/test-on-docker.sh",
+    "lint:shell": "RUNNER=$(command -v docker 2>/dev/null || command -v podman 2>/dev/null) && $RUNNER run --rm -v \"${PWD}:/mnt:z\" docker.io/koalaman/shellcheck:stable /mnt/docker/init.sh /mnt/spec/bin/test-on-docker.sh",
     "typecheck": "./node_modules/.bin/tsc --project .tsconfig.checkjs.json",
     "test": "npm run lint && npm run test:docker",
     "test:docker": "./spec/bin/test-on-docker.sh",

--- a/spec/BinWrapperTest.js
+++ b/spec/BinWrapperTest.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { readFileSync } from 'fs';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
@@ -7,6 +8,11 @@ import { execFile } from 'promisify-child-process';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const binVarietyPath = fileURLToPath(new URL('../bin/variety', import.meta.url));
+/** @typedef {{ version: string }} PackageMetadata */
+const rawPackageMetadata = /** @type {unknown} */ (
+  JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+);
+const packageMetadata = /** @type {PackageMetadata} */ (rawPackageMetadata);
 
 /**
  * @typedef {{
@@ -53,12 +59,16 @@ const readInvocation = async (recordPath) => {
 /**
  * @param {{
  *   shells?: string[],
+ *   args?: string[],
  *   env?: NodeJS.ProcessEnv,
+ *   includeSystemPath?: boolean,
  * }} [options]
  */
 const runBinVariety = async (options = {}) => {
   const shellNames = options.shells || ['mongosh'];
+  const args = options.args || [];
   const env = options.env || {};
+  const includeSystemPath = typeof options.includeSystemPath === 'undefined' ? true : options.includeSystemPath;
   const fixtureDir = await mkdtemp(path.join(tmpdir(), 'variety-bin-wrapper-'));
   const recordPath = path.join(fixtureDir, 'invocation.txt');
 
@@ -67,20 +77,20 @@ const runBinVariety = async (options = {}) => {
       await createFakeShell(fixtureDir, shellName);
     }
 
-    const result = await execFile('/bin/bash', [binVarietyPath], {
+    const result = await execFile(process.execPath, [binVarietyPath, ...args], {
       cwd: repoRoot,
       env: {
         ...process.env,
         ...env,
         FAKE_SHELL_ARGS_FILE: recordPath,
-        PATH: fixtureDir,
+        PATH: [fixtureDir, includeSystemPath ? process.env['PATH'] || '' : ''].filter(Boolean).join(path.delimiter),
       },
     });
 
     return {
       stderr: String(result.stderr || ''),
       stdout: String(result.stdout || ''),
-      invocation: await readInvocation(recordPath),
+      invocation: await readInvocation(recordPath).catch(() => null),
     };
   } finally {
     await rm(fixtureDir, { recursive: true, force: true });
@@ -88,7 +98,68 @@ const runBinVariety = async (options = {}) => {
 };
 
 describe('bin/variety wrapper', () => {
-  it('prefers mongosh and forwards DB plus eval arguments', async () => {
+  it('supports the db/collection CLI target plus core analysis flags', async () => {
+    const { invocation, stderr } = await runBinVariety({
+      args: [
+        'testdb/users',
+        '--limit', '5',
+        '--maxDepth=3',
+        '--output-format', 'json',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "users"; var limit = 5; var maxDepth = 3; var outputFormat = "json"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+    assert.equal(stderr, '');
+  });
+
+  it('passes through connection flags and appends extra eval code', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'analytics/events',
+        '--host', 'localhost',
+        '--port', '27017',
+        '--username', 'alice',
+        '--password', 'secret',
+        '--authenticationDatabase', 'admin',
+        '--quiet',
+        '--query', '{"type":"pageview"}',
+        '--sort', '{"updatedAt":-1}',
+        '--eval', 'var plugins = "custom"',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        '--host', 'localhost',
+        '--port', '27017',
+        'analytics',
+        '--quiet',
+        '--username', 'alice',
+        '--password', 'secret',
+        '--authenticationDatabase', 'admin',
+        '--eval',
+        'var collection = "events"; var query = {"type":"pageview"}; var sort = {"updatedAt":-1}; var plugins = "custom"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
+  it('prefers mongosh and preserves the documented DB plus EVAL_CMDS compatibility mode', async () => {
     const { invocation, stdout, stderr } = await runBinVariety({
       shells: ['mongosh', 'mongo'],
       env: {
@@ -97,6 +168,9 @@ describe('bin/variety wrapper', () => {
       },
     });
 
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
     assert.deepEqual(invocation, {
       command: 'mongosh',
       args: ['testdb', '--eval', 'var collection = \'users\', limit = 1', './variety.js'],
@@ -114,6 +188,9 @@ describe('bin/variety wrapper', () => {
       },
     });
 
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
     assert.deepEqual(invocation, {
       command: 'mongo',
       args: [`${varietyDir}/variety.js`],
@@ -127,6 +204,9 @@ describe('bin/variety wrapper', () => {
       },
     });
 
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
     assert.deepEqual(invocation.args, ['--eval', 'var collection = \'users\', limit = 2', './variety.js']);
   });
 
@@ -137,6 +217,9 @@ describe('bin/variety wrapper', () => {
       },
     });
 
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
     assert.deepEqual(invocation.args, ['--eval', 'var collection = "users", limit = 2', './variety.js']);
   });
 
@@ -148,16 +231,59 @@ describe('bin/variety wrapper', () => {
       },
     });
 
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
     assert.deepEqual(invocation.args, ['--eval', evalCommands, './variety.js']);
   });
 
   it('fails with exit 127 when neither shell is available', async () => {
     await assert.rejects(
-      () => runBinVariety({ shells: [] }),
+      () => runBinVariety({
+        args: ['test/users'],
+        includeSystemPath: false,
+        shells: [],
+      }),
       /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
       (error) => {
         assert.equal(error.code, 127);
         assert.match(String(error.stderr || ''), /neither mongosh nor mongo found in PATH/);
+        return true;
+      }
+    );
+  });
+
+  it('prints help without invoking a Mongo shell', async () => {
+    const { invocation, stdout, stderr } = await runBinVariety({
+      args: ['--help'],
+      shells: [],
+    });
+
+    assert.equal(invocation, null);
+    assert.match(stdout, /Usage:/);
+    assert.equal(stderr, '');
+  });
+
+  it('prints the package version without invoking a Mongo shell', async () => {
+    const { invocation, stdout, stderr } = await runBinVariety({
+      args: ['--version'],
+      shells: [],
+    });
+
+    assert.equal(invocation, null);
+    assert.equal(stdout.trim(), packageMetadata.version);
+    assert.equal(stderr, '');
+  });
+
+  it('fails fast on invalid JSON query input', async () => {
+    await assert.rejects(
+      () => runBinVariety({
+        args: ['test/users', '--query', '{bad-json}'],
+      }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 2);
+        assert.match(String(error.stderr || ''), /--query must be strict JSON/);
         return true;
       }
     );

--- a/spec/BinWrapperTest.js
+++ b/spec/BinWrapperTest.js
@@ -182,6 +182,7 @@ describe('bin/variety wrapper', () => {
   it('falls back to mongo and honors VARIETYJS_DIR', async () => {
     const varietyDir = '/tmp/custom-variety-dir';
     const { invocation } = await runBinVariety({
+      includeSystemPath: false,
       shells: ['mongo'],
       env: {
         VARIETYJS_DIR: varietyDir,

--- a/spec/CliOptionsTest.js
+++ b/spec/CliOptionsTest.js
@@ -1,0 +1,174 @@
+import assert from 'assert';
+import { chmod, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+/**
+ * @typedef {{
+ *   CliUsageError: typeof Error,
+ *   createExecutionPlan: (argv: string[], env: NodeJS.ProcessEnv) => {
+ *     database?: string,
+ *     evalCode?: string,
+ *     mode: string,
+ *     scriptPath?: string,
+ *     shellOptions?: Record<string, unknown>,
+ *   },
+ *   formatUsage: () => string,
+ *   stripMatchingOuterQuotes: (value: string) => string,
+ * }} CliOptionsModule
+ */
+
+/**
+ * @typedef {{
+ *   buildShellInvocation: (
+ *     plan: {
+ *       database: string,
+ *       evalCode: string,
+ *       scriptPath: string,
+ *       shellOptions: {
+ *         authenticationDatabase: string,
+ *         host: string,
+ *         password: string,
+ *         port: number,
+ *         quiet: boolean,
+ *         username: string,
+ *       },
+ *     },
+ *     env: NodeJS.ProcessEnv
+ *   ) => { command: string, args: string[] },
+ * }} MongoShellModule
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const cliOptionsModule = /** @type {CliOptionsModule} */ (
+  /** @type {unknown} */ (require('../lib/cli-options.js'))
+);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const mongoShellModule = /** @type {MongoShellModule} */ (
+  /** @type {unknown} */ (require('../lib/mongo-shell.js'))
+);
+
+const {
+  CliUsageError,
+  createExecutionPlan,
+  formatUsage,
+  stripMatchingOuterQuotes,
+} = cliOptionsModule;
+const { buildShellInvocation } = mongoShellModule;
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+describe('CLI option parsing', () => {
+  it('builds a CLI execution plan with bundled variety.js by default', () => {
+    const plan = createExecutionPlan([
+      'sales/orders',
+      '--limit', '25',
+      '--maxDepth', '4',
+      '--outputFormat', 'json',
+      '--query', '{"status":"open"}',
+      '--sort', '{"updatedAt":-1}',
+      '--eval', 'var plugins = "csv"',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'sales',
+      evalCode: 'var collection = "orders"; var query = {"status":"open"}; var sort = {"updatedAt":-1}; var limit = 25; var maxDepth = 4; var outputFormat = "json"; var plugins = "csv"',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+  });
+
+  it('keeps the documented env-var compatibility mode available', () => {
+    const plan = createExecutionPlan([], {
+      DB: 'testdb',
+      EVAL_CMDS: '"var collection = \'users\', limit = 2"',
+      VARIETYJS_DIR: '/tmp/custom-variety',
+    });
+
+    assert.deepEqual(plan, {
+      database: 'testdb',
+      evalCode: 'var collection = \'users\', limit = 2',
+      mode: 'compatibility',
+      scriptPath: '/tmp/custom-variety/variety.js',
+      shellOptions: {},
+    });
+  });
+
+  it('renders Mongo shell arguments in the expected order', () => {
+    return (async () => {
+      const shellDir = await mkdtemp(path.join(tmpdir(), 'variety-cli-options-'));
+      const shellPath = path.join(shellDir, 'mongosh');
+
+      try {
+        await writeFile(shellPath, '#!/bin/sh\nexit 0\n');
+        await chmod(shellPath, 0o755);
+
+        const invocation = buildShellInvocation({
+          database: 'appdb',
+          evalCode: 'var collection = "users"',
+          scriptPath: '/tmp/variety.js',
+          shellOptions: {
+            authenticationDatabase: 'admin',
+            host: 'localhost',
+            password: 'secret',
+            port: 27018,
+            quiet: true,
+            username: 'alice',
+          },
+        }, {
+          PATH: shellDir,
+        });
+
+        assert.deepEqual(invocation.args, [
+          '--host', 'localhost',
+          '--port', '27018',
+          'appdb',
+          '--quiet',
+          '--username', 'alice',
+          '--password', 'secret',
+          '--authenticationDatabase', 'admin',
+          '--eval', 'var collection = "users"',
+          '/tmp/variety.js',
+        ]);
+      } finally {
+        await rm(shellDir, { recursive: true, force: true });
+      }
+    })();
+  });
+
+  it('throws a usage error when the target is missing', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan([], {});
+      },
+      CliUsageError
+    );
+  });
+
+  it('throws a usage error for malformed JSON flags', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan(['test/users', '--query', '{broken-json}'], {});
+      },
+      /--query must be strict JSON/
+    );
+  });
+
+  it('strips only matching outer quotes in compatibility eval input', () => {
+    assert.equal(stripMatchingOuterQuotes('"hello"'), 'hello');
+    assert.equal(stripMatchingOuterQuotes('\'hello\''), 'hello');
+    assert.equal(stripMatchingOuterQuotes('"hello\''), '"hello\'');
+  });
+
+  it('documents the compatibility mode in help output', () => {
+    const helpText = formatUsage();
+
+    assert.match(helpText, /variety DB\/COLLECTION \[options\]/);
+    assert.match(helpText, /DB=test EVAL_CMDS=/);
+    assert.match(helpText, /backwards compatibility/);
+  });
+});

--- a/spec/CliOptionsTest.js
+++ b/spec/CliOptionsTest.js
@@ -6,50 +6,11 @@ import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 
 const require = createRequire(import.meta.url);
-/**
- * @typedef {{
- *   CliUsageError: typeof Error,
- *   createExecutionPlan: (argv: string[], env: NodeJS.ProcessEnv) => {
- *     database?: string,
- *     evalCode?: string,
- *     mode: string,
- *     scriptPath?: string,
- *     shellOptions?: Record<string, unknown>,
- *   },
- *   formatUsage: () => string,
- *   stripMatchingOuterQuotes: (value: string) => string,
- * }} CliOptionsModule
- */
-
-/**
- * @typedef {{
- *   buildShellInvocation: (
- *     plan: {
- *       database: string,
- *       evalCode: string,
- *       scriptPath: string,
- *       shellOptions: {
- *         authenticationDatabase: string,
- *         host: string,
- *         password: string,
- *         port: number,
- *         quiet: boolean,
- *         username: string,
- *       },
- *     },
- *     env: NodeJS.ProcessEnv
- *   ) => { command: string, args: string[] },
- * }} MongoShellModule
- */
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const cliOptionsModule = /** @type {CliOptionsModule} */ (
-  /** @type {unknown} */ (require('../lib/cli-options.js'))
-);
+const cliOptionsModule = /** @type {typeof import('../lib/cli-options.js')} */ (require('../lib/cli-options.js'));
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const mongoShellModule = /** @type {MongoShellModule} */ (
-  /** @type {unknown} */ (require('../lib/mongo-shell.js'))
-);
+const mongoShellModule = /** @type {typeof import('../lib/mongo-shell.js')} */ (require('../lib/mongo-shell.js'));
 
 const {
   CliUsageError,
@@ -80,6 +41,29 @@ describe('CLI option parsing', () => {
       scriptPath: path.join(repoRoot, 'variety.js'),
       shellOptions: {},
     });
+  });
+
+  it('keeps zero-valued analysis options while requiring a positive port', () => {
+    const plan = createExecutionPlan([
+      'sales/orders',
+      '--limit', '0',
+      '--maxDepth', '0',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'sales',
+      evalCode: 'var collection = "orders"; var limit = 0; var maxDepth = 0',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+
+    assert.throws(
+      () => {
+        createExecutionPlan(['sales/orders', '--port', '0'], {});
+      },
+      /--port must be a positive integer/
+    );
   });
 
   it('keeps the documented env-var compatibility mode available', () => {


### PR DESCRIPTION
Closes #232.

## Summary
- evolve the bash-only `bin/variety` wrapper into a real Node CLI that supports `variety DB/COLLECTION [options]`
- preserve the documented `DB` / `EVAL_CMDS` / `VARIETYJS_DIR` compatibility mode while keeping raw `mongosh ... variety.js` usage intact
- add focused CLI parsing and wrapper coverage, and update README/CONTRIBUTING plus lint/package metadata for the new entrypoint

## Testing
- `npm run lint`
- `npm run lint:markdown`
- `npm run typecheck`
- `npm run verify:build`
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 spec/BinWrapperTest.js spec/CliOptionsTest.js`
- `npm run test:docker`
- `MONGODB_VERSION=5.0 npm run test:docker`