### PR TITLE
Pin GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       only-markdown: ${{ steps.check.outputs.only-markdown }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Check if only existing markdown files were modified
@@ -48,12 +48,12 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22'
           cache: npm
-      - run: npm install
+      - run: npm ci
         env:
           HUSKY: '0'
       - run: npm run verify:build
@@ -82,18 +82,18 @@ jobs:
       matrix:
         mongodb-version: ['5.0', '7.0', '8.0']
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22'
           cache: npm
-      - run: npm install
+      - run: npm ci
         env:
           HUSKY: '0'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Expose GitHub Actions cache runtime
-        uses: crazy-max/ghaction-github-runtime@v4
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - run: mkdir -p docker/Dockerfiles
       - run: npm run test:docker
         env:
@@ -108,18 +108,18 @@ jobs:
     if: needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24'
           cache: npm
-      - run: npm install
+      - run: npm ci
         env:
           HUSKY: '0'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Expose GitHub Actions cache runtime
-        uses: crazy-max/ghaction-github-runtime@v4
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - run: mkdir -p docker/Dockerfiles
       - run: npm run test:docker
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       only-markdown: ${{ steps.check.outputs.only-markdown }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Check if only existing markdown files were modified
@@ -66,14 +66,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: /language:${{ matrix.language }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ to GitHub code scanning, and keeps `publish_results: false` so results are not
 published to the OpenSSF REST API or README badges until maintainers explicitly
 enable public publishing.
 
+GitHub Actions workflows pin third-party actions to full commit SHAs with a
+nearby version comment for reviewability. CI jobs install NPM dependencies with
+`npm ci` so GitHub Actions uses the committed lockfile exactly.
+
 ## Linting
 
 Variety keeps its repository checks split into a few layers so it is clear which tool is complaining and why.


### PR DESCRIPTION
## Summary
- pin existing CI and CodeQL workflow actions to full commit SHAs with version comments
- switch GitHub Actions dependency installation from `npm install` to lockfile-backed `npm ci`
- document the workflow pinning and `npm ci` expectations in `CONTRIBUTING.md`

## Why
OpenSSF Scorecard reported `Pinned-Dependencies` findings in the existing `ci.yml` and `codeql.yml` workflows. The newer Scorecard workflow was already pinned; this follows through on the older workflows.

## Testing
- `env HUSKY=0 npm ci`
- `npm run verify:build`
- `npm run lint`
- `npm run lint:json`
- `npm run lint:markdown`
- `npm run lint:yaml`
- `npm run lint:dockerfile`
- `npm run lint:shell`
- `npm run lint:spdx`
- `npm run typecheck`