### PR TITLE
Expose all variety.js options via the first-party CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,11 @@ Passing an unrecognised value throws an error listing the valid options.
 
 A plugin is a `.js` file that exports a plain object with lifecycle hooks. Load one with the `plugins` option (comma-separated for multiple):
 
-    $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-plugin.js'" variety.js
+    $ variety test/users --plugins /path/to/my-plugin.js --quiet
 
 Pass per-plugin configuration by appending `|key=value` after the path:
 
-    $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-plugin.js|delimiter=;'" variety.js
+    $ variety test/users --plugins '/path/to/my-plugin.js|delimiter=;' --quiet
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full hook reference and a guide to writing and testing plugins.
 
@@ -269,16 +269,16 @@ Variety can also read that option and mute unnecessary output. This is useful in
     $ mongosh test --quiet --eval "var collection = 'users', outputFormat='json', sort = { updated_at : -1 }" variety.js
 
 ### Log Keys and Types As They Arrive Option
-Sometimes you want to see the keys and types come in as it happens.  Maybe you have a large dataset and want accurate results, but you also are impatient and want to see something now.  Or maybe you have a large mangled dataset with crazy keys (that probably shouldn't be keys) and Variety is going out of memory.  This option will show you the keys and types as they come in and help you identify problems with your dataset without needing the Variety script to finish.  
+Sometimes you want to see the keys and types come in as it happens.  Maybe you have a large dataset and want accurate results, but you also are impatient and want to see something now.  Or maybe you have a large mangled dataset with crazy keys (that probably shouldn't be keys) and Variety is going out of memory.  This option will show you the keys and types as they come in and help you identify problems with your dataset without needing the Variety script to finish.
 
-    $ mongosh test --eval "var collection = 'users', sort = { updated_at : -1 }, logKeysContinuously = true" variety.js
+    $ variety test/users --logKeysContinuously
 
 ### Exclude Subkeys
-Sometimes you inherit a database full of junk.  Maybe the previous developer put data in the database keys, which causes Variety to go out of memory when run.  After you've run the `logKeysContinuously` to figure out which subkeys may be a problem, you can use this option to run Variety without those subkeys.  
+Sometimes you inherit a database full of junk.  Maybe the previous developer put data in the database keys, which causes Variety to go out of memory when run.  After you've run the `logKeysContinuously` to figure out which subkeys may be a problem, you can use this option to run Variety without those subkeys.
 
     db.users.insertOne({name:"Walter", someNestedObject:{a:{b:{c:{d:{e:1}}}}}, otherNestedObject:{a:{b:{c:{d:{e:1}}}}}});
 
-    $ mongosh test --eval "var collection = 'users', sort = { updated_at : -1 }, excludeSubkeys = [ 'someNestedObject.a.b' ]" variety.js
+    $ variety test/users --excludeSubkeys '["someNestedObject.a.b"]'
 
     +-----------------------------------------------------------------+
     | key                         | types    | occurrences | percents |
@@ -300,7 +300,7 @@ Sometimes you inherit a database full of junk.  Maybe the previous developer put
 
 By default, Variety suppresses keys that end with an array index (e.g. `tags.XX`), because the parent key already captures the `Array` type. If you want to see the types of the values _inside_ primitive arrays — useful for verifying element-type consistency — set `showArrayElements` to `true`:
 
-    $ mongosh test --eval "var collection = 'users', showArrayElements = true" variety.js
+    $ variety test/users --showArrayElements
 
 For example, given documents like:
 
@@ -324,7 +324,7 @@ This reveals that `tags` contains mixed element types across the collection.
 
 If you want the parent array key itself to carry a more informative summary than plain `Array`, set `compactArrayTypes` to `true`:
 
-    $ mongosh test --eval "var collection = 'users', compactArrayTypes = true" variety.js
+    $ variety test/users --compactArrayTypes
 
 With this option enabled, parent keys can be reported as values such as `Array(String)`, `Array(Number|String)`, or `Array(empty)` instead of just `Array`.
 
@@ -336,30 +336,32 @@ _Thanks to [@oufeng](https://github.com/oufeng) for suggesting this feature ([#1
 Analyzing a large collection on a busy replica set primary could take a lot longer than if you read from a secondary. To do so, we have to tell MongoDB it's okay to perform secondary reads
 by setting the `slaveOk` property to `true`:
 
-    $ mongosh secondary.replicaset.member:31337/somedb --eval "var collection = 'users', slaveOk = true" variety.js
+    $ variety somedb/users --host secondary.replicaset.member --port 31337 --slaveOk
 
 ## Save Results in MongoDB For Future Use
 By default, Variety prints results only to standard output and does not store them in MongoDB itself. If you want to persist them automatically in MongoDB for later usage, you can set the `persistResults` parameter.
 Variety then stores result documents in the `varietyResults` database, and the collection name is derived from the source collection's name.
 If the source collection's name is `users`, Variety stores results in the `usersKeys` collection under the `varietyResults` database.
 
-    $ mongosh test --quiet --eval "var collection = 'users', persistResults=true" variety.js
+    $ variety test/users --persistResults --quiet
 
-To persist to an alternate MongoDB database, you may specify the following parameters:
+To persist to an alternate MongoDB database, pass the result destination flags directly:
 
-- `resultsDatabase` - The database to store Variety results in. Accepts either a database name or a `host[:port]/database` URL.
-- `resultsCollection` - Collection to store Variety results in. **WARNING:** This collection is dropped before results are inserted.
-- `resultsUser` - MongoDB username for results database
-- `resultsPass` - MongoDB password for results database
-
+```bash
+variety test/users --persistResults --resultsDatabase db.example.com/variety --quiet
 ```
-$ mongosh test --quiet --eval "var collection = 'users', persistResults=true, resultsDatabase='db.example.com/variety'" variety.js
-```
+
+The full set of result persistence options:
+
+- `--resultsDatabase` — target database name or `host[:port]/database` URL
+- `--resultsCollection` — target collection (**WARNING:** this collection is dropped before results are inserted)
+- `--resultsUser` — MongoDB username for the results database
+- `--resultsPass` — MongoDB password for the results database
 
 ## Reserved Keys
 Variety expects keys to be well formed, not having any `.`s in them (MongoDB 2.4 allows dots in certain cases).  Also MongoDB uses the pseudo keys `XX` and keys corresponding to the regex `XX\d+XX.*` for use with arrays.  You can change the string `XX` in these patterns to whatever you like if there is a conflict in your database using the `arrayEscape` parameter.  
 
-    $ mongosh test --quiet --eval "var collection = 'users', arrayEscape = 'YY'" variety.js
+    $ variety test/users --arrayEscape YY
 
 ## Command Line Interface
 This NPM package publishes a built-in `variety` executable that resolves the bundled `variety.js`, prefers `mongosh` when available, and falls back to the legacy `mongo` shell.
@@ -409,7 +411,42 @@ First-class MongoDB URI support in the built-in CLI is being discussed in
 [@YNX940214](https://github.com/YNX940214)
 ([#152](https://github.com/variety/variety/issues/152)).
 
-Structured flags such as `--query` and `--sort` accept strict JSON. Connection flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationDatabase`, and `--quiet` are passed through to the Mongo shell. `--eval` remains available as an escape hatch when you need to append raw JavaScript assignments.
+All Variety-specific options are available directly as CLI flags. Structured flags such as `--query`, `--sort`, and `--excludeSubkeys` accept strict JSON. Connection flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationDatabase`, and `--quiet` are passed through to the Mongo shell. `--eval` remains available as an escape hatch when you need to append raw JavaScript assignments.
+
+#### Available flags
+
+| Flag | Type | Description |
+| --- | --- | --- |
+| `--query <json>` | JSON object | Filter documents analyzed |
+| `--sort <json>` | JSON object | Sort order for analyzed documents |
+| `--limit <number>` | integer ≥ 0 | Limit documents analyzed |
+| `--maxDepth <number>` | integer ≥ 0 | Maximum traversal depth |
+| `--maxExamples <number>` | integer ≥ 0 | Example values to collect per key |
+| `--lastValue` | boolean | Capture one representative value per key |
+| `--outputFormat <value>` | string | Output format: `ascii` (default) or `json` |
+| `--showArrayElements` | boolean | Include `tags.XX`-style keys in output |
+| `--compactArrayTypes` | boolean | Render `Array(Type)` instead of plain `Array` |
+| `--arrayEscape <value>` | string | Custom escape for array index keys (default `XX`) |
+| `--excludeSubkeys <json>` | JSON array | Dot-paths to skip (e.g. `'["a.b","c.d"]'`) |
+| `--logKeysContinuously` | boolean | Stream keys as they arrive |
+| `--slaveOk` | boolean | Allow secondary reads on a replica set |
+| `--plugins <path>` | string | Path to a plugin file; comma-separated for multiple |
+| `--persistResults` | boolean | Write results to MongoDB |
+| `--resultsDatabase <value>` | string | Target DB for persisted results |
+| `--resultsCollection <value>` | string | Target collection for persisted results |
+| `--resultsUser <value>` | string | MongoDB username for results database |
+| `--resultsPass <value>` | string | MongoDB password for results database |
+| `--quiet` | boolean | Pass `--quiet` through to the Mongo shell |
+| `--host <value>` | string | Mongo shell host |
+| `--port <number>` | integer ≥ 1 | Mongo shell port |
+| `--username <value>` | string | MongoDB username |
+| `--password <value>` | string | MongoDB password |
+| `--authenticationDatabase <value>` | string | Authentication database |
+| `--eval <javascript>` | string | Extra JavaScript appended after CLI assignments |
+| `--help` | — | Show usage |
+| `--version` | — | Show the Variety package version |
+
+Kebab-case aliases (e.g. `--output-format`, `--max-depth`, `--show-array-elements`) are accepted for all multi-word flags.
 
 When you invoke `variety` with no CLI arguments, the documented compatibility environment variables remain supported:
 

--- a/cli/options.js
+++ b/cli/options.js
@@ -17,11 +17,24 @@ const path = require('path');
 
 /**
  * @typedef {{
+ *   arrayEscape?: string,
+ *   compactArrayTypes?: boolean,
+ *   excludeSubkeys?: unknown[],
+ *   lastValue?: boolean,
  *   limit?: number,
+ *   logKeysContinuously?: boolean,
  *   maxDepth?: number,
  *   maxExamples?: number,
  *   outputFormat?: string,
+ *   persistResults?: boolean,
+ *   plugins?: string,
  *   query?: Record<string, unknown>,
+ *   resultsCollection?: string,
+ *   resultsDatabase?: string,
+ *   resultsPass?: string,
+ *   resultsUser?: string,
+ *   showArrayElements?: boolean,
+ *   slaveOk?: boolean,
  *   sort?: Record<string, unknown>,
  * }} VarietyOptions
  */
@@ -80,13 +93,45 @@ class CliUsageError extends Error {
 
 const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
 /** @type {Array<keyof VarietyOptions>} */
-const TARGET_OPTION_NAMES = ['query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples'];
+const TARGET_OPTION_NAMES = [
+  'query',
+  'sort',
+  'limit',
+  'maxDepth',
+  'outputFormat',
+  'maxExamples',
+  'lastValue',
+  'showArrayElements',
+  'compactArrayTypes',
+  'arrayEscape',
+  'excludeSubkeys',
+  'logKeysContinuously',
+  'slaveOk',
+  'persistResults',
+  'resultsDatabase',
+  'resultsCollection',
+  'resultsUser',
+  'resultsPass',
+  'plugins',
+];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
+  'array-escape': 'arrayEscape',
   'authentication-database': 'authenticationDatabase',
+  'compact-array-types': 'compactArrayTypes',
+  'exclude-subkeys': 'excludeSubkeys',
+  'last-value': 'lastValue',
+  'log-keys-continuously': 'logKeysContinuously',
   'max-depth': 'maxDepth',
   'max-examples': 'maxExamples',
   'output-format': 'outputFormat',
+  'persist-results': 'persistResults',
+  'results-collection': 'resultsCollection',
+  'results-database': 'resultsDatabase',
+  'results-pass': 'resultsPass',
+  'results-user': 'resultsUser',
+  'show-array-elements': 'showArrayElements',
+  'slave-ok': 'slaveOk',
 };
 
 /**
@@ -192,6 +237,29 @@ const parseBooleanValue = (optionName, rawValue) => {
   }
 
   throw new CliUsageError(`--${optionName} accepts only true or false when given a value.`);
+};
+
+/**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {unknown[]}
+ */
+const parseJsonArray = (optionName, rawValue) => {
+  /** @type {unknown} */
+  let parsedValue;
+
+  try {
+    parsedValue = JSON.parse(rawValue);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new CliUsageError(`--${optionName} must be strict JSON. ${errorMessage}`);
+  }
+
+  if (!Array.isArray(parsedValue)) {
+    throw new CliUsageError(`--${optionName} must be a JSON array.`);
+  }
+
+  return parsedValue;
 };
 
 /**
@@ -366,6 +434,66 @@ const parseCliArguments = (argv) => {
       parsed.shellOptions.port = parsePositiveInteger(optionName, result.value);
       break;
     }
+    case 'lastValue':
+      parsed.varietyOptions.lastValue = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'showArrayElements':
+      parsed.varietyOptions.showArrayElements = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'compactArrayTypes':
+      parsed.varietyOptions.compactArrayTypes = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'logKeysContinuously':
+      parsed.varietyOptions.logKeysContinuously = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'slaveOk':
+      parsed.varietyOptions.slaveOk = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'persistResults':
+      parsed.varietyOptions.persistResults = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'arrayEscape': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.arrayEscape = result.value;
+      break;
+    }
+    case 'excludeSubkeys': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.excludeSubkeys = parseJsonArray(optionName, result.value);
+      break;
+    }
+    case 'plugins': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.plugins = result.value;
+      break;
+    }
+    case 'resultsDatabase': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsDatabase = result.value;
+      break;
+    }
+    case 'resultsCollection': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsCollection = result.value;
+      break;
+    }
+    case 'resultsUser': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsUser = result.value;
+      break;
+    }
+    case 'resultsPass': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsPass = result.value;
+      break;
+    }
     case 'eval': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
@@ -486,7 +614,20 @@ const formatUsage = () => {
     '  --limit <number>                 Limit documents analyzed',
     '  --maxDepth <number>              Maximum traversal depth',
     '  --maxExamples <number>           Number of example values to collect per key',
+    '  --lastValue                      Capture one representative value per key',
     '  --outputFormat <value>           Output format, e.g. ascii or json',
+    '  --showArrayElements              Include tags.XX-style keys in output',
+    '  --compactArrayTypes              Render Array(Type) instead of plain Array',
+    '  --arrayEscape <value>            Custom escape for array index conflicts (default XX)',
+    '  --excludeSubkeys <json>          JSON array of dot-paths to skip',
+    '  --logKeysContinuously            Stream keys as they arrive',
+    '  --slaveOk                        Allow secondary reads on a replica set',
+    '  --plugins <path>                 Path to a plugin file (comma-separated for multiple)',
+    '  --persistResults                 Write results to MongoDB',
+    '  --resultsDatabase <value>        Target DB for persisted results',
+    '  --resultsCollection <value>      Target collection for persisted results',
+    '  --resultsUser <value>            MongoDB username for results database',
+    '  --resultsPass <value>            MongoDB password for results database',
     '  --quiet                          Pass --quiet through to the Mongo shell',
     '  --host <value>                   Mongo shell host',
     '  --port <number>                  Mongo shell port',
@@ -509,5 +650,6 @@ module.exports = {
   formatUsage,
   hasCompatibilityEnv,
   parseCliArguments,
+  parseJsonArray,
   stripMatchingOuterQuotes,
 };

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -291,4 +291,72 @@ describe('bin/variety wrapper', () => {
       }
     );
   });
+
+  it('translates new boolean and string variety flags into eval assignments', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'test/users',
+        '--showArrayElements',
+        '--compactArrayTypes',
+        '--lastValue',
+        '--slaveOk',
+        '--arrayEscape', 'YY',
+        '--plugins', '/path/to/plugin.js',
+        '--excludeSubkeys', '["a.b"]',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'test',
+        '--eval',
+        'var collection = "users"; var lastValue = true; var showArrayElements = true; var compactArrayTypes = true; var arrayEscape = "YY"; var excludeSubkeys = ["a.b"]; var slaveOk = true; var plugins = "/path/to/plugin.js"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
+  it('translates result persistence flags into eval assignments', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'test/users',
+        '--persistResults',
+        '--resultsDatabase', 'myResults',
+        '--resultsCollection', 'usersKeys',
+        '--resultsUser', 'writer',
+        '--resultsPass', 'pass123',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'test',
+        '--eval',
+        'var collection = "users"; var persistResults = true; var resultsDatabase = "myResults"; var resultsCollection = "usersKeys"; var resultsUser = "writer"; var resultsPass = "pass123"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
+  it('fails fast on invalid excludeSubkeys input', async () => {
+    await assert.rejects(
+      () => runBinVariety({
+        args: ['test/users', '--excludeSubkeys', '{"not":"an-array"}'],
+      }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 2);
+        assert.match(String(error.stderr || ''), /--excludeSubkeys must be a JSON array/);
+        return true;
+      }
+    );
+  });
 });

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -172,4 +172,112 @@ describe('CLI option parsing', () => {
     assert.match(helpText, /DB=test EVAL_CMDS=/);
     assert.match(helpText, /backwards compatibility/);
   });
+
+  it('includes boolean variety options in the execution plan', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--lastValue',
+      '--showArrayElements',
+      '--compactArrayTypes',
+      '--logKeysContinuously',
+      '--slaveOk',
+      '--persistResults',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'test',
+      evalCode: 'var collection = "users"; var lastValue = true; var showArrayElements = true; var compactArrayTypes = true; var logKeysContinuously = true; var slaveOk = true; var persistResults = true',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+  });
+
+  it('includes string variety options in the execution plan', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--arrayEscape', 'YY',
+      '--plugins', '/path/to/my-plugin.js',
+      '--resultsDatabase', 'variety_results',
+      '--resultsCollection', 'usersKeys',
+      '--resultsUser', 'admin',
+      '--resultsPass', 'secret',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'test',
+      evalCode: 'var collection = "users"; var arrayEscape = "YY"; var resultsDatabase = "variety_results"; var resultsCollection = "usersKeys"; var resultsUser = "admin"; var resultsPass = "secret"; var plugins = "/path/to/my-plugin.js"',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+  });
+
+  it('includes excludeSubkeys JSON array in the execution plan', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--excludeSubkeys', '["someNestedObject.a.b","otherPath"]',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'test',
+      evalCode: 'var collection = "users"; var excludeSubkeys = ["someNestedObject.a.b","otherPath"]',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+  });
+
+  it('throws a usage error for non-array excludeSubkeys input', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan(['test/users', '--excludeSubkeys', '{"key":"value"}'], {});
+      },
+      /--excludeSubkeys must be a JSON array/
+    );
+  });
+
+  it('accepts kebab-case aliases for new options', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--show-array-elements',
+      '--compact-array-types',
+      '--log-keys-continuously',
+      '--slave-ok',
+      '--persist-results',
+      '--array-escape', 'ZZ',
+      '--exclude-subkeys', '["a.b"]',
+      '--last-value',
+      '--results-database', 'mydb',
+      '--results-collection', 'mycol',
+      '--results-user', 'u',
+      '--results-pass', 'p',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'test',
+      evalCode: 'var collection = "users"; var lastValue = true; var showArrayElements = true; var compactArrayTypes = true; var arrayEscape = "ZZ"; var excludeSubkeys = ["a.b"]; var logKeysContinuously = true; var slaveOk = true; var persistResults = true; var resultsDatabase = "mydb"; var resultsCollection = "mycol"; var resultsUser = "u"; var resultsPass = "p"',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {},
+    });
+  });
+
+  it('documents new options in help output', () => {
+    const helpText = formatUsage();
+
+    assert.match(helpText, /--showArrayElements/);
+    assert.match(helpText, /--compactArrayTypes/);
+    assert.match(helpText, /--excludeSubkeys/);
+    assert.match(helpText, /--logKeysContinuously/);
+    assert.match(helpText, /--slaveOk/);
+    assert.match(helpText, /--persistResults/);
+    assert.match(helpText, /--resultsDatabase/);
+    assert.match(helpText, /--resultsCollection/);
+    assert.match(helpText, /--resultsUser/);
+    assert.match(helpText, /--resultsPass/);
+    assert.match(helpText, /--plugins/);
+    assert.match(helpText, /--lastValue/);
+    assert.match(helpText, /--arrayEscape/);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the 12-option parity gap identified in issue #232 (@JamesCropcho).

The `bin/variety` CLI previously exposed only 6 of Variety's 18 configurable options. This PR adds the remaining 13 options (including `--plugins`) so that everything available via raw `mongosh ... variety.js` is now reachable through `variety DB/COLLECTION [options]`.

### New flags

- `--lastValue` — capture one representative value per key
- `--showArrayElements` — include `tags.XX`-style keys in output
- `--compactArrayTypes` — render `Array(Type)` instead of plain `Array`
- `--arrayEscape <value>` — custom escape for array index keys (default `XX`)
- `--excludeSubkeys <json>` — JSON array of dot-paths to skip
- `--logKeysContinuously` — stream keys as they arrive
- `--slaveOk` — allow secondary reads on a replica set
- `--plugins <path>` — load a plugin file (comma-separated for multiple)
- `--persistResults` — write results to MongoDB
- `--resultsDatabase <value>` — target DB for persisted results
- `--resultsCollection <value>` — target collection for persisted results
- `--resultsUser <value>` — MongoDB username for results database
- `--resultsPass <value>` — MongoDB password for results database

Kebab-case aliases (e.g. `--show-array-elements`, `--exclude-subkeys`) are accepted for all multi-word flags. `--excludeSubkeys` expects a strict JSON array.

### Documentation

README updated to use `variety DB/COLLECTION` as the primary example throughout all relevant option sections. A complete flag reference table has been added to the CLI section.

### Tests

CLI test suite expanded from 20 to 29 tests covering all new flags, kebab aliases, and `--excludeSubkeys` validation.

## Test plan

- [x] All 29 CLI unit tests pass (`mocha test/cases/cli/BinWrapperTest.js test/cases/cli/CliOptionsTest.js`)
- [x] ESLint, TypeScript checkJs, markdownlint, SPDX, build-verify all clean
- [x] Docker-backed integration suite runs via `npm run test:container` in CI

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)