### PR TITLE
Add test coverage for all deprecated top-level BSON types

### DIFF
--- a/test/cases/analysis/DatatypeRecognitionTest.js
+++ b/test/cases/analysis/DatatypeRecognitionTest.js
@@ -3,6 +3,7 @@
 import {
   Binary,
   BSONRegExp,
+  BSONSymbol,
   Code,
   DBRef,
   Decimal128,
@@ -37,7 +38,8 @@ const crazyObject = {
   key_maxKey: new MaxKey(),
   key_dbRef: new DBRef('widgets', new ObjectId(), 'test'),
   key_double: new Double(3.14),
-  key_int32: new Int32(7)
+  key_int32: new Int32(7),
+  key_symbol: new BSONSymbol('mysymbol')
 };
 
 describe('Data type recognition', () => {
@@ -49,7 +51,7 @@ describe('Data type recognition', () => {
     // Issue #164 (@vitorcampos-db): BSON wrappers should stay distinct from
     // plain Object and should not expand into nested subkeys during analysis.
     const results = await test.runJsonAnalysis({collection:'users'}, true);
-    results.validateResultsCount(20);
+    results.validateResultsCount(21);
     results.validate('_id', 1, 100.0, {ObjectId: 1});
     results.validate('key_string', 1, 100.0, {String: 1});
     results.validate('key_boolean', 1, 100.0, {Boolean: 1});
@@ -71,5 +73,8 @@ describe('Data type recognition', () => {
     // mongosh promotes BSON Double and Int32 to plain JavaScript numbers.
     results.validate('key_double', 1, 100.0, {Number: 1});
     results.validate('key_int32', 1, 100.0, {Number: 1});
+    // Deprecated BSON Symbol (type 14): mongosh promotes it to a plain string,
+    // so Variety reports 'String' — a broader, merged label.
+    results.validate('key_symbol', 1, 100.0, {String: 1});
   });
 });

--- a/test/cases/analysis/DeprecatedBsonTypesTest.js
+++ b/test/cases/analysis/DeprecatedBsonTypesTest.js
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert/strict';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { BSONSymbol, Code, DBRef, ObjectId } from 'mongodb';
+
+const require = createRequire(import.meta.url);
+const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
+require(analyzerPath);
+
+/**
+ * @typedef {{
+ *   arrayEscape: string,
+ *   excludeSubkeys: Record<string, true>,
+ *   maxDepth: number,
+ *   compactArrayTypes: boolean,
+ *   lastValue: boolean,
+ *   logKeysContinuously: boolean,
+ *   maxExamples: number,
+ * }} AnalyzerConfig
+ * @typedef {{
+ *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+ * }} VarietyImpl
+ */
+
+const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
+const impl = analyzerGlobal.__varietyImpl;
+if (typeof impl === 'undefined') {
+  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
+}
+
+/** @type {AnalyzerConfig} */
+const config = {
+  arrayEscape: 'XX',
+  excludeSubkeys: /** @type {Record<string, true>} */ ({}),
+  maxDepth: 5,
+  compactArrayTypes: false,
+  lastValue: false,
+  logKeysContinuously: false,
+  maxExamples: 0,
+};
+
+// These tests exercise the Variety analyzer directly (no MongoDB connection
+// required) and prove the label each deprecated top-level BSON type receives.
+//
+// For BSON Undefined (type 6) and BSON DBPointer (type 12), the bson library
+// used by the MongoDB Node.js driver cannot serialize these types from modern
+// JavaScript values: the library drops `undefined`-valued fields on
+// serialization, and there is no DBPointer constructor. Modern MongoDB 8.x
+// servers also reject type-6 and type-12 on insert. Integration tests via
+// MongoDB are therefore not feasible for these two types; the tests here
+// exercise the Variety analyzer with the values that mongosh returns when
+// deserializing legacy documents that contain these types.
+describe('Deprecated top-level BSON types', () => {
+
+  // BSON type 6: Undefined
+  // The bson library deserializes a stored type-6 value as JavaScript
+  // `undefined`. The Variety analyzer checks `typeof thing === 'undefined'`
+  // first and returns the label `'undefined'`.
+  it('should label BSON Undefined (type 6) as "undefined"', () => {
+    const result = impl.varietyTypeOf(config, undefined);
+    assert.equal(result, 'undefined');
+  });
+
+  // BSON type 12: DBPointer
+  // The bson library maps a stored type-12 value to a DBRef object (the same
+  // wrapper used for the DBRef document convention, which is a plain
+  // Object/type-3). Variety reports type-12-sourced values as `'DBRef'` — a
+  // broader, driver-facing label shared with the DBRef convention.
+  it('should label BSON DBPointer (type 12) as "DBRef" (via driver DBRef mapping)', () => {
+    const dbPointerAsDBRef = new DBRef('legacy', new ObjectId('aabbccddaabbccddaabbccdd'), 'testdb');
+    const result = impl.varietyTypeOf(config, dbPointerAsDBRef);
+    assert.equal(result, 'DBRef');
+  });
+
+  // BSON type 14: Symbol
+  // Mongosh promotes a stored type-14 value to a plain JavaScript string, so
+  // Variety reports `'String'` — a broader, merged label — in the end-to-end
+  // pipeline. This is confirmed by the integration test in
+  // DatatypeRecognitionTest.js (key_symbol).
+  //
+  // The analyzer also has a `BSONSymbol → 'BSONSymbol'` mapping. That path is
+  // exercised when the value arrives as a BSONSymbol object rather than a
+  // promoted string (e.g., when Variety is used programmatically via the Node.js
+  // driver with promoteValues: false).
+  it('should label a BSONSymbol object as "BSONSymbol" (Node.js driver path)', () => {
+    const result = impl.varietyTypeOf(config, new BSONSymbol('mysymbol'));
+    assert.equal(result, 'BSONSymbol');
+  });
+
+  it('should label mongosh-promoted BSON Symbol (type 14) as "String"', () => {
+    // Mongosh promotes type-14 to a plain JavaScript string before passing it
+    // to the Variety analyzer running inside the shell.
+    const result = impl.varietyTypeOf(config, 'mysymbol');
+    assert.equal(result, 'String');
+  });
+
+  // BSON type 15: JavaScript code with scope
+  // Mongosh deserializes a stored type-15 value as a Code object with a scope
+  // property. Variety reports `'Code'`. See also the integration-level
+  // assertion in DatatypeRecognitionTest.js (key_code).
+  it('should label JavaScript code with scope (type 15) as "Code"', () => {
+    const result = impl.varietyTypeOf(config, new Code('function() { return n; }', { n: 1 }));
+    assert.equal(result, 'Code');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Adds `test/cases/analysis/DeprecatedBsonTypesTest.js` — a new unit test file proving the Variety label for each of the four deprecated top-level BSON types (Undefined/6, DBPointer/12, Symbol/14, JavaScript code with scope/15).
- Extends `test/cases/analysis/DatatypeRecognitionTest.js` with a `key_symbol` (BSON type 14) integration test that confirms mongosh promotes type-14 to a plain string, so Variety reports `'String'`.

### Variety labels confirmed by this change

| BSON type | Code | Variety label (via mongosh) | How covered |
|---|---|---|---|
| Undefined | 6 | `'undefined'` | Unit test (MongoDB 8.x cannot store type-6) |
| DBPointer | 12 | `'DBRef'` (bson library maps type-12 → DBRef) | Unit test (MongoDB 8.x cannot store type-12) |
| Symbol | 14 | `'String'` (mongosh promotes type-14 to plain string) | Integration test (key_symbol in DatatypeRecognitionTest.js) |
| JS code with scope | 15 | `'Code'` | Integration test (key_code, pre-existing) + unit test |

## Test plan

- [x] Unit tests in `DeprecatedBsonTypesTest.js`: 5 tests, all passing
- [x] Integration test in `DatatypeRecognitionTest.js` (key_symbol assertion): passes — mongosh reports `String` for BSON type 14
- [x] Full test suite in `localhost/variety:1.5.2-mongodb8.2-nodejs22` container: **69 passing**
- [x] Markdown linting: no errors
- [x] ESLint on new and modified test files: no errors
- [x] SPDX header check: all files pass

### Container test run output (summary)

```
69 passing (18s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)