### PR TITLE
Fix markdown-only skip breaking required status checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,27 +75,43 @@ jobs:
   test:
     name: Test (Node 22, MongoDB ${{ matrix.mongodb-version }})
     needs: changes
-    if: needs.changes.outputs.only-markdown != 'true'
+    # No job-level if: here — see note below. Steps are guarded individually.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         mongodb-version: ['5.0', '7.0', '8.0']
     steps:
+      # NOTE: The only-markdown skip is applied at the step level rather than
+      # the job level. A job-level `if: only-markdown != true` causes GitHub
+      # Actions to skip the entire job, which: (a) leaves the job name showing
+      # the raw `${{ matrix.mongodb-version }}` template string (matrix
+      # variables are only expanded when the job runs), and (b) never reports
+      # the expanded check names (e.g. "Test (Node 22, MongoDB 5.0)") that
+      # branch protection requires, leaving those checks permanently pending.
+      # Step-level guards let the job start, do nothing, and exit success —
+      # satisfying required checks while still skipping the expensive work.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: needs.changes.outputs.only-markdown != 'true'
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        if: needs.changes.outputs.only-markdown != 'true'
         with:
           node-version: '22'
           cache: npm
       - run: npm ci
+        if: needs.changes.outputs.only-markdown != 'true'
         env:
           HUSKY: '0'
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.only-markdown != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Expose GitHub Actions cache runtime
+        if: needs.changes.outputs.only-markdown != 'true'
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - run: mkdir -p docker/Dockerfiles
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run test:container
+        if: needs.changes.outputs.only-markdown != 'true'
         env:
           MONGODB_VERSION: ${{ matrix.mongodb-version }}
           NODEJS_VERSION: '22'
@@ -105,23 +121,30 @@ jobs:
   test-smoke:
     name: Smoke Test (Node 24, MongoDB 8.0)
     needs: changes
-    if: needs.changes.outputs.only-markdown != 'true'
+    # No job-level if: here — same reason as the test matrix job above.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: needs.changes.outputs.only-markdown != 'true'
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        if: needs.changes.outputs.only-markdown != 'true'
         with:
           node-version: '24'
           cache: npm
       - run: npm ci
+        if: needs.changes.outputs.only-markdown != 'true'
         env:
           HUSKY: '0'
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.only-markdown != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Expose GitHub Actions cache runtime
+        if: needs.changes.outputs.only-markdown != 'true'
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - run: mkdir -p docker/Dockerfiles
+        if: needs.changes.outputs.only-markdown != 'true'
       - run: npm run test:container
+        if: needs.changes.outputs.only-markdown != 'true'
         env:
           MONGODB_VERSION: '8.0'
           NODEJS_VERSION: '24'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,20 @@ build failures fall back to a clean `docker build --no-cache` rebuild so CI
 behavior remains predictable. Local `npm run test:container` runs keep the clean
 rebuild behavior by default.
 
+**Why test and smoke-test jobs guard at the step level, not the job level:**
+When a matrix job is skipped via a job-level `if:`, GitHub Actions never
+expands the matrix variables, so the job name stays as the raw template
+string (e.g. `Test (Node 22, MongoDB ${{ matrix.mongodb-version }})`).
+More importantly, the expanded check names that branch protection requires
+(e.g. `CI / Test (Node 22, MongoDB 5.0)`) are never reported at all,
+leaving those required checks permanently in a "waiting" state. Guarding
+individual steps instead lets the job start, skip all real work, and exit
+success — the expanded name gets reported, required checks are satisfied,
+and no tests are falsely implied. This is safe because the `only-markdown`
+detection (which requires all changed files to be existing `.md` files with
+`M` status — no additions or deletions, no non-`.md` files) is the gate;
+if it is correct, "success with no steps run" is semantically accurate.
+
 GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. CodeQL
 runs on every push to `main`, every pull request targeting `main`, weekly on
 `main`, and on manual dispatch so SAST coverage stays attached to all commits.


### PR DESCRIPTION
## Summary

- Matrix test jobs (`test`, `test-smoke`) had a job-level `if: only-markdown != 'true'` that caused two problems when a markdown-only PR landed:
  - The job name showed the raw `${{ matrix.mongodb-version }}` template string instead of the expanded value (matrix variables are only substituted when a job actually runs)
  - The expanded check names branch protection requires (e.g. `CI / Test (Node 22, MongoDB 5.0)`) were never reported, leaving those required checks permanently pending ("Expected — Waiting for status to be reported")
- Fix: move the `only-markdown` guard to the step level so the job always starts, skips all real work, and exits success — satisfying required checks without running tests
- Documents the rationale in `CONTRIBUTING.md` and in a code comment adjacent to the affected steps

## Test plan

- [ ] Open a markdown-only PR and verify all three matrix check names appear as green (not pending/skipped)
- [ ] Open a non-markdown PR and verify tests still run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)