### PR TITLE
Unify built-in formatters under the same registry pattern as plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,23 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 
 ## Repo Layout and the `variety.js` Build
 
-`variety.js` at the repo root is a generated file, assembled from two sources:
+`variety.js` at the repo root is a generated file, assembled from four sources in this order:
 
+- `core/formatters/ascii.js` — built-in ASCII table formatter. Self-contained
+  IIFE; registers an `ascii` factory on `shellContext.__varietyFormatters`.
+- `core/formatters/json.js` — built-in JSON formatter. Self-contained IIFE;
+  registers a `json` factory on `shellContext.__varietyFormatters`.
 - `core/analyzer.js` — pure, transport-agnostic analysis logic. No runtime
-  dependencies on shell globals, Node I/O, or any other layer. This is the
+  dependencies on shell globals, Node I/O, or any other layer. Reads
+  `shellContext.__varietyFormatters` to dispatch output. This is the
   future `@variety/core` package boundary.
 - `shell/mongo-shell-adapter.js` — the shell-facing layer that reads shell
   globals (`collection`, `plugins`, `slaveOk`, etc.), loads plugins, and
   hands dependencies to `impl.run()`. The only place in the build that
-  touches `db`, `print`, and `load`. Depends on `core`; compiled into
-  `variety.js` by `build.js` (not a separately published package).
+  touches `db`, `print`, and `load`. Cleans up both `__varietyImpl` and
+  `__varietyFormatters` after execution so repeated loads are idempotent.
+  Depends on `core`; compiled into `variety.js` by `build.js` (not a
+  separately published package).
 - `bin/variety` — the published Node entrypoint that implements the main
   CLI surface.
 - `cli/main.js`, `cli/options.js`, `cli/mongo-shell-launcher.js` — Node-side
@@ -31,11 +38,12 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   The only place that touches Node `process`, `fs`, and `spawnSync`. Depends
   on `core`; this is the future `@variety/cli` package boundary.
 
-**Dependency directions:** `core` has no runtime deps on any other layer.
-`shell` depends on `core`. `cli` depends on `core`. `build.js` composes
-`core` + `shell` → `variety.js`.
+**Dependency directions:** `core/formatters/` has no runtime deps on any other
+layer. `core` depends on `core/formatters/`. `shell` depends on `core`. `cli`
+depends on `core`. `build.js` composes `core/formatters/` + `core` + `shell`
+→ `variety.js`.
 
-`build.js` concatenates those two source files under a generated-file banner.
+`build.js` concatenates those source files under a generated-file banner.
 Edit the sources in `core/` or `shell/`, then run:
 
 ```
@@ -52,7 +60,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 npm run test:mocha
 ```
 
-The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern — `test/analysis/`, `test/cli/`, `test/persistence/`, and `test/plugins/` — with shared helpers under `test/utils/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install.
+The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern — `test/analysis/`, `test/cli/`, `test/formatters/`, `test/persistence/`, and `test/plugins/` — with shared helpers under `test/utils/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install.
 
 If you have Docker or Podman installed and don't want to test against your own MongoDB instance,
 you can execute tests against dockerized MongoDB:
@@ -84,7 +92,7 @@ Variety keeps its repository checks split into a few layers so it is clear which
 
 Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and installed automatically on `npm install`. Each commit runs all of the following, and is blocked if any fail:
 
-- `npm run verify:build` — verifies `variety.js` matches what `build.js` would produce from `core/` and `shell/`
+- `npm run verify:build` — verifies `variety.js` matches what `build.js` would produce from `core/formatters/`, `core/`, and `shell/`
 - `npm run lint` — ESLint (JavaScript)
 - `npm run lint:json` — `@prantlf/jsonlint` (JSON files)
 - `npm run lint:markdown` — markdownlint (Markdown files)
