### PR TITLE
Publish OpenSSF Scorecard badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       security-events: write
 
     steps:
@@ -28,7 +29,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: false
+          publish_results: true
 
       - name: Upload SARIF artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,8 @@ GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. CodeQL
 runs on every push to `main`, every pull request targeting `main`, weekly on
 `main`, and on manual dispatch so SAST coverage stays attached to all commits.
 OpenSSF Scorecard runs on pushes to `main` and weekly on `main`, uploads SARIF
-results to GitHub code scanning, and keeps `publish_results: false` so results
-are not published to the OpenSSF REST API or README badges until maintainers
-explicitly enable public publishing.
+results to GitHub code scanning, and publishes results to the OpenSSF REST API
+so the README badge reflects the repository's current public security posture.
 
 GitHub Actions workflows pin third-party actions to full commit SHAs with a
 nearby version comment for reviewability. CI jobs install NPM dependencies with

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Meet Variety, a Schema Analyzer for MongoDB
+
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/variety/variety/badge)](https://scorecard.dev/viewer/?uri=github.com/variety/variety)
+
 This lightweight tool helps you get a sense of your application's schema, as well as any outliers to that schema. Particularly useful when you inherit a codebase with a data dump and want to quickly learn how the data's structured. Also useful for finding rare keys.
 
 ***


### PR DESCRIPTION
Refs #277.

## Summary
- enable public OpenSSF Scorecard result publishing with `publish_results: true`
- grant the Scorecard workflow `id-token: write` for result publishing
- add the OpenSSF Scorecard badge near the top of `README.md`
- update `CONTRIBUTING.md` to describe public Scorecard results

## Notes
The badge may show stale or unavailable data until the Scorecard workflow runs on `main` after merge and publishes the first public result.

## Testing
- `env HUSKY=0 npm ci`
- pre-commit hook completed successfully during commit:
  - `npm run verify:build`
  - `npm run lint`
  - `npm run lint:json`
  - `npm run lint:markdown`
  - `npm run lint:yaml`
  - `npm run lint:dockerfile`
  - `npm run lint:shell`
  - `npm run lint:spdx`
  - `npm run typecheck`
- after rebasing onto latest `main`:
  - `npm run lint:yaml`
  - `npm run lint:markdown`
  - `npm run lint:spdx`
  - `git diff --check origin/main...HEAD`