### PR TITLE
Run CodeQL on all commits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,45 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  changes:
-    name: Detect changes
-    # Only meaningful for push/PR — scheduled and manual runs always analyze
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      only-markdown: ${{ steps.check.outputs.only-markdown }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Check if only existing markdown files were modified
-        id: check
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-          fi
-          # First push to a branch has no meaningful base
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          changed=$(git diff --name-status "$BASE" "${{ github.sha }}")
-          if [ -z "$changed" ]; then
-            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
-          elif printf '%s\n' "$changed" | awk 'NF && ($1 != "M" || $2 !~ /\.md$/) { exit 1 }'; then
-            echo "only-markdown=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "only-markdown=false" >> "$GITHUB_OUTPUT"
-          fi
-
   analyze:
     name: Analyze (${{ matrix.language }})
-    needs: [changes]
-    # always() lets this run even when `changes` was skipped (schedule/dispatch).
-    # When skipped, only-markdown is empty → != 'true' → analyze proceeds.
-    if: always() && needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,11 +96,13 @@ build failures fall back to a clean `docker build --no-cache` rebuild so CI
 behavior remains predictable. Local `npm run test:container` runs keep the clean
 rebuild behavior by default.
 
-GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. OpenSSF
-Scorecard runs on pushes to `main` and weekly on `main`, uploads SARIF results
-to GitHub code scanning, and keeps `publish_results: false` so results are not
-published to the OpenSSF REST API or README badges until maintainers explicitly
-enable public publishing.
+GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. CodeQL
+runs on every push to `main`, every pull request targeting `main`, weekly on
+`main`, and on manual dispatch so SAST coverage stays attached to all commits.
+OpenSSF Scorecard runs on pushes to `main` and weekly on `main`, uploads SARIF
+results to GitHub code scanning, and keeps `publish_results: false` so results
+are not published to the OpenSSF REST API or README badges until maintainers
+explicitly enable public publishing.
 
 GitHub Actions workflows pin third-party actions to full commit SHAs with a
 nearby version comment for reviewability. CI jobs install NPM dependencies with


### PR DESCRIPTION
Addresses https://github.com/variety/variety/security/code-scanning/28.

## Summary
- remove the markdown-only skip from the CodeQL workflow
- document that CodeQL runs on every main push and pull request, plus scheduled and manual runs

## Why
OpenSSF Scorecard detected that SAST existed but was not attached to every recent commit. The skipped CodeQL runs for markdown-only changes were the likely source of the gap.

## Validation
- npm run lint:yaml
- npm run lint:markdown
- git diff --check