@@ -120,6 +128,65 @@ That pass enables stricter flags such as `noImplicitReturns`, `noUncheckedIndexe
 ### Container-backed Linters
 
 `npm run lint:dockerfile` and `npm run lint:shell` run inside containers. [Docker](https://www.docker.com/) is used if available, with [Podman](https://podman.io/) as a fallback. At least one must be installed. `npm run lint:shell` now covers the remaining shell scripts (`docker/init.sh` and `test/bin/test-on-docker.sh`), while the published `bin/variety` entrypoint is linted as Node-side JavaScript.
+
+## Writing a Plugin
+
+A plugin is a CommonJS module (`.js` file) that exports a plain object. Variety calls any hooks it finds on that object; omit the ones you don't need.
+
+### Hooks
+
+| Hook | Signature | Notes |
+| --- | --- | --- |
+| `init` | `init(pluginConfig)` | Called once after the plugin is loaded. `pluginConfig` is a key/value object parsed from the `\|key=value` suffix in the `plugins` option. |
+| `onConfig` | `onConfig(config)` | Called once after Variety's full config is resolved. Use this to read analysis settings. |
+| `formatResults` | `formatResults(results)` → `string` | Called after analysis. The returned string is printed instead of the built-in formatter. Omit this hook to keep the default output format. |
+
+### Minimal example
+
+```js
+// my-plugin.js
+module.exports = {
+  formatResults(results) {
+    return results.map((r) => `${r._id.key}: ${r.percentContaining}%`).join('\n');
+  },
+};
+```
+
+Run it:
+
+```bash
+mongosh test --quiet --eval "var collection='users', plugins='./my-plugin.js'" variety.js
+```
+
+### Example with configuration
+
+```js
+// csv-plugin.js
+let delimiter = ',';
+
+module.exports = {
+  init(cfg) {
+    if (cfg.delimiter) { delimiter = cfg.delimiter; }
+  },
+  formatResults(results) {
+    const headers = ['key', 'types', 'occurrences', 'percents'];
+    const rows = results.map((r) =>
+      [r._id.key, Object.keys(r.value.types).join('+'), r.totalOccurrences, r.percentContaining].join(delimiter)
+    );
+    return [headers.join(delimiter), ...rows].join('\n');
+  },
+};
+```
+
+Pass config via the `|` separator:
+
+```bash
+mongosh test --quiet --eval "var collection='users', plugins='./csv-plugin.js|delimiter=;'" variety.js
+```
+
+### Testing a plugin
+
+Integration tests for plugins live in `test/plugins/`. Copy the structure of `test/plugins/PluginTest.js` and put your fixture file under `test/fixtures/`. The `Tester` helper's `runAnalysis({ plugins: getPluginPath() })` method is the easiest way to wire everything up.
 
 ## Reporting Issues / Contributing
 

--- a/README.md
+++ b/README.md
@@ -169,16 +169,61 @@ Variety captures each `lastValue` from the first matching document it sees in th
 `Date` is converted into `timestamp`, `ObjectId` into `string`, and binary data into hex. Other types are shown in square brackets.
 Variety reports BSON wrapper types such as `Decimal128`, `Timestamp`, `Code`, `BSONRegExp`, `MinKey`, `MaxKey`, and `DBRef` by their BSON type names in the `types` column.
 
-## Render Output As JSON For Easy Ingestion and Parsing
+## Output Formats and Plugins
 
-Variety supports two built-in output formats:
+Variety has a built-in formatter registry and a plugin system, both of which use the same `formatResults` interface. Built-in formatters are selected by name; plugins override the built-in entirely when a `formatResults` hook is provided.
 
-- ASCII: nicely formatted tables (as in this README)
-- JSON: valid JSON results for subsequent processing in other tools (see also [quiet option](#quiet-option))
+### Built-in Formats
 
-Default format is `ascii`. You can select the format with the `outputFormat` property provided to Variety. Valid values are `ascii` and `json`. If you load a plugin with a `formatResults` hook, the plugin can emit a custom format instead.
+Two formatters are included out of the box:
+
+| Format | Description |
+| --- | --- |
+| `ascii` (default) | Padded table, as shown throughout this README |
+| `json` | Pretty-printed JSON array, suitable for piping to other tools |
+
+Select a format with the `outputFormat` option:
 
     $ mongosh test --quiet --eval "var collection = 'users', outputFormat='json'" variety.js
+
+Passing an unrecognised value throws an error listing the valid options.
+
+### Plugins
+
+A plugin is a `.js` file that exports a plain object. Variety calls lifecycle hooks on it at specific points during execution:
+
+| Hook | When called | Expected return value |
+| --- | --- | --- |
+| `init(config)` | Once, after the plugin is loaded | — |
+| `onConfig(config)` | Once, after Variety's config is resolved | — |
+| `formatResults(results)` | After analysis completes, instead of the built-in formatter | String to print |
+
+Any hook may be omitted. A plugin that only defines `formatResults` is a custom output formatter; one that only defines `onConfig` can act as a post-processing step without changing the output.
+
+**Example: CSV plugin**
+
+```js
+// my-csv-plugin.js
+module.exports = {
+  formatResults(results) {
+    const headers = ['key', 'types', 'occurrences', 'percents'];
+    const rows = results.map((row) =>
+      [row._id.key, Object.keys(row.value.types).join('+'), row.totalOccurrences, row.percentContaining].join(',')
+    );
+    return [headers.join(','), ...rows].join('\n');
+  },
+};
+```
+
+Load it with the `plugins` option (comma-separated for multiple):
+
+    $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-csv-plugin.js'" variety.js
+
+Pass per-plugin configuration by appending `|key=value&key=value` after the path:
+
+    $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-csv-plugin.js|delimiter=;'" variety.js
+
+The plugin receives the config object in `init` as `{ delimiter: ';' }`. See [CONTRIBUTING.md](CONTRIBUTING.md) for a complete guide to writing and testing plugins.
 
 ### Quiet Option
 

--- a/build.js
+++ b/build.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-// Assembles variety.js by concatenating core/analyzer.js and shell/mongo-shell-adapter.js
-// underneath a generated-file banner. The built variety.js is committed to
-// the repository so `mongosh variety.js` works from a fresh clone without
+// Assembles variety.js by concatenating the formatter files, core/analyzer.js, and
+// shell/mongo-shell-adapter.js underneath a generated-file banner. The built variety.js
+// is committed to the repository so `mongosh variety.js` works from a fresh clone without
 // running a build step first; CI runs this script and fails if the
 // committed file drifts from its sources.
 
@@ -24,9 +24,11 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
 // -----------------------------------------------------------------------------
 // GENERATED FILE — do not edit directly.
 //
-// Assembled by build.js from core/analyzer.js and shell/mongo-shell-adapter.js. To change
-// behavior, edit those source files and run \`npm run build\`. The build
-// output is committed so \`mongosh variety.js\` works from a fresh clone
+// Assembled by build.js from:
+//   core/formatters/ascii.js, core/formatters/json.js,
+//   core/analyzer.js, shell/mongo-shell-adapter.js.
+// To change behavior, edit those source files and run \`npm run build\`. The
+// build output is committed so \`mongosh variety.js\` works from a fresh clone
 // without a build step; CI verifies the committed file matches its sources.
 // -----------------------------------------------------------------------------
 
@@ -40,32 +42,39 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
 // See .eslint.config.js for the enforced rule set.
 
 // -----------------------------------------------------------------------------
-// This file is organized in two sections, sourced from two separate files:
+// This file is organized in four sections, sourced from four separate files:
 //
-//   1. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
+//   1. FORMATTER SECTION (core/formatters/ascii.js, core/formatters/json.js) —
+//      built-in output formatters. Each is a self-contained IIFE that registers
+//      a factory function on \`shellContext.__varietyFormatters\`. Third-party
+//      formatters can be supplied as plugins instead (see README).
+//
+//   2. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
 //      analysis logic. Functions take their dependencies (config, and where
 //      needed a \`log\` function or a \`deps\` bag holding shell primitives)
 //      as explicit parameters. The section hands a bundle of functions to
 //      the interface section via \`shellContext.__varietyImpl\`.
 //
-//   2. INTERFACE SECTION (shell/mongo-shell-adapter.js) — everything that touches shell
-//      globals: reading input (\`collection\`, \`plugins\`, \`__quiet\`,
+//   3. INTERFACE SECTION (shell/mongo-shell-adapter.js) — everything that touches
+//      shell globals: reading input (\`collection\`, \`plugins\`, \`__quiet\`,
 //      \`slaveOk\`, etc.), the config-echo logging, plugin loading via
 //      \`load()\`, input validation, and constructing the dependency bag
 //      passed to \`impl.run()\`.
 //
-// The handoff property is deleted at the end so the pair is idempotent and
+// The handoff properties are deleted at the end so the build is idempotent and
 // does not pollute the shell's global namespace after execution.
 // -----------------------------------------------------------------------------
 `;
 
 const root = __dirname;
