### PR TITLE
Retry apt-get update once on flaky Ubuntu mirror

### DIFF
--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -6,7 +6,7 @@ FROM docker.io/library/mongo:${MONGODB_VERSION}
 RUN rm -f /etc/apt/sources.list.d/mongodb*.list
 
 # hadolint ignore=DL3008
-RUN apt-get update  -qq && \
+RUN (apt-get update -qq || (sleep 15 && apt-get update -qq)) && \
     apt-get install -qq --assume-yes --no-install-recommends --no-install-suggests \
         curl \
       > /dev/null && \


### PR DESCRIPTION
## Summary

- Wraps `apt-get update` in `(apt-get update || (sleep 15 && apt-get update))` so a transient Ubuntu mirror sync error doesn't fail the build outright

The MongoDB 8.0 Docker base image runs on Ubuntu Noble (24.04). Its package mirrors have been producing hash-mismatch and mid-sync size errors on GitHub-hosted runners, causing the `Test (Node 22, MongoDB 8.0)` job to fail before any tests run. This happened twice in a row on PR #258. The 5.0 and 7.0 jobs use older Ubuntu bases and are unaffected.

The retry buys 15 seconds for the mirror to finish syncing and then tries once more. If both attempts fail, the build still exits non-zero as expected.

## Test plan

- [ ] `Test (Node 22, MongoDB 8.0)` passes in CI (the apt-get step completes even on a flaky mirror)
- [ ] hadolint still passes (verified locally before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)