### PR TITLE
Skip non-Markdown checks for Markdown-only commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,40 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      only-markdown: ${{ steps.check.outputs.only-markdown }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check if only existing markdown files were modified
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          # First push to a branch has no meaningful base
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-status "$BASE" "${{ github.sha }}")
+          if [ -z "$changed" ]; then
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$changed" | awk 'NF && ($1 != "M" || $2 !~ /\.md$/) { exit 1 }'; then
+            echo "only-markdown=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Lint (Node 22)
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,16 +55,25 @@ jobs:
         env:
           HUSKY: '0'
       - run: npm run verify:build
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run lint
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run lint:json
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run lint:markdown
       - run: npm run lint:yaml
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run lint:dockerfile
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run lint:shell
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run typecheck
+        if: needs.changes.outputs.only-markdown != 'true'
 
   test:
     name: Test (Node 22, MongoDB ${{ matrix.mongodb-version }})
+    needs: changes
+    if: needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,6 +96,8 @@ jobs:
 
   test-smoke:
     name: Smoke Test (Node 24, MongoDB 8.0)
+    needs: changes
+    if: needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,45 @@ permissions:
   security-events: write
 
 jobs:
+  changes:
+    name: Detect changes
+    # Only meaningful for push/PR — scheduled and manual runs always analyze
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      only-markdown: ${{ steps.check.outputs.only-markdown }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check if only existing markdown files were modified
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          # First push to a branch has no meaningful base
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-status "$BASE" "${{ github.sha }}")
+          if [ -z "$changed" ]; then
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$changed" | awk 'NF && ($1 != "M" || $2 !~ /\.md$/) { exit 1 }'; then
+            echo "only-markdown=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: [changes]
+    # always() lets this run even when `changes` was skipped (schedule/dispatch).
+    # When skipped, only-markdown is empty → != 'true' → analyze proceeds.
+    if: always() && needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+# If every staged change is a modification (not add/delete) to an existing .md
+# file, skip the non-Markdown checks — they have nothing to verify.
+staged=$(git diff --cached --name-status)
+non_md=$(printf '%s\n' "$staged" | awk 'NF && ($1 != "M" || $2 !~ /\.md$/)')
+
+if [ -n "$staged" ] && [ -z "$non_md" ]; then
+  echo "→ Only existing Markdown files modified — skipping non-Markdown checks"
+  echo "→ markdownlint (Markdown)"
+  npm run lint:markdown
+  exit 0
+fi
+
 echo "→ build check (variety.js vs src/)"
 npm run verify:build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,11 @@ Variety keeps its repository checks split into a few layers so it is clear which
 
 ### Pre-commit Hooks
 
-Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and installed automatically on `npm install`. Each commit runs all of the following, and is blocked if any fail:
+Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and installed automatically on `npm install`. Each commit is blocked if any applicable check fails.
+
+If every staged change is a modification to an existing `.md` file (no new or deleted files), only `npm run lint:markdown` runs — all other checks are skipped as they have nothing to verify.
+
+Otherwise all of the following run:
 
 - `npm run verify:build` — verifies `variety.js` matches what `build.js` would produce from `core/formatters/`, `core/`, and `mongo-shell/adapter.js`
 - `npm run lint` — ESLint (JavaScript)


### PR DESCRIPTION
## Summary

- Adds a short-circuit to the Husky pre-commit hook: if every staged change is a modification to an existing `.md` file (no new or deleted files), only `markdownlint` runs and the hook exits early — skipping the build check, ESLint, jsonlint, yaml, Dockerfile, shellcheck, and typecheck steps.
- Adds a `changes` detection job to `ci.yml` that sets `only-markdown=true` when the same condition holds; the `lint` job skips all non-Markdown steps when that flag is set, and the `test` / `test-smoke` jobs are skipped entirely.
- Applies the same optimisation to `codeql.yml` for push/PR events, while leaving scheduled and manual (`workflow_dispatch`) runs unconditionally active.
- Updates `CONTRIBUTING.md` to document the pre-commit short-circuit.

## Detection logic

```sh
changed=$(git diff --name-status "$BASE" "$HEAD")
printf '%s\n' "$changed" | awk 'NF && ($1 != "M" || $2 !~ /\.md$/) { exit 1 }'
```

Any status other than `M` (add, delete, rename, copy…) or any non-`.md` filename causes the awk to exit non-zero, keeping full checks active.

## Test plan

- [ ] Commit touching only an existing `.md` file — pre-commit hook prints "Only existing Markdown files modified" and runs only markdownlint
- [ ] Commit touching a `.js` file (or adding/deleting a `.md`) — all pre-commit checks run as before
- [ ] Push a Markdown-only change to a PR — CI `changes` job outputs `only-markdown=true`; `test` and `test-smoke` are skipped; `lint` runs only `lint:markdown`
- [ ] Push a non-Markdown change — CI runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)