-const impl = fs.readFileSync(path.join(root, 'core', 'analyzer.js'), 'utf8');
-const iface = fs.readFileSync(path.join(root, 'shell', 'mongo-shell-adapter.js'), 'utf8');
+const fmtAscii = fs.readFileSync(path.join(root, 'core', 'formatters', 'ascii.js'), 'utf8');
+const fmtJson  = fs.readFileSync(path.join(root, 'core', 'formatters', 'json.js'), 'utf8');
+const impl     = fs.readFileSync(path.join(root, 'core', 'analyzer.js'), 'utf8');
+const iface    = fs.readFileSync(path.join(root, 'shell', 'mongo-shell-adapter.js'), 'utf8');
 
 // HEADER ends with a single \n; each source file ends with a single \n. We
 // want two blank lines (three \n total) between each region in the output.
-const output = `${HEADER}\n\n${impl}\n\n${iface}`;
+const output = `${HEADER}\n\n${fmtAscii}\n\n${fmtJson}\n\n${impl}\n\n${iface}`;
 
 const outPath = path.join(root, 'variety.js');
 
@@ -74,7 +83,7 @@ if (args.includes('--check')) {
   const existing = fs.readFileSync(outPath, 'utf8');
   if (existing !== output) {
     process.stderr.write(
-      'variety.js is out of date relative to core/analyzer.js and shell/mongo-shell-adapter.js.\n' +
+      'variety.js is out of date relative to its sources (core/formatters/, core/analyzer.js, shell/mongo-shell-adapter.js).\n' +
       'Run `npm run build` and commit the updated variety.js.\n'
     );
     process.exit(1);

--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -291,45 +291,6 @@
     return result;
   };
 
-  const createAsciiTable = (config, results) => {
-    const headers = ['key', 'types', 'occurrences', 'percents'];
-    if (config.lastValue) {
-      headers.push('lastValue');
-    }
-
-    // Return the number of decimal places, or 1 for integers (1.23 => 2, 100 => 1, 0.1415 => 4).
-    const significantDigits = (value) => {
-      const res = value.toString().match(/^[0-9]+\.([0-9]+)$/);
-      return res !== null ? res[1].length : 1;
-    };
-
-    const maxDigits = results
-      .map((value) => significantDigits(value.percentContaining))
-      .reduce((acc, val) => Math.max(acc, val), 1);
-
-    const rows = results.map((row) => {
-      const typeKeys = Object.keys(row.value.types);
-      const types = typeKeys.length > 1
-        ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
-        : typeKeys;
-
-      const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
-      if (config.lastValue && row.lastValue) {
-        rawArray.push(row.lastValue);
-      }
-      return rawArray;
-    });
-
-    const table = [headers, headers.map(() => '')].concat(rows);
-    const colMaxWidth = (arr, index) => Math.max(...arr.map((row) => row[index] ? row[index].toString().length : 0));
-    const pad = (width, string, symbol) => width <= string.length ? string : pad(width, isNaN(string) ? string + symbol : symbol + string, symbol);
-    const formattedTable = table.map((row, ri) =>
-      `| ${row.map((cell, i) => pad(colMaxWidth(table, i), cell.toString(), ri === 1 ? '-' : ' ')).join(' | ')} |`
-    );
-    const border = `+${pad(formattedTable[0].length - 2, '', '-')}+`;
-    return [border].concat(formattedTable).concat(border).join('\n');
-  };
-
   // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
   // since the parent key already captures the Array type. Set showArrayElements:true
   // to include them — useful for verifying element-type consistency within arrays.
@@ -347,7 +308,7 @@
   // Orchestrates a Variety analysis from a parsed config and constructed
   // pluginsRunner, pulling every shell primitive it needs from `deps`.
   const run = (config, pluginsRunner, deps) => {
-    const {db, connect, log, print, shellPrintJson, countMatchingDocuments} = deps;
+    const {db, connect, log, print, countMatchingDocuments} = deps;
 
     // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
     let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
@@ -383,14 +344,15 @@
       resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
     }
 
-    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
-    if (pluginsOutput.length > 0) {
-      pluginsOutput.forEach((output) => print(output));
-    } else if (config.outputFormat === 'json') {
-      shellPrintJson(varietyResults); // valid formatted json output, compressed variant is printjsononeline()
-    } else {
-      print(createAsciiTable(config, varietyResults)); // output nice ascii table with results
+    const formatterFactory = shellContext.__varietyFormatters[config.outputFormat];
+    if (typeof formatterFactory !== 'function') {
+      throw new Error(`Unknown outputFormat "${config.outputFormat}". Valid values are: ${Object.keys(shellContext.__varietyFormatters).join(', ')}.`);
     }
+    const builtInFormatter = formatterFactory(config);
+
+    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
+    const outputs = pluginsOutput.length > 0 ? pluginsOutput : [builtInFormatter.formatResults(varietyResults)];
+    outputs.forEach((output) => print(output));
   };
 
   shellContext.__varietyImpl = {
@@ -408,7 +370,6 @@
     convertResults,
     reduceDocuments,
     reduceCursor,
-    createAsciiTable,
     run,
   };
 }(this));

