### PR TITLE
Document interactive Mongo shell loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,8 +406,6 @@ command.
 
 Hat tip: [@abrin](https://github.com/abrin) ([issue #131](https://github.com/variety/variety/issues/131)). Follow-up: [issue #264](https://github.com/variety/variety/issues/264)
 
-Note: `variety-cli`, a formerly available companion project that offered higher-level argument parsing, has been archived and is no longer maintained.
-
 ### Calling Variety From Node.js
 
 Variety can be automated from a Node.js application by spawning the packaged
@@ -440,6 +438,8 @@ only needs the available field names, the MongoDB Node.js driver may be a better
 fit than shelling out to Variety for each request.
 
 Hat tip: [@ashishtilara](https://github.com/ashishtilara) ([issue #125](https://github.com/variety/variety/issues/125)). Follow-up: [issue #263](https://github.com/variety/variety/issues/263)
+
+Note: `variety-cli`, a formerly available companion project that offered higher-level argument parsing, has been archived and is no longer maintained.
 
 ## "But my dad told me MongoDB is a schemaless database!"
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,32 @@ DB=test EVAL_CMDS="var collection = 'users', maxDepth = 3, limit = 500" variety
 
 Direct `mongosh ... variety.js` usage remains supported and is still useful when you want the most transparent low-level invocation for debugging or advanced shell work.
 
+### Loading Variety From an Interactive Mongo Shell
+
+If you are already inside `mongosh` or the legacy `mongo` shell, define the
+same globals you would normally pass with `--eval`, then load `variety.js`:
+
+```js
+var collection = "users";
+load("/path/to/variety.js");
+```
+
+The `load()` call executes Variety immediately; there is no separate function
+to call after the script loads. Set any additional options before `load()`:
+
+```js
+var collection = "users";
+var outputFormat = "json";
+var limit = 100;
+load("/path/to/variety.js");
+```
+
+This low-level form is useful for exploratory shell sessions or debugging. For
+regular terminal use, prefer the packaged `variety DB/COLLECTION [options]`
+command.
+
+Hat tip: [@abrin](https://github.com/abrin) ([issue #131](https://github.com/variety/variety/issues/131)). Follow-up: [issue #264](https://github.com/variety/variety/issues/264)
+
 Note: `variety-cli`, a formerly available companion project that offered higher-level argument parsing, has been archived and is no longer maintained.
 
 ### Calling Variety From Node.js


### PR DESCRIPTION
Closes #131.
Refs #264.

## Summary
- document how to load `variety.js` from an already-running `mongosh` or legacy `mongo` session
- clarify that `load()` executes Variety immediately after globals such as `collection` are defined
- add a README hat-tip to @abrin with the original issue and the new interactive shell API follow-up

## Testing
- `npm run lint:markdown`
- pre-commit checks via `git commit`: `npm run verify:build`, `npm run lint`, `npm run lint:json`, `npm run lint:markdown`, `npm run lint:yaml`, `npm run lint:dockerfile`, `npm run lint:shell`, `npm run typecheck`

## Notes
- This is docs-only, so I did not run the MongoDB-backed integration suite.