### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues,
+discussions, or pull requests.
+
+If GitHub shows the private **Report a vulnerability** button for this
+repository, use that workflow. It lets maintainers coordinate the report through
+a private GitHub security advisory.
+
+If that option is unavailable, email James Cropcho at
+[numerate_penniless652@dralias.com](mailto:numerate_penniless652@dralias.com).
+Include as much detail as you can safely share, such as affected versions,
+reproduction steps, impact, and any suggested mitigation.
+
+We will acknowledge private reports as soon as practical and will coordinate
+next steps privately before public disclosure.
+
+## Supported Versions
+
+We consider security reports affecting any released version of Variety. Fixes
+are prioritized for the current release and `main`; fixes or mitigation guidance
+for older releases are handled case by case.


### PR DESCRIPTION
## Summary
- add SECURITY.md with private vulnerability reporting guidance
- direct reporters to GitHub private reporting when available, with the SPDX-header email as a fallback
- document the support posture for security reports affecting any released Variety version

## Testing
- /home/j/variety/node_modules/.bin/markdownlint SECURITY.md