--- a/core/formatters/ascii.js
+++ b/core/formatters/ascii.js
@@ -1,0 +1,58 @@
+// =============================================================================
+// BUILT-IN FORMATTER: ASCII TABLE
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  shellContext.__varietyFormatters = shellContext.__varietyFormatters || Object.create(null);
+
+  /**
+   * Returns a formatter that renders results as a padded ASCII table.
+   * @param {object} config - The parsed Variety config (uses config.lastValue and config.arrayEscape).
+   * @returns {{ formatResults: function(Array): string }}
+   */
+  shellContext.__varietyFormatters.ascii = (config) => {
+    const formatResults = (results) => {
+      const headers = ['key', 'types', 'occurrences', 'percents'];
+      if (config.lastValue) {
+        headers.push('lastValue');
+      }
+
+      // Return the number of decimal places, or 1 for integers (1.23 => 2, 100 => 1, 0.1415 => 4).
+      const significantDigits = (value) => {
+        const res = value.toString().match(/^[0-9]+\.([0-9]+)$/);
+        return res !== null ? res[1].length : 1;
+      };
+
+      const maxDigits = results
+        .map((value) => significantDigits(value.percentContaining))
+        .reduce((acc, val) => Math.max(acc, val), 1);
+
+      const rows = results.map((row) => {
+        const typeKeys = Object.keys(row.value.types);
+        const types = typeKeys.length > 1
+          ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
+          : typeKeys;
+
+        const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
+        if (config.lastValue && row.lastValue) {
+          rawArray.push(row.lastValue);
+        }
+        return rawArray;
+      });
+
+      const table = [headers, headers.map(() => '')].concat(rows);
+      const colMaxWidth = (arr, index) => Math.max(...arr.map((row) => row[index] ? row[index].toString().length : 0));
+      const pad = (width, string, symbol) => width <= string.length ? string : pad(width, isNaN(string) ? string + symbol : symbol + string, symbol);
+      const formattedTable = table.map((row, ri) =>
+        `| ${row.map((cell, i) => pad(colMaxWidth(table, i), cell.toString(), ri === 1 ? '-' : ' ')).join(' | ')} |`
+      );
+      const border = `+${pad(formattedTable[0].length - 2, '', '-')}+`;
+      return [border].concat(formattedTable).concat(border).join('\n');
+    };
+
+    return {formatResults};
+  };
+}(this));

