### PR TITLE
Scope startup DB validation to selected database

### DIFF
--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -25,14 +25,6 @@
     }
   };
 
-  const getDatabase = (name) => {
-    if (typeof db.getSisterDB === 'function') {
-      return db.getSisterDB(name);
-    }
-
-    return db.getMongo().getDB(name);
-  };
-
   const countMatchingDocuments = (collectionName, query, limit) => {
     const coll = db.getCollection(collectionName);
     const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
@@ -42,38 +34,38 @@
   log('Variety: A MongoDB Schema Analyzer');
   log('Version 1.5.2, released 30 September 2025');
 
-  const dbs = [];
-  const emptyDbs = [];
-
   if (typeof slaveOk !== 'undefined') {
     if (slaveOk === true) {
       db.getMongo().setSlaveOk();
     }
   }
 
+  const selectedDatabaseName = db.getName();
   const knownDatabases = db.adminCommand('listDatabases').databases;
+  const knownDatabaseNames = [];
   if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
-    knownDatabases.forEach((d) => {
-      const collectionNames = getDatabase(d.name).getCollectionNames();
-      if (collectionNames.length > 0) {
-        dbs.push(d.name);
-      } else {
-        emptyDbs.push(d.name);
+    // Keep validation scoped to the selected database. Issue #145
+    // (@pkgajulapalli) hit a startup failure while enumerating collections for
+    // an unrelated database.
+    knownDatabases.forEach((database) => {
+      if (typeof database.name === 'string' && database.name.length > 0) {
+        knownDatabaseNames.push(database.name);
       }
     });
 
-    if (emptyDbs.includes(db.getName())) {
-      throw new Error(`The database specified (${db.getName()}) is empty.\n` +
-          `Possible database options are: ${dbs.join(', ')}.`);
-    }
-
-    if (!dbs.includes(db.getName())) {
-      throw new Error(`The database specified (${db.getName()}) does not exist.\n` +
-          `Possible database options are: ${dbs.join(', ')}.`);
+    if (!knownDatabaseNames.includes(selectedDatabaseName)) {
+      throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+          `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
     }
   }
 
-  const collNames = db.getCollectionNames().join(', ');
+  const collectionNames = db.getCollectionNames();
+  const collNames = collectionNames.join(', ');
+  if (collectionNames.length === 0) {
+    throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
+        `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
+  }
+
   if (typeof collection === 'undefined') {
     throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
         `Possible collection options for database specified: ${collNames}.\n` +

--- a/test/mongo-shell/AdapterValidationTest.js
+++ b/test/mongo-shell/AdapterValidationTest.js
@@ -1,0 +1,105 @@
+import assert from 'assert';
+import fs from 'fs';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
+
+const adapterPath = fileURLToPath(new URL('../../mongo-shell/adapter.js', import.meta.url));
+const adapterSource = fs.readFileSync(adapterPath, 'utf8');
+
+/**
+ * @typedef {{ countDocuments(query: Record<string, unknown>, options?: { limit: number }): number }} FakeCollection
+ * @typedef {{ name: string }} FakeDatabaseInfo
+ * @typedef {{ databases?: FakeDatabaseInfo[] }} FakeListDatabasesResult
+ * @typedef {{
+ *   adminCommand(command: string): FakeListDatabasesResult,
+ *   getCollection(name: string): FakeCollection,
+ *   getCollectionNames(): string[],
+ *   getMongo(): { setSlaveOk(): void },
+ *   getName(): string,
+ *   getSisterDB(name: string): never,
+ * }} FakeDb
+ */
+
+/**
+ * @param {string[]} sisterDbCalls
+ * @returns {FakeDb}
+ */
+const createDb = (sisterDbCalls) => ({
+  adminCommand(command) {
+    assert.equal(command, 'listDatabases');
+    return {
+      databases: [
+        { name: 'test' },
+        { name: '' },
+        { name: 'analytics' },
+      ],
+    };
+  },
+  getCollection(name) {
+    assert.equal(name, 'users');
+    return {
+      countDocuments(query, options) {
+        assert.deepEqual(query, {});
+        assert.equal(options, undefined);
+        return 1;
+      },
+    };
+  },
+  getCollectionNames() {
+    return ['users'];
+  },
+  getMongo() {
+    return {
+      setSlaveOk() {},
+    };
+  },
+  getName() {
+    return 'test';
+  },
+  getSisterDB(name) {
+    sisterDbCalls.push(name);
+    throw new Error(`Unexpected scan of database ${name}`);
+  },
+});
+
+describe('Mongo shell adapter validation', () => {
+  it('does not enumerate collections for unrelated databases during startup', () => {
+    /** @type {unknown[]} */
+    const runConfigs = [];
+    /** @type {string[]} */
+    const sisterDbCalls = [];
+    /**
+     * @returns {Record<string, unknown>}
+     */
+    const createKeyMap = () => ({});
+    /**
+     * @param {unknown} config
+     */
+    const captureRunConfig = (config) => {
+      runConfigs.push(config);
+    };
+
+    const context = {
+      __varietyImpl: {
+        createKeyMap,
+        run: captureRunConfig,
+        shellToJson: JSON.stringify,
+      },
+      collection: 'users',
+      db: createDb(sisterDbCalls),
+      print: () => {},
+    };
+
+    vm.createContext(context);
+    vm.runInContext(adapterSource, context, { filename: adapterPath });
+
+    assert.deepEqual(sisterDbCalls, []);
+    assert.equal(runConfigs.length, 1);
+
+    const [config] = runConfigs;
+    assert.ok(config && typeof config === 'object');
+    const typedConfig = /** @type {{ collection?: unknown, limit?: unknown }} */ (config);
+    assert.equal(typedConfig.collection, 'users');
+    assert.equal(typedConfig.limit, 1);
+  });
+});

--- a/variety.js
+++ b/variety.js
@@ -538,14 +538,6 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
     }
   };
 
-  const getDatabase = (name) => {
-    if (typeof db.getSisterDB === 'function') {
-      return db.getSisterDB(name);
-    }
-
-    return db.getMongo().getDB(name);
-  };
-
   const countMatchingDocuments = (collectionName, query, limit) => {
     const coll = db.getCollection(collectionName);
     const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
@@ -555,38 +547,38 @@ Released by James Cropcho, © 2012–2026, under the MIT License. */
   log('Variety: A MongoDB Schema Analyzer');
   log('Version 1.5.2, released 30 September 2025');
 
-  const dbs = [];
-  const emptyDbs = [];
-
   if (typeof slaveOk !== 'undefined') {
     if (slaveOk === true) {
       db.getMongo().setSlaveOk();
     }
   }
 
+  const selectedDatabaseName = db.getName();
   const knownDatabases = db.adminCommand('listDatabases').databases;
+  const knownDatabaseNames = [];
   if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
-    knownDatabases.forEach((d) => {
-      const collectionNames = getDatabase(d.name).getCollectionNames();
-      if (collectionNames.length > 0) {
-        dbs.push(d.name);
-      } else {
-        emptyDbs.push(d.name);
+    // Keep validation scoped to the selected database. Issue #145
+    // (@pkgajulapalli) hit a startup failure while enumerating collections for
+    // an unrelated database.
+    knownDatabases.forEach((database) => {
+      if (typeof database.name === 'string' && database.name.length > 0) {
+        knownDatabaseNames.push(database.name);
       }
     });
 
-    if (emptyDbs.includes(db.getName())) {
-      throw new Error(`The database specified (${db.getName()}) is empty.\n` +
-          `Possible database options are: ${dbs.join(', ')}.`);
-    }
-
-    if (!dbs.includes(db.getName())) {
-      throw new Error(`The database specified (${db.getName()}) does not exist.\n` +
-          `Possible database options are: ${dbs.join(', ')}.`);
+    if (!knownDatabaseNames.includes(selectedDatabaseName)) {
+      throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+          `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
     }
   }
 
-  const collNames = db.getCollectionNames().join(', ');
+  const collectionNames = db.getCollectionNames();
+  const collNames = collectionNames.join(', ');
+  if (collectionNames.length === 0) {
+    throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
+        `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
+  }
+
   if (typeof collection === 'undefined') {
     throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
         `Possible collection options for database specified: ${collNames}.\n` +


### PR DESCRIPTION
Closes #145. Reported by @pkgajulapalli.

## Summary
- keep startup database validation scoped to the selected database instead of enumerating collections for every listed database
- preserve selected database/collection validation while avoiding unrelated namespace failures during startup
- add adapter regression coverage for the Issue #145 class of failure

## Testing
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/mongo-shell/AdapterValidationTest.js`
- `npm run lint`
- `npm run typecheck`
- `npm run verify:build`
- targeted Podman check against the final worktree: `ParametersParsingTest.js` + `AdapterValidationTest.js` (8 passing)
- commit hooks also ran build verification, ESLint, JSON lint, Markdown lint, YAML lint, Dockerfile lint, shellcheck, and typecheck

## Notes
- I also attempted the full `npm run test:docker`; MongoDB reset the connection mid-run (`MongoNetworkError: read ECONNRESET`), after which Mocha printed a failure summary but the container process hung and had to be stopped. The narrower Mongo-backed container check above passed after rebasing onto current `origin/main`.
