### PR TITLE
Add fast-check analyzer property tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 npm run test:mocha
 ```
 
-The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern under `test/cases/` — `test/cases/analysis/`, `test/cases/cli/`, `test/cases/formatters/`, `test/cases/persistence/`, and `test/cases/plugins/` — with shared helpers under `test/helpers/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install.
+The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern under `test/cases/` — `test/cases/analysis/`, `test/cases/cli/`, `test/cases/formatters/`, `test/cases/persistence/`, and `test/cases/plugins/` — with shared helpers under `test/helpers/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install. Analysis tests include deterministic property-based fuzzing with `fast-check` to exercise generated Mongo-like documents against core analyzer invariants.
 
 If you have Docker or Podman installed and don't want to test against your own MongoDB instance,
 you can execute tests against dockerized MongoDB:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",
         "eslint": "^10.2.0",
+        "fast-check": "^4.7.0",
         "globals": "^17.5.0",
         "husky": "^9.1.7",
         "js-yaml": "^4.1.1",
@@ -1420,6 +1421,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3120,6 +3144,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
     "eslint": "^10.2.0",
+    "fast-check": "^4.7.0",
     "globals": "^17.5.0",
     "husky": "^9.1.7",
     "js-yaml": "^4.1.1",

--- a/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
+++ b/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert/strict';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import fc from 'fast-check';
+
+const require = createRequire(import.meta.url);
+const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
+require(analyzerPath);
+
+/**
+ * @typedef {Record<string, unknown>} FuzzDocument
+ * @typedef {{ types: Record<string, number>, totalOccurrences: number, lastValue?: unknown }} InterimResult
+ * @typedef {{ _id: { key: string }, value: { types: Record<string, number> }, totalOccurrences: number, percentContaining: number }} VarietyResultRow
+ * @typedef {{
+ *   arrayEscape: string,
+ *   excludeSubkeys: Record<string, true>,
+ *   maxDepth: number,
+ *   compactArrayTypes: boolean,
+ *   lastValue: boolean,
+ *   logKeysContinuously: boolean
+ * }} AnalyzerConfig
+ * @typedef {{
+ *   createKeyMap: () => Record<string, InterimResult>,
+ *   reduceDocuments: (
+ *     config: AnalyzerConfig,
+ *     accumulator: Record<string, InterimResult>,
+ *     object: FuzzDocument,
+ *     log: (message: string) => void
+ *   ) => Record<string, InterimResult>,
+ *   convertResults: (
+ *     config: AnalyzerConfig,
+ *     interimResults: Record<string, InterimResult>,
+ *     documentsCount: number
+ *   ) => VarietyResultRow[]
+ * }} VarietyImpl
+ */
+
+const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
+const impl = analyzerGlobal.__varietyImpl;
+if (typeof impl === 'undefined') {
+  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
+}
+
+const noop = () => {};
+
+const keyArbitrary = fc.stringMatching(/^[a-z][a-z0-9_]{0,6}$/);
+const scalarValueArbitrary = fc.oneof(
+  fc.constant(null),
+  fc.boolean(),
+  fc.integer({ min: -1000, max: 1000 }),
+  fc.string({ maxLength: 24 }),
+  fc.date({ min: new Date('2000-01-01T00:00:00.000Z'), max: new Date('2030-12-31T23:59:59.999Z') })
+);
+
+const recursiveArbitraries = fc.letrec((tie) => ({
+  value: fc.oneof(
+    scalarValueArbitrary,
+    fc.array(tie('value'), { maxLength: 4 }),
+    fc.dictionary(keyArbitrary, tie('value'), { maxKeys: 4, noNullPrototype: true })
+  ),
+  document: fc.dictionary(keyArbitrary, tie('value'), { minKeys: 1, maxKeys: 5, noNullPrototype: true }),
+}));
+
+const documentArbitrary = /** @type {fc.Arbitrary<FuzzDocument>} */ (recursiveArbitraries['document']);
+const documentsArbitrary = fc.array(documentArbitrary, { minLength: 1, maxLength: 8 });
+const configArbitrary = fc.record({
+  compactArrayTypes: fc.boolean(),
+  maxDepth: fc.integer({ min: 1, max: 5 }),
+});
+
+/**
+ * @param {{ compactArrayTypes: boolean, maxDepth: number }} options
+ * @returns {AnalyzerConfig}
+ */
+const makeConfig = (options) => ({
+  arrayEscape: 'XX',
+  excludeSubkeys: {},
+  maxDepth: options.maxDepth,
+  compactArrayTypes: options.compactArrayTypes,
+  lastValue: false,
+  logKeysContinuously: false,
+});
+
+/**
+ * @param {FuzzDocument[]} documents
+ * @param {AnalyzerConfig} config
+ * @returns {VarietyResultRow[]}
+ */
+const analyzeDocuments = (documents, config) => {
+  const accumulator = impl.createKeyMap();
+  for (const document of documents) {
+    impl.reduceDocuments(config, accumulator, document, noop);
+  }
+  return impl.convertResults(config, accumulator, documents.length);
+};
+
+/**
+ * @param {VarietyResultRow[]} results
+ * @returns {Array<{ key: string, totalOccurrences: number, percentContaining: number, types: Record<string, number> }>}
+ */
+const normalizeResults = (results) => results
+  .map((row) => {
+    /** @type {Record<string, number>} */
+    const sortedTypes = {};
+    for (const typeName of Object.keys(row.value.types).sort()) {
+      const typeCount = row.value.types[typeName];
+      if (typeof typeCount !== 'number') {
+        throw new Error(`Missing type count for ${row._id.key}:${typeName}`);
+      }
+      sortedTypes[typeName] = typeCount;
+    }
+
+    return {
+      key: row._id.key,
+      totalOccurrences: row.totalOccurrences,
+      percentContaining: row.percentContaining,
+      types: sortedTypes,
+    };
+  })
+  .sort((left, right) => left.key.localeCompare(right.key));
+
+/**
+ * @param {VarietyResultRow[]} results
+ * @param {number} documentsCount
+ */
+const assertSaneResults = (results, documentsCount) => {
+  assert.ok(results.length > 0, 'analysis should find at least one key');
+
+  for (const row of results) {
+    assert.ok(row._id.key.length > 0, 'result keys should be non-empty');
+    assert.ok(Number.isInteger(row.totalOccurrences), `${row._id.key} should have an integer occurrence count`);
+    assert.ok(row.totalOccurrences >= 1, `${row._id.key} should occur in at least one document`);
+    assert.ok(row.totalOccurrences <= documentsCount, `${row._id.key} should not occur more often than documents`);
+    assert.equal(row.percentContaining, row.totalOccurrences * 100 / documentsCount);
+
+    const typeNames = Object.keys(row.value.types);
+    assert.ok(typeNames.length > 0, `${row._id.key} should include at least one type`);
+    for (const typeName of typeNames) {
+      const typeCount = row.value.types[typeName];
+      if (typeof typeCount !== 'number') {
+        throw new Error(`${row._id.key}:${typeName} should have a numeric count`);
+      }
+      assert.ok(Number.isInteger(typeCount), `${row._id.key}:${typeName} should have an integer count`);
+      assert.ok(typeCount >= 1, `${row._id.key}:${typeName} should appear at least once`);
+      assert.ok(typeCount <= row.totalOccurrences, `${row._id.key}:${typeName} should not exceed key occurrences`);
+    }
+  }
+};
+
+describe('Analyzer property fuzzing', () => {
+
+  it('should produce sane counts for generated documents', () => {
+    fc.assert(
+      fc.property(documentsArbitrary, configArbitrary, (documents, options) => {
+        const results = analyzeDocuments(documents, makeConfig(options));
+        assertSaneResults(results, documents.length);
+      }),
+      { numRuns: 200, seed: 29103 }
+    );
+  });
+
+  it('should produce the same result regardless of document order', () => {
+    fc.assert(
+      fc.property(documentsArbitrary, configArbitrary, (documents, options) => {
+        const config = makeConfig(options);
+        const forwardResults = normalizeResults(analyzeDocuments(documents, config));
+        const reversedResults = normalizeResults(analyzeDocuments([...documents].reverse(), config));
+
+        assert.deepEqual(forwardResults, reversedResults);
+      }),
+      { numRuns: 200, seed: 29104 }
+    );
+  });
+
+});


### PR DESCRIPTION
## Summary
- add deterministic `fast-check` property fuzzing around core analyzer invariants
- cover generated Mongo-like document analysis for sane counts and order-independent reductions
- document the new property-based analyzer coverage in `CONTRIBUTING.md`

Addresses https://github.com/variety/variety/security/code-scanning/29 from OpenSSF Scorecard FuzzingID.

## Validation
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/analysis/AnalyzerPropertyFuzzingTest.js`
- `npm run lint`
- `npm run typecheck`
- `npm run verify:build`
- `npm run lint:markdown`
- `npm run lint:json`
- `npm run lint:yaml`
- `npm run lint:spdx`
- `npm run lint:dockerfile`
- `npm run lint:shell`
- container run with relabeled `/tmp` worktree volume: `60 passing`

Note: plain `npm test` reached the container run but failed before tests started because Podman could not execute `/opt/variety/docker/init.sh` from the `/tmp` worktree bind mount. Running the already-built image with the same worktree mounted using `:z` completed successfully.