--- a/core/formatters/json.js
+++ b/core/formatters/json.js
@@ -1,0 +1,18 @@
+// =============================================================================
+// BUILT-IN FORMATTER: JSON
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  shellContext.__varietyFormatters = shellContext.__varietyFormatters || Object.create(null);
+
+  /**
+   * Returns a formatter that serializes results as pretty-printed JSON.
+   * @returns {{ formatResults: function(Array): string }}
+   */
+  shellContext.__varietyFormatters.json = () => ({
+    formatResults: (results) => JSON.stringify(results, null, 2),
+  });
+}(this));

--- a/shell/mongo-shell-adapter.js
+++ b/shell/mongo-shell-adapter.js
@@ -25,10 +25,6 @@
     }
   };
 
-  const shellPrintJson = (value) => {
-    print(JSON.stringify(value, null, 2));
-  };
-
   const getDatabase = (name) => {
     if (typeof db.getSisterDB === 'function') {
       return db.getSisterDB(name);
@@ -173,11 +169,11 @@
     connect: typeof connect !== 'undefined' ? connect : undefined,
     log,
     print,
-    shellPrintJson,
     countMatchingDocuments,
   });
 
-  // Clean up the implementation handoff so repeated loads remain idempotent
+  // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.
   delete shellContext.__varietyImpl;
