### PR TITLE
Add README CodeQL and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meet Variety, a Schema Analyzer for MongoDB
 
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/variety/variety/badge)](https://scorecard.dev/viewer/?uri=github.com/variety/variety)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/variety/variety/badge)](https://scorecard.dev/viewer/?uri=github.com/variety/variety) [![CodeQL](https://github.com/variety/variety/actions/workflows/codeql.yml/badge.svg)](https://github.com/variety/variety/actions/workflows/codeql.yml) [![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 This lightweight tool helps you get a sense of your application's schema, as well as any outliers to that schema. Particularly useful when you inherit a codebase with a data dump and want to quickly learn how the data's structured. Also useful for finding rare keys.
 


### PR DESCRIPTION
## Summary
- add CodeQL and MIT License badges to the existing README badge row
- keep the badge change scoped to README only

Refs #279, reported by @JamesCropcho.

## Validation
- `npm run lint:markdown`