### PR TITLE
Add project code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Variety Code of Conduct
+
+Variety welcomes constructive participation from anyone who wants to improve the project. Contributions can include code, documentation, bug reports, testing, support, design feedback, or other work that helps users and maintainers.
+
+This code of conduct applies to participation in Variety's project spaces, including GitHub issues, pull requests, code review, and other project-maintained communication channels.
+
+## Be Respectful
+
+People will sometimes disagree or find it difficult to cooperate. Accept that, but remain respectful. Disagreement is not an excuse for poor behavior or personal attacks, and a project where people feel threatened is not healthy.
+
+## Assume Good Faith
+
+Contributors may have different ways of working toward the shared goal of improving Variety. Assume that other people are trying to help the project, even when their approach differs from yours.
+
+Some contributors may not be native English speakers or may have different cultural backgrounds. Please leave room for that in how you read and respond to people.
+
+## Be Collaborative
+
+It is good to ask for help when you need it, and offers of help should be understood in the context of the shared goal of improving the project.
+
+When you make something for the benefit of Variety, be willing to explain how it works so others can understand, review, maintain, and build on it.
+
+## Try To Be Concise
+
+Keep in mind that public project communication may be read by many people, now and in the future. Writing concisely helps people understand the conversation efficiently. When a long explanation is necessary, consider adding a summary.
+
+Try to bring new information or arguments to a conversation so each message adds something useful. Stay on topic, especially in large discussions.
+
+## Be Open
+
+Use public project channels for Variety-related messages when that is appropriate. Public discussion makes it easier for others to answer questions, review decisions, catch mistakes, and learn from the work.
+
+Use private communication when a message is sensitive, includes private information, or reports a conduct concern.
+
+## In Case Of Problems
+
+Sometimes people have a bad day or are unaware of these guidelines. When that happens, it may be appropriate to point them to this code of conduct, publicly or privately, depending on the situation.
+
+Any such message should itself follow this code of conduct. In particular, it should not be abusive or disrespectful. Assume good faith where possible.
+
+Serious or persistent misconduct may result in temporary or permanent loss of the ability to participate in Variety's project spaces.
+
+## Reporting Issues
+
+Conduct concerns may be reported privately to James Cropcho at <numerate_penniless652@dralias.com>. Please include relevant context, links, and screenshots where practical.
+
+Reports will be reviewed as privately as practical, while allowing enough disclosure to understand the issue, respond appropriately, and maintain the project.
+
+## Attribution
+
+This code of conduct is adapted from the [Debian Code of Conduct](https://www.debian.org/code_of_conduct), version 1.0, ratified on April 28, 2014, and the [Debian Diversity Statement](https://www.debian.org/intro/diversity). Debian website material is copyright Software in the Public Interest, Inc. and others and is used under the [Debian website license terms](https://www.debian.org/license), choosing the MIT/Expat license option.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,8 @@ Integration tests for plugins live in `test/plugins/`. Copy the structure of `te
 
 ## Reporting Issues / Contributing
 
+Please follow the [Variety Code of Conduct](CODE_OF_CONDUCT.md) when participating in project spaces.
+
 Please report any bugs and feature requests on the Github issue tracker. I will read all reports!
 
 I accept pull requests from forks. Very grateful to accept contributions from folks.


### PR DESCRIPTION
## Summary

- add a Variety Code of Conduct adapted from the Debian Code of Conduct and Debian Diversity Statement
- use the existing SPDX-header email address as the private conduct reporting contact
- link the Code of Conduct from CONTRIBUTING.md

## Testing

- npm run lint:markdown
- pre-commit hook:
  - npm run verify:build
  - npm run lint
  - npm run lint:json
  - npm run lint:markdown
  - npm run lint:yaml
  - npm run lint:dockerfile
  - npm run lint:shell
  - npm run lint:spdx
  - npm run typecheck
