### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '43 5 * * 1'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openssf-scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,12 @@ build failures fall back to a clean `docker build --no-cache` rebuild so CI
 behavior remains predictable. Local `npm run test:docker` runs keep the clean
 rebuild behavior by default.
 
+GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. OpenSSF
+Scorecard runs on pushes to `main` and weekly on `main`, uploads SARIF results
+to GitHub code scanning, and keeps `publish_results: false` so results are not
+published to the OpenSSF REST API or README badges until maintainers explicitly
+enable public publishing.
+
 ## Linting
 
 Variety keeps its repository checks split into a few layers so it is clear which tool is complaining and why.


### PR DESCRIPTION
## Summary
- add an OpenSSF Scorecard workflow for pushes to `main` and a weekly scheduled scan
- upload SARIF to GitHub code scanning and retain a short-lived SARIF artifact
- keep `publish_results: false` so results are not published through the OpenSSF API or badge yet
- document the new security scan behavior in `CONTRIBUTING.md`

## Notes
- New workflow actions are pinned to exact commit SHAs with version comments.
- Public publishing can be enabled later by flipping `publish_results: true` and adding the required `id-token: write` permission.

## Testing
- `npm run verify:build`
- `npm run lint`
- `npm run lint:json`
- `npm run lint:markdown`
- `npm run lint:yaml`
- `npm run lint:spdx`
- `npm run typecheck`
- pre-commit hook ran successfully, including `npm run lint:dockerfile` and `npm run lint:shell`