### PR TITLE
Add required CI gate for markdown-only skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,62 @@ jobs:
           NODEJS_VERSION: '24'
           DOCKER_BUILD_CACHE: gha
           DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-8.0-node-24
+
+  required-ci-gate:
+    name: Required CI Gate
+    needs: [changes, lint, test, test-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate required CI result
+        env:
+          ONLY_MARKDOWN: ${{ needs.changes.outputs.only-markdown }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          SMOKE_RESULT: ${{ needs.test-smoke.result }}
+        run: |
+          {
+            echo "### Required CI Gate"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| Detect changes | $CHANGES_RESULT |"
+            echo "| Lint | $LINT_RESULT |"
+            echo "| Test matrix | $TEST_RESULT |"
+            echo "| Smoke test | $SMOKE_RESULT |"
+            echo
+            echo "only-markdown: \`$ONLY_MARKDOWN\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Detect changes did not succeed." >&2
+            exit 1
+          fi
+
+          if [ "$LINT_RESULT" != "success" ]; then
+            echo "Lint did not succeed." >&2
+            exit 1
+          fi
+
+          if [ "$ONLY_MARKDOWN" = "true" ]; then
+            if [ "$TEST_RESULT" != "skipped" ] || [ "$SMOKE_RESULT" != "skipped" ]; then
+              echo "Markdown-only changes should skip test jobs; got test=$TEST_RESULT smoke=$SMOKE_RESULT." >&2
+              exit 1
+            fi
+
+            echo "Markdown-only change: tests were intentionally skipped." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "Test matrix did not succeed." >&2
+            exit 1
+          fi
+
+          if [ "$SMOKE_RESULT" != "success" ]; then
+            echo "Smoke test did not succeed." >&2
+            exit 1
+          fi
+
+          echo "Full CI passed." >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,17 @@ build failures fall back to a clean `docker build --no-cache` rebuild so CI
 behavior remains predictable. Local `npm run test:container` runs keep the clean
 rebuild behavior by default.
 
+**Required CI Gate and markdown-only pull requests:** The `changes` job detects
+pull requests that only modify existing `.md` files. For those PRs, CI still
+runs markdown linting, but the Dockerized test matrix and Node.js 24 smoke test
+are skipped at the job level so GitHub shows those jobs as skipped rather than
+successful. The always-running `Required CI Gate` job is the branch-protection
+status that should be required instead of the individual test-matrix and smoke
+test statuses: it passes only when either full CI passed, or the change is
+markdown-only and the test jobs were intentionally skipped. This replaces the
+workaround from #295, which satisfied required matrix check names by reporting
+green test jobs even when the test commands did not run.
+
 GitHub Actions also runs CodeQL and OpenSSF Scorecard security scans. CodeQL
 runs on every push to `main`, every pull request targeting `main`, weekly on
 `main`, and on manual dispatch so SAST coverage stays attached to all commits.


### PR DESCRIPTION
## Summary
- Add an always-running `Required CI Gate` job to the CI workflow.
- Keep the test matrix and smoke test jobs honestly skipped at the job level for markdown-only PRs.
- Document the required-check model in `CONTRIBUTING.md`.

## Why this is better than #295
#295 solved a real branch-protection problem: skipped matrix jobs did not emit the expanded required check names, which could leave markdown-only PRs stuck waiting for required checks that would never appear.

The tradeoff in #295 was that markdown-only PRs showed green `Test (...)` and `Smoke Test (...)` checks even though the actual test commands were skipped. That was mechanically safe for code changes because the markdown-only detector was narrow, but the checks list could still be read as tests having run and passed.

This PR moves the required signal to an explicit aggregate gate. For markdown-only PRs, the test jobs remain visibly skipped and `Required CI Gate` passes because that skip was intentional. For code, workflow, package, or tooling changes, the gate requires lint, the full MongoDB test matrix, and the Node 24 smoke test to succeed. That makes the UI story clearer: tests either ran and passed, or they were skipped and the gate says why.

## Repository setting follow-up
After this lands, the branch ruleset should require `Required CI Gate` instead of the individual `Test (Node 22, MongoDB ...)` and `Smoke Test (Node 24, MongoDB 8.0)` contexts. Separate security checks can still be required independently if maintainers want that. Until that ruleset change is made, the old individual required checks can still recreate the pending-check problem for markdown-only PRs.

## Validation
- `npm run lint:yaml`
- `npm run lint:markdown`
- Pre-commit hook during `git commit`: `npm run verify:build`, `npm run lint`, `npm run lint:json`, `npm run lint:markdown`, `npm run lint:yaml`, `npm run lint:dockerfile`, `npm run lint:shell`, `npm run lint:spdx`, and `npm run typecheck`
