### PR TITLE
Restrict CodeQL token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   changes:
@@ -57,6 +55,9 @@ jobs:
     # When skipped, only-markdown is empty → != 'true' → analyze proceeds.
     if: always() && needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- move the CodeQL workflow's code-scanning write permission from workflow scope to the analyze job
- leave the workflow-level token restricted to contents read access

## Why
OpenSSF Scorecard reported code-scanning alert 6 because `.github/workflows/codeql.yml` granted `security-events: write` at the top level. CodeQL still needs that permission to upload results, but only the analysis job needs it.

Refs https://github.com/variety/variety/security/code-scanning/6. Reported by OpenSSF Scorecard.

## Validation
- npm run lint:yaml
- npm run lint:spdx
- pre-commit hook: verify:build, lint, lint:json, lint:markdown, lint:yaml, lint:dockerfile, lint:shell, lint:spdx, typecheck