+  delete shellContext.__varietyFormatters;
 }(this)); // end strict mode

--- a/test/formatters/FormattersTest.js
+++ b/test/formatters/FormattersTest.js
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import Tester from '../utils/Tester.js';
+import sampleData from '../fixtures/SampleData.js';
+import expectedAscii from '../fixtures/ExpectedAscii.js';
+
+const test = new Tester('test', 'users');
+
+describe('Formatter registry dispatch', () => {
+
+  beforeEach(() => test.init(sampleData));
+  afterEach(() => test.cleanUp());
+
+  it('dispatches to the ascii formatter when outputFormat is "ascii"', async () => {
+    const output = await test.runAnalysis({collection: 'users', outputFormat: 'ascii'}, true);
+    assert.equal(output, expectedAscii);
+  });
+
+  it('dispatches to the json formatter when outputFormat is "json"', async () => {
+    const results = await test.runJsonAnalysis({collection: 'users'}, true);
+    results.validateResultsCount(7);
+    results.validate('_id', 5, 100.0, {ObjectId: 5});
+  });
+
+  it('throws for an unknown outputFormat', async () => {
+    await assert.rejects(
+      () => test.runAnalysis({collection: 'users', outputFormat: 'xml'}, true),
+      (err) => {
+        const output = /** @type {Error & { stdout?: string }} */ (err).stdout ?? '';
+        assert.match(output, /Unknown outputFormat/);
+        assert.match(output, /ascii/);
+        assert.match(output, /json/);
+        return true;
+      }
+    );
+  });
+
+});

--- a/variety.js
+++ b/variety.js
@@ -12,9 +12,11 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
 // -----------------------------------------------------------------------------
 // GENERATED FILE — do not edit directly.
 //
-// Assembled by build.js from core/analyzer.js and shell/mongo-shell-adapter.js. To change
-// behavior, edit those source files and run `npm run build`. The build
-// output is committed so `mongosh variety.js` works from a fresh clone
+// Assembled by build.js from:
+//   core/formatters/ascii.js, core/formatters/json.js,
+//   core/analyzer.js, shell/mongo-shell-adapter.js.
+// To change behavior, edit those source files and run `npm run build`. The
+// build output is committed so `mongosh variety.js` works from a fresh clone
 // without a build step; CI verifies the committed file matches its sources.
 // -----------------------------------------------------------------------------
 
@@ -28,23 +30,108 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
 // See .eslint.config.js for the enforced rule set.
 
 // -----------------------------------------------------------------------------
-// This file is organized in two sections, sourced from two separate files:
+// This file is organized in four sections, sourced from four separate files:
 //
-//   1. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
+//   1. FORMATTER SECTION (core/formatters/ascii.js, core/formatters/json.js) —
+//      built-in output formatters. Each is a self-contained IIFE that registers
+//      a factory function on `shellContext.__varietyFormatters`. Third-party
+//      formatters can be supplied as plugins instead (see README).
+//
+//   2. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
 //      analysis logic. Functions take their dependencies (config, and where
 //      needed a `log` function or a `deps` bag holding shell primitives)
 //      as explicit parameters. The section hands a bundle of functions to
 //      the interface section via `shellContext.__varietyImpl`.
 //
-//   2. INTERFACE SECTION (shell/mongo-shell-adapter.js) — everything that touches shell
-//      globals: reading input (`collection`, `plugins`, `__quiet`,
+//   3. INTERFACE SECTION (shell/mongo-shell-adapter.js) — everything that touches
+//      shell globals: reading input (`collection`, `plugins`, `__quiet`,
 //      `slaveOk`, etc.), the config-echo logging, plugin loading via
 //      `load()`, input validation, and constructing the dependency bag
 //      passed to `impl.run()`.
 //
