### PR TITLE
Serialize Date values as ISO 8601 strings instead of Unix ms timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ One can also apply a `lastValue` constraint to capture one representative value 
     | animals         | Array        |           1 |    100.0 | [Array]                          |
     | animals.XX.type | String       |           1 |    100.0 | dog                              |
     | balance         | NumberLong   |           1 |    100.0 |                 1236458945684846 |
-    | date            | Date         |           1 |    100.0 |                    1513539969000 |
+    | date            | Date         |           1 |    100.0 | 2017-12-17T19:46:09.000Z         |
     | fn              | Object       |           1 |    100.0 | [Object]                         |
     | fn.code         | String       |           1 |    100.0 | function (x, y){ return x + y; } |
     | name            | String       |           1 |    100.0 | John                             |
@@ -189,7 +189,7 @@ One can also apply a `lastValue` constraint to capture one representative value 
     +--------------------------------------------------------------------------------------------+
 
 Variety captures each `lastValue` from the first matching document it sees in the configured sort order. If you do not provide `sort`, it uses the default `{ _id: -1 }` ordering, so these values come from the newest matching documents encountered during the scan.
-`Date` is converted into `timestamp`, `ObjectId` into `string`, and binary data into hex. Other types are shown in square brackets.
+`Date` is converted into an ISO 8601 string, `ObjectId` into `string`, and binary data into hex. Other types are shown in square brackets.
 Variety reports BSON wrapper types such as `Decimal128`, `Timestamp`, `Code`, `BSONRegExp`, `MinKey`, `MaxKey`, and `DBRef` by their BSON type names in the `types` column.
 
 ## Collect Multiple Example Values
@@ -201,22 +201,22 @@ When a single representative value is not enough, use `maxExamples` to gather up
     +---------------------------------------------------------------------------------------------------------------------------------------------------+
     | key                | types                | occurrences | percents | examples                                                                     |
     | ------------------ | -------------------- | ----------- | -------- | ---------------------------------------------------------------------------- |
-    | _id                | ObjectId             |           5 |    100.0 | 69e6a561b5d42ed48544ba8d, 69e6a561b5d42ed48544ba8c, 69e6a561b5d42ed48544ba8b |
+    | _id                | ObjectId             |           5 |    100.0 | 69e6cbc2e9ccbf038c44ba8d, 69e6cbc2e9ccbf038c44ba8c, 69e6cbc2e9ccbf038c44ba8b |
     | name               | String               |           5 |    100.0 | Jim, Geneviève, Harry                                                        |
     | bio                | String               |           3 |     60.0 | Ça va?, I swordfight., A nice guy.                                           |
-    | birthday           | Date                 |           2 |     40.0 | 448070400000, 132451200000                                                   |
+    | birthday           | Date                 |           2 |     40.0 | 1984-03-14T00:00:00.000Z, 1974-03-14T00:00:00.000Z                           |
     | pets               | String (1),Array (1) |           2 |     40.0 | egret, [Array]                                                               |
     | someBinData        | BinData-old          |           1 |     20.0 | d76df8                                                                       |
     | someWeirdLegacyKey | String               |           1 |     20.0 | I like Ike!                                                                  |
     +---------------------------------------------------------------------------------------------------------------------------------------------------+
 
-_(ObjectId hex strings and timestamps are runtime-generated; exact values will differ.)_
+_(ObjectId hex strings are runtime-generated; exact values will differ.)_
 
 Via the first-party CLI:
 
     $ variety test/users --maxExamples 3
 
-The same serialisation rules as `lastValue` apply: `Date` → Unix timestamp (ms), `ObjectId` → hex string, binary data → hex. Non-serialisable types such as `Array` or `Object` appear as `[TypeName]` placeholders.
+The same serialisation rules as `lastValue` apply: `Date` → ISO 8601 string, `ObjectId` → hex string, binary data → hex. Non-serialisable types such as `Array` or `Object` appear as `[TypeName]` placeholders.
 
 `maxExamples` and `lastValue` are independent; both can be used together.
 

--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -211,7 +211,7 @@
         } else if (type === 'ObjectId') {
           result[key][type] = typeof value.toHexString === 'function' ? value.toHexString() : value.str;
         } else if (type === 'Date') {
-          result[key][type] = new Date(value).getTime();
+          result[key][type] = new Date(value).toISOString();
         } else if (type.startsWith('BinData')) {
           result[key][type] = getBinDataHex(value);
         }

--- a/test/cases/analysis/BasicAnalysisTest.js
+++ b/test/cases/analysis/BasicAnalysisTest.js
@@ -23,7 +23,7 @@ describe('Basic Analysis', () => {
     results.validate('_id', 5, 100.0, {ObjectId: 5});
     results.validate('name', 5, 100.0, {String: 5}, 'Jim');
     results.validate('bio', 3, 60.0, {String: 3}, 'Ça va?');
-    results.validate('birthday', 2,  40.0, {Date: 2}, 448070400000);
+    results.validate('birthday', 2,  40.0, {Date: 2}, '1984-03-14T00:00:00.000Z');
     results.validate('pets', 2,  40.0, {String: 1, Array: 1}, 'egret');
     results.validate('someBinData', 1,  20.0, {'BinData-generic': 1});
     results.validate('someWeirdLegacyKey', 1,  20.0, {String: 1}, 'I like Ike!');
@@ -35,6 +35,7 @@ describe('Basic Analysis', () => {
     results.validateResultsCount(7);
     results.validateExamples('name', ['Jim', 'Geneviève', 'Harry']);
     results.validateExamples('bio', ['Ça va?', 'I swordfight.', 'A nice guy.']);
+    results.validateExamples('birthday', ['1984-03-14T00:00:00.000Z', '1974-03-14T00:00:00.000Z']);
     results.validateExamples('pets', ['egret', '[Array]']);
     results.validateExamples('someWeirdLegacyKey', ['I like Ike!']);
   });

--- a/variety.js
+++ b/variety.js
@@ -357,7 +357,7 @@ Please see https://github.com/variety/variety for details. */
         } else if (type === 'ObjectId') {
           result[key][type] = typeof value.toHexString === 'function' ? value.toHexString() : value.str;
         } else if (type === 'Date') {
-          result[key][type] = new Date(value).getTime();
+          result[key][type] = new Date(value).toISOString();
         } else if (type.startsWith('BinData')) {
           result[key][type] = getBinDataHex(value);
         }


### PR DESCRIPTION
## Summary

- `lastValue` and `maxExamples` previously represented BSON `Date` values as Unix millisecond integers (e.g. `448070400000`), which are opaque without manual conversion
- They now render as ISO 8601 strings (e.g. `"1984-03-14T00:00:00.000Z"`), which are human-readable and unambiguous
- Updates README examples (using actual command output) and `BasicAnalysisTest` expectations accordingly; also adds a `validateExamples('birthday', ...)` assertion to the `maxExamples` test

## Test plan

- [x] `Basic Analysis > should return JSON results` — validates birthday `lastValue` is `'1984-03-14T00:00:00.000Z'`
- [x] `Basic Analysis > should collect up to maxExamples example values per key` — validates birthday examples are `['1984-03-14T00:00:00.000Z', '1974-03-14T00:00:00.000Z']`
- [x] All other previously-passing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)