### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+name: Bug report
+description: Report something that is not working as expected.
+title: "Bug: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Variety. Please include enough detail for someone else to reproduce the problem.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched existing issues before opening this report.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the behavior you saw.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: Describe the behavior you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can someone reproduce this?
+      description: Include commands, relevant Variety options, and a small sample document shape when possible.
+      placeholder: |
+        1. Run ...
+        2. Analyze collection ...
+        3. See error ...
+    validations:
+      required: true
+  - type: input
+    id: variety-version
+    attributes:
+      label: Variety version or commit
+      description: For example, an npm version, release tag, or commit SHA.
+      placeholder: "1.5.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: invocation
+    attributes:
+      label: How are you running Variety?
+      options:
+        - Direct mongosh or mongo invocation with variety.js
+        - variety CLI
+        - npm package
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: mongodb-shell
+    attributes:
+      label: MongoDB shell
+      description: Include shell name and version if available.
+      placeholder: "mongosh 2.5.0"
+  - type: input
+    id: mongodb-server
+    attributes:
+      label: MongoDB server version
+      placeholder: "8.0.0"
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Required only when using the Variety CLI or npm package.
+      placeholder: "22.14.0"
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.4, Ubuntu 24.04, Windows 11, etc."
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: Paste error messages, command output, or logs here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+name: Documentation issue
+description: Report confusing, missing, or outdated documentation.
+title: "Docs: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make Variety easier to understand. Please point to the affected docs and the reader problem they create.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched existing issues before opening this report.
+          required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Where is the documentation problem?
+      description: Link to the section, file, heading, or example if possible.
+      placeholder: "README.md -> Analyze a Subset of Documents"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is confusing, missing, or outdated?
+      description: Describe what made the docs hard to use.
+    validations:
+      required: true
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Suggested improvement
+      description: Share wording, examples, commands, or structure that would help.
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who is the documentation for?
+      options:
+        - Someone using Variety from the MongoDB shell
+        - Someone using the Variety CLI
+        - Someone contributing to Variety
+        - Someone writing a plugin
+        - Other
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, links, command output, or related issues if useful.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+name: Feature request
+description: Suggest an improvement or new capability.
+title: "Feature: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. The most useful feature requests explain the data-analysis problem first, then the possible solution.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues
+      options:
+        - label: I searched existing issues before opening this request.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do with Variety that is difficult or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior, option, output format, or workflow you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds or other designs have you tried or considered?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Analysis behavior
+        - Output formatting
+        - CLI usage
+        - MongoDB shell usage
+        - Plugin support
+        - Documentation
+        - Testing or development workflow
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples
+      description: Include sample input, desired output, commands, or links that clarify the request.
+      render: shell
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility considerations
+      description: Note any MongoDB, mongosh, legacy mongo shell, or Node.js version concerns you know about.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+name: Question
+description: Ask for usage help or clarification.
+title: "Question: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking. Please include the command or workflow you are trying so someone can answer from the same context.
+  - type: checkboxes
+    id: existing-issues
+    attributes:
+      label: Existing issues and docs
+      options:
+        - label: I searched existing issues and checked the README before opening this question.
+          required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe the analysis, output, or workflow you want.
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command or configuration
+      description: Paste the command, Variety options, plugin configuration, or relevant code.
+      render: shell
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Mention docs, commands, examples, or workarounds you already checked.
+  - type: input
+    id: variety-version
+    attributes:
+      label: Variety version or commit
+      placeholder: "1.5.0"
+  - type: input
+    id: mongodb-shell
+    attributes:
+      label: MongoDB shell and server version
+      placeholder: "mongosh 2.5.0, MongoDB 8.0.0"
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Required only when using the Variety CLI or npm package.
+      placeholder: "22.14.0"
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add output, error messages, sample document shape, or links if useful.
+      render: shell

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+-
+
+## Related Issues
+
+-
+
+## Documentation
+
+- [ ] I updated `README.md`, `CONTRIBUTING.md`, or other docs where needed.
+- [ ] Documentation changes are not needed for this PR.
+
+## Testing
+
+- [ ] I ran the relevant local checks.
+- [ ] I could not run checks locally and explained why.
+
+Commands run:
+
+```text
+
+```
+
+## Review Notes
+
+- [ ] This PR is ready for human review.
+- [ ] A human approval was submitted in GitHub, or approval is not practical for this PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,10 @@ Commands run:
 
 ## Review Notes
 
+Maintainers prefer formal GitHub reviews for human signoff. When someone other
+than the PR author reviews the change, please use **Review changes** and submit
+**Approve** instead of only leaving comments. This is expected practice, but it
+is not currently enforced by branch rules.
+
 - [ ] This PR is ready for human review.
 - [ ] A human approval was submitted in GitHub, or approval is not practical for this PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,3 +258,8 @@ though approvals are not currently required by the branch rules. When someone
 other than the PR author has reviewed a change and is comfortable with it, use
 GitHub's **Review changes** flow and submit **Approve** instead of only leaving
 comments.
+
+That formal approval gives the project an auditable human review signal for
+future maintainers and supply-chain checks such as OpenSSF Scorecard. Automated
+review comments from Copilot, Codex, or other bots are useful, but they do not
+replace human approval.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,6 +242,19 @@ Integration tests for plugins live in `test/cases/plugins/`. Copy the structure 
 
 Please follow the [Variety Code of Conduct](CODE_OF_CONDUCT.md) when participating in project spaces.
 
-Please report any bugs and feature requests on the Github issue tracker. I will read all reports!
+Please report bugs, feature requests, documentation issues, and usage questions
+on the GitHub issue tracker. The repository includes issue forms for each of
+those report types; choose the closest fit and include the requested details. I
+will read all reports!
 
 I accept pull requests from forks. Very grateful to accept contributions from folks.
+
+Pull requests use the repository's GitHub pull request template. Please summarize
+the change, link related issues when they exist, note documentation impact, and
+include the checks you ran or explain why local checks were not run.
+
+Maintainers prefer formal GitHub pull request reviews for human signoff, even
+though approvals are not currently required by the branch rules. When someone
+other than the PR author has reviewed a change and is comfortable with it, use
+GitHub's **Review changes** flow and submit **Approve** instead of only leaving
+comments.


### PR DESCRIPTION
## Summary

- add structured GitHub issue forms for bug reports, feature requests, documentation issues, and questions
- add a pull request template for summaries, related issues, documentation impact, testing, and review readiness
- document the new reporting and pull request expectations in `CONTRIBUTING.md`

## Validation

- `npm run lint:yaml`
- `npm run lint:markdown`
- `npm run lint:spdx`
- Husky pre-commit hook:
  - `npm run verify:build`
  - `npm run lint`
  - `npm run lint:json`
  - `npm run lint:markdown`
  - `npm run lint:yaml`
  - `npm run lint:dockerfile`
  - `npm run lint:shell`
  - `npm run lint:spdx`
  - `npm run typecheck`
