### PR TITLE
Test all mapped BSON binary subtypes; upgrade Binary data inventory row to Tested merged

### DIFF
--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import { Binary, UUID } from 'mongodb';
+import VarietyHarness from '../../helpers/VarietyHarness.js';
+
+const test = new VarietyHarness('test', 'bindata_subtypes');
+
+// One document with a field per BSON binary subtype that Variety intentionally
+// maps. Subtypes 3 (UUID old) and 4 (UUID) both report as BinData-UUID.
+const doc = {
+  binData_generic:  new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_DEFAULT),
+  binData_function: new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_FUNCTION),
+  binData_old:      new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_BYTE_ARRAY),
+  binData_uuid_old: new Binary(
+    Uint8Array.from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
+    Binary.SUBTYPE_UUID_OLD
+  ),
+  binData_uuid:     new UUID('00112233-4455-6677-8899-aabbccddeeff'),
+  binData_md5:      new Binary(
+    Uint8Array.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]),
+    Binary.SUBTYPE_MD5
+  ),
+  binData_user:     new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
+};
+
+describe('Binary subtype recognition', () => {
+  beforeEach(() => test.init([doc]));
+  afterEach(() => test.cleanUp());
+
+  it('should report each mapped binary subtype under its Variety label', async () => {
+    const results = await test.runJsonAnalysis({ collection: 'bindata_subtypes' }, true);
+    results.validateResultsCount(8); // _id plus one field per subtype
+    results.validate('_id',              1, 100.0, { ObjectId: 1 });
+    results.validate('binData_generic',  1, 100.0, { 'BinData-generic':  1 });
+    results.validate('binData_function', 1, 100.0, { 'BinData-function': 1 });
+    results.validate('binData_old',      1, 100.0, { 'BinData-old':      1 });
+    // Subtypes 3 (UUID old) and 4 (UUID) both map to BinData-UUID.
+    results.validate('binData_uuid_old', 1, 100.0, { 'BinData-UUID':     1 });
+    results.validate('binData_uuid',     1, 100.0, { 'BinData-UUID':     1 });
+    results.validate('binData_md5',      1, 100.0, { 'BinData-MD5':      1 });
+    results.validate('binData_user',     1, 100.0, { 'BinData-user':     1 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `test/cases/analysis/BinarySubtypeTest.js`: one Mocha test that asserts the exact Variety label for all seven binary subtypes that the analyzer maps intentionally — generic (`0x00`), function (`0x01`), old (`0x02`), UUID-old (`0x03`), UUID (`0x04`), MD5 (`0x05`), and user-defined `0x80`.
- Updates `BSON_TYPE_INVENTORY.md`:
  - Top-level **Binary data** row (type `5`): `Partial` → **`Tested merged`**, with a note explaining that Variety emits `BinData-{subtype}` labels rather than a single `Binary data` label.
  - Subtypes `0x01`, `0x02`, `0x03`, `0x05`: `Untested` → `Tested`.
  - User-defined range (`0x80`–`0xFF`) row: `Untested` → `Partial` (`0x80` tested; `0x81`–`0xFF` fall through to `BinData-undefined`, intentionally unmapped).
  - Legacy UUID rows (`PYTHON_LEGACY`, `JAVA_LEGACY`, `CSHARP_LEGACY`): `Untested` → `Tested`, noting that Variety maps any subtype-3 value to `BinData-UUID` regardless of byte order.
  - Adds source reference `[V6]` for the new test file.

## Validation results

**Test suite** (`npm run test:container` — Node 22, MongoDB 8.2 via Podman):

```
Binary subtype recognition
  ✔ should report each mapped binary subtype under its Variety label (490ms)

65 passing (21s)
```

All 65 tests pass, including the new `BinarySubtypeTest`.

**Markdown linting** (`npm run lint:markdown`): clean, no errors.

**Pre-commit hooks** (build check, ESLint, jsonlint, markdownlint, YAML, hadolint, shellcheck, SPDX, tsc): all passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)