-// The handoff property is deleted at the end so the pair is idempotent and
+// The handoff properties are deleted at the end so the build is idempotent and
 // does not pollute the shell's global namespace after execution.
 // -----------------------------------------------------------------------------
+
+
+// =============================================================================
+// BUILT-IN FORMATTER: ASCII TABLE
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  shellContext.__varietyFormatters = shellContext.__varietyFormatters || Object.create(null);
+
+  /**
+   * Returns a formatter that renders results as a padded ASCII table.
+   * @param {object} config - The parsed Variety config (uses config.lastValue and config.arrayEscape).
+   * @returns {{ formatResults: function(Array): string }}
+   */
+  shellContext.__varietyFormatters.ascii = (config) => {
+    const formatResults = (results) => {
+      const headers = ['key', 'types', 'occurrences', 'percents'];
+      if (config.lastValue) {
+        headers.push('lastValue');
+      }
+
+      // Return the number of decimal places, or 1 for integers (1.23 => 2, 100 => 1, 0.1415 => 4).
+      const significantDigits = (value) => {
+        const res = value.toString().match(/^[0-9]+\.([0-9]+)$/);
+        return res !== null ? res[1].length : 1;
+      };
+
+      const maxDigits = results
+        .map((value) => significantDigits(value.percentContaining))
+        .reduce((acc, val) => Math.max(acc, val), 1);
+
+      const rows = results.map((row) => {
+        const typeKeys = Object.keys(row.value.types);
+        const types = typeKeys.length > 1
+          ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
+          : typeKeys;
+
+        const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
+        if (config.lastValue && row.lastValue) {
+          rawArray.push(row.lastValue);
+        }
+        return rawArray;
+      });
+
+      const table = [headers, headers.map(() => '')].concat(rows);
+      const colMaxWidth = (arr, index) => Math.max(...arr.map((row) => row[index] ? row[index].toString().length : 0));
+      const pad = (width, string, symbol) => width <= string.length ? string : pad(width, isNaN(string) ? string + symbol : symbol + string, symbol);
+      const formattedTable = table.map((row, ri) =>
+        `| ${row.map((cell, i) => pad(colMaxWidth(table, i), cell.toString(), ri === 1 ? '-' : ' ')).join(' | ')} |`
+      );
+      const border = `+${pad(formattedTable[0].length - 2, '', '-')}+`;
+      return [border].concat(formattedTable).concat(border).join('\n');
+    };
+
+    return {formatResults};
+  };
+}(this));
+
+
+// =============================================================================
+// BUILT-IN FORMATTER: JSON
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  shellContext.__varietyFormatters = shellContext.__varietyFormatters || Object.create(null);
+
+  /**
+   * Returns a formatter that serializes results as pretty-printed JSON.
+   * @returns {{ formatResults: function(Array): string }}
+   */
+  shellContext.__varietyFormatters.json = () => ({
+    formatResults: (results) => JSON.stringify(results, null, 2),
+  });
+}(this));
 
 
 // =============================================================================
@@ -340,45 +427,6 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
     return result;
   };
 
-  const createAsciiTable = (config, results) => {
-    const headers = ['key', 'types', 'occurrences', 'percents'];
-    if (config.lastValue) {
-      headers.push('lastValue');
-    }
-
-    // Return the number of decimal places, or 1 for integers (1.23 => 2, 100 => 1, 0.1415 => 4).
-    const significantDigits = (value) => {
-      const res = value.toString().match(/^[0-9]+\.([0-9]+)$/);
-      return res !== null ? res[1].length : 1;
-    };
-
-    const maxDigits = results
-      .map((value) => significantDigits(value.percentContaining))
-      .reduce((acc, val) => Math.max(acc, val), 1);
-
-    const rows = results.map((row) => {
-      const typeKeys = Object.keys(row.value.types);
-      const types = typeKeys.length > 1
-        ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
-        : typeKeys;
-
-      const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
-      if (config.lastValue && row.lastValue) {
-        rawArray.push(row.lastValue);
-      }
-      return rawArray;
-    });
-
-    const table = [headers, headers.map(() => '')].concat(rows);
-    const colMaxWidth = (arr, index) => Math.max(...arr.map((row) => row[index] ? row[index].toString().length : 0));
-    const pad = (width, string, symbol) => width <= string.length ? string : pad(width, isNaN(string) ? string + symbol : symbol + string, symbol);
-    const formattedTable = table.map((row, ri) =>
-      `| ${row.map((cell, i) => pad(colMaxWidth(table, i), cell.toString(), ri === 1 ? '-' : ' ')).join(' | ')} |`
-    );
-    const border = `+${pad(formattedTable[0].length - 2, '', '-')}+`;
-    return [border].concat(formattedTable).concat(border).join('\n');
-  };
-
   // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
   // since the parent key already captures the Array type. Set showArrayElements:true
   // to include them — useful for verifying element-type consistency within arrays.
