### PR TITLE
Document tested runtimes in README

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -11,6 +11,8 @@
   "MD022": false,
   // MD031: Fenced code blocks should be surrounded by blank lines — disabled
   "MD031": false,
+  // MD033: Inline HTML — allow explicit line breaks in compact tables only
+  "MD033": { "allowed_elements": [ "br" ] },
   // MD036: Emphasis used instead of a heading — disabled
   "MD036": false,
   // MD040: Fenced code blocks should have a language specified — disabled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,8 @@ Otherwise all of the following run:
 - `npm run lint:spdx` — verifies `SPDX-License-Identifier: MIT` headers in all tracked source files
 - `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `bin/variety`, `cli/**/*.js`, `.eslint.config.js`, `build.js`, and Node-side test code under `test`
 
+Markdownlint allows only one inline HTML element, `<br />`, for intentional line breaks inside compact Markdown tables.
+
 ### ESLint Rulesets
 
 #### Shared Baseline

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ _“This code saved me at least an hour of work, so least i could do was spend a
 
 Also featured on the [official MongoDB blog](https://web.archive.org/web/20231002225312/http://www.mongodb.com:80/blog/post/meet-variety-a-schema-analyzer-for-mongodb).
 
+## Tested Runtimes
+
+| Runtime | Tested Release Lines |
+| --- | --- |
+| MongoDB | latest 8.2.x, 8.0.x, 7.0.x, and 5.0.x |
+| MongoDB shell | `mongosh`: MongoDB >= 6.0<br />`mongo`: MongoDB < 6.0 |
+| Node.js | latest 22.x, plus a latest 24.x smoke test |
+
 ## An Easy Example
 
 We'll make a collection:


### PR DESCRIPTION
## Summary
- add a Tested Runtimes table near the top of the README
- document tested MongoDB and Node.js release lines, plus the MongoDB shell boundary
- allow `<br />` as the only markdownlint inline HTML exception and document that convention in CONTRIBUTING

Refs #279, reported by @JamesCropcho.

## Validation
- `npm run lint:markdown`
- `npm run lint:json`
- commit hook also ran `npm run verify:build`, `npm run lint`, `npm run lint:yaml`, `npm run lint:dockerfile`, `npm run lint:shell`, `npm run lint:spdx`, and `npm run typecheck`