### PR TITLE
Cache Docker test builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,17 @@ jobs:
       - run: npm install
         env:
           HUSKY: '0'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Expose GitHub Actions cache runtime
+        uses: crazy-max/ghaction-github-runtime@v4
       - run: mkdir -p docker/Dockerfiles
       - run: npm run test:docker
         env:
           MONGODB_VERSION: ${{ matrix.mongodb-version }}
           NODEJS_VERSION: '22'
+          DOCKER_BUILD_CACHE: gha
+          DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-${{ matrix.mongodb-version }}-node-22
 
   test-smoke:
     name: Smoke Test (Node 24, MongoDB 8.0)
@@ -108,8 +114,14 @@ jobs:
       - run: npm install
         env:
           HUSKY: '0'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Expose GitHub Actions cache runtime
+        uses: crazy-max/ghaction-github-runtime@v4
       - run: mkdir -p docker/Dockerfiles
       - run: npm run test:docker
         env:
           MONGODB_VERSION: '8.0'
           NODEJS_VERSION: '24'
+          DOCKER_BUILD_CACHE: gha
+          DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-8.0-node-24

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,14 @@ MONGODB_VERSION=8.0 NODEJS_VERSION=24 npm run test:docker
 
 GitHub Actions runs a MongoDB matrix on Node.js 22: `5.0` (which ships only the legacy `mongo` shell, exercising that code path), `7.0`, and `8.0` (both of which ship only `mongosh`). A single Node.js 24 smoke test also runs against MongoDB 8.0. MongoDB 6.0+ no longer ships the legacy `mongo` shell, so `5.0` is the newest version available for `mongo`-shell coverage.
 
+In GitHub Actions, Dockerized test jobs opt into Docker Buildx's GitHub
+Actions cache for the generated test images. Cache scopes are separated by
+runner OS/architecture, MongoDB version, and Node.js version. This cache is
+only an optimization: cache misses, unavailable cache support, or cache-backed
+build failures fall back to a clean `docker build --no-cache` rebuild so CI
+behavior remains predictable. Local `npm run test:docker` runs keep the clean
+rebuild behavior by default.
+
 ## Linting
 
 Variety keeps its repository checks split into a few layers so it is clear which tool is complaining and why.

--- a/test/bin/test-on-docker.sh
+++ b/test/bin/test-on-docker.sh
@@ -6,6 +6,7 @@ if [ -z "$RUNNER" ]; then
   echo "Error: neither docker nor podman found in PATH" >&2
   exit 1
 fi
+RUNNER_NAME=$(basename "$RUNNER")
 
 # default versions if none in env
 MONGODB_VERSION=${MONGODB_VERSION:=8.0}
@@ -22,6 +23,7 @@ DOCKERFILES_DIR=./docker/Dockerfiles
 DOCKERFILE=variety.$VERSIONS_ID.Dockerfile
 
 CONTAINER=${CONTAINER:=variety-test-$VERSIONS_ID}
+CACHE_SCOPE=${DOCKER_BUILD_CACHE_SCOPE:-variety-test-mongodb$MONGODB_VERSION-nodejs$NODEJS_VERSION}
 
 VARIETY_SOURCECODE_PATH=$(readlink -f "$(dirname "$0")")/../..
 
@@ -45,7 +47,44 @@ sed -e "s/\${MONGODB_VERSION}/$MONGODB_VERSION/g" \
     -e "s/\${NODEJS_VERSION}/$NODEJS_VERSION/g"   \
     docker/Dockerfile.template > "$DOCKERFILES_DIR/$DOCKERFILE"
 
-echo "Building Docker image for Variety tests…"
-"$RUNNER" build --no-cache --tag "$DOCKERIMAGE" -f "$DOCKERFILES_DIR/$DOCKERFILE" .
+build_without_cache() {
+  echo "Building Docker image for Variety tests without cache…"
+  "$RUNNER" build --no-cache --tag "$DOCKERIMAGE" -f "$DOCKERFILES_DIR/$DOCKERFILE" .
+}
+
+build_with_github_actions_cache() {
+  echo "Building Docker image for Variety tests with GitHub Actions cache scope \"$CACHE_SCOPE\"…"
+  "$RUNNER" buildx build \
+    --pull \
+    --cache-from "type=gha,scope=$CACHE_SCOPE" \
+    --cache-to "type=gha,mode=min,scope=$CACHE_SCOPE,ignore-error=true" \
+    --load \
+    --tag "$DOCKERIMAGE" \
+    -f "$DOCKERFILES_DIR/$DOCKERFILE" .
+}
+
+github_actions_cache_available() {
+  [ "$RUNNER_NAME" = "docker" ] || return 1
+  [ "${GITHUB_ACTIONS:-}" = "true" ] || return 1
+  [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ] || return 1
+  if [ -z "${ACTIONS_CACHE_URL:-}" ] && [ -z "${ACTIONS_RESULTS_URL:-}" ]; then
+    return 1
+  fi
+  "$RUNNER" buildx version >/dev/null 2>&1
+}
+
+if [ "${DOCKER_BUILD_CACHE:-}" = "gha" ]; then
+  if github_actions_cache_available; then
+    if ! build_with_github_actions_cache; then
+      echo "GitHub Actions Docker cache build failed; retrying with a clean rebuild."
+      build_without_cache
+    fi
+  else
+    echo "GitHub Actions Docker cache requested but unavailable; doing a clean rebuild."
+    build_without_cache
+  fi
+else
+  build_without_cache
+fi
 
 "$RUNNER" run --rm --tty --volume "$VARIETY_SOURCECODE_PATH:$VARIETY_DOCKERDIR" --name "$CONTAINER" "$DOCKERIMAGE"


### PR DESCRIPTION
## Summary

- opt GitHub Actions Dockerized test jobs into Docker Buildx's GitHub Actions cache
- keep local `npm run test:docker` on the existing clean rebuild path by default
- document the CI cache behavior in `CONTRIBUTING.md`

## Conservative cache behavior

This intentionally treats the cache as a best-effort speedup, not as required infrastructure.

- Cache scopes are separated by runner OS/architecture, MongoDB version, and Node.js version.
- Cache export uses `mode=min` to keep the cache smaller.
- Cached builds use `--pull` so upstream MongoDB image tag movement causes a rebuild instead of silently leaning on an old base.
- If the GitHub Actions cache runtime is unavailable, CI does a clean `docker build --no-cache`.
- If the cache-backed `docker buildx build` fails, CI retries with a clean `docker build --no-cache`.

The intended failure mode is a slower rebuild/cache miss, not surprising test behavior.

## Testing

- `bash -n test/bin/test-on-docker.sh`
- `npm run lint:yaml`
- `npm run lint:markdown`
- `npm run lint:shell`
- `git diff --check`

`README.md` was checked and did not need a user-facing update.