@@ -396,7 +444,7 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
   // Orchestrates a Variety analysis from a parsed config and constructed
   // pluginsRunner, pulling every shell primitive it needs from `deps`.
   const run = (config, pluginsRunner, deps) => {
-    const {db, connect, log, print, shellPrintJson, countMatchingDocuments} = deps;
+    const {db, connect, log, print, countMatchingDocuments} = deps;
 
     // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
     let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
@@ -432,14 +480,15 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
       resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
     }
 
-    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
-    if (pluginsOutput.length > 0) {
-      pluginsOutput.forEach((output) => print(output));
-    } else if (config.outputFormat === 'json') {
-      shellPrintJson(varietyResults); // valid formatted json output, compressed variant is printjsononeline()
-    } else {
-      print(createAsciiTable(config, varietyResults)); // output nice ascii table with results
+    const formatterFactory = shellContext.__varietyFormatters[config.outputFormat];
+    if (typeof formatterFactory !== 'function') {
+      throw new Error(`Unknown outputFormat "${config.outputFormat}". Valid values are: ${Object.keys(shellContext.__varietyFormatters).join(', ')}.`);
     }
+    const builtInFormatter = formatterFactory(config);
+
+    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
+    const outputs = pluginsOutput.length > 0 ? pluginsOutput : [builtInFormatter.formatResults(varietyResults)];
+    outputs.forEach((output) => print(output));
   };
 
   shellContext.__varietyImpl = {
@@ -457,7 +506,6 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
     convertResults,
     reduceDocuments,
     reduceCursor,
-    createAsciiTable,
     run,
   };
 }(this));
@@ -488,10 +536,6 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
     if (!shellIsQuiet()) {
       print(message);
     }
-  };
-
-  const shellPrintJson = (value) => {
-    print(JSON.stringify(value, null, 2));
   };
 
   const getDatabase = (name) => {
@@ -638,11 +682,11 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
     connect: typeof connect !== 'undefined' ? connect : undefined,
     log,
     print,
-    shellPrintJson,
     countMatchingDocuments,
   });
 
-  // Clean up the implementation handoff so repeated loads remain idempotent
+  // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.
   delete shellContext.__varietyImpl;
+  delete shellContext.__varietyFormatters;
 }(this)); // end strict mode


### PR DESCRIPTION
## Summary

- Extracts ASCII and JSON output formatters into dedicated files (`core/formatters/ascii.js`, `core/formatters/json.js`), each a self-contained IIFE that registers a `(config) => { formatResults }` factory on `shellContext.__varietyFormatters`
- Replaces the hardcoded `if/else` dispatch in `run()` with a registry lookup — built-ins now use the same `formatResults(results) → string` interface as plugins
- Unknown `outputFormat` values now throw a descriptive error listing valid options, rather than silently falling back to ASCII
- Removes `shellPrintJson` from `shell/mongo-shell-adapter.js` (dead code after this change)
- Updates `build.js` to include the formatter files before `core/analyzer.js` in the concatenated output; cleans up `__varietyFormatters` alongside `__varietyImpl` at end of execution
- Adds `test/formatters/FormattersTest.js` verifying ascii dispatch, json dispatch, and the unknown-format error path
- Updates README to give formatters and plugins first-class treatment (dedicated section with tables, examples, and a quick-start)
- Updates CONTRIBUTING.md with revised repo layout description and a complete plugin-writing guide

## Test plan

- [ ] `npm run test:docker` passes (all existing analysis, persistence, plugin, and CLI tests green; new formatter dispatch tests green)
- [ ] `npm run verify:build` passes (already verified by pre-commit hook)
- [ ] All lint passes (already verified by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)