### PR TITLE
Expose array and streaming flags in bin/variety CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,20 @@ Sometimes you want to see the keys and types come in as it happens.  Maybe you h
 
     $ mongosh test --eval "var collection = 'users', sort = { updated_at : -1 }, logKeysContinuously = true" variety.js
 
+Via the first-party CLI:
+
+    $ variety test/users --sort '{"updated_at":-1}' --log-keys-continuously
+
 ### Exclude Subkeys
 Sometimes you inherit a database full of junk.  Maybe the previous developer put data in the database keys, which causes Variety to go out of memory when run.  After you've run the `logKeysContinuously` to figure out which subkeys may be a problem, you can use this option to run Variety without those subkeys.  
 
     db.users.insertOne({name:"Walter", someNestedObject:{a:{b:{c:{d:{e:1}}}}}, otherNestedObject:{a:{b:{c:{d:{e:1}}}}}});
 
     $ mongosh test --eval "var collection = 'users', sort = { updated_at : -1 }, excludeSubkeys = [ 'someNestedObject.a.b' ]" variety.js
+
+Via the first-party CLI (repeat `--exclude-subkeys` for multiple paths):
+
+    $ variety test/users --sort '{"updated_at":-1}' --exclude-subkeys someNestedObject.a.b
 
     +-----------------------------------------------------------------+
     | key                         | types    | occurrences | percents |
@@ -301,6 +309,10 @@ Sometimes you inherit a database full of junk.  Maybe the previous developer put
 By default, Variety suppresses keys that end with an array index (e.g. `tags.XX`), because the parent key already captures the `Array` type. If you want to see the types of the values _inside_ primitive arrays — useful for verifying element-type consistency — set `showArrayElements` to `true`:
 
     $ mongosh test --eval "var collection = 'users', showArrayElements = true" variety.js
+
+Via the first-party CLI:
+
+    $ variety test/users --show-array-elements
 
 For example, given documents like:
 
@@ -325,6 +337,10 @@ This reveals that `tags` contains mixed element types across the collection.
 If you want the parent array key itself to carry a more informative summary than plain `Array`, set `compactArrayTypes` to `true`:
 
     $ mongosh test --eval "var collection = 'users', compactArrayTypes = true" variety.js
+
+Via the first-party CLI:
+
+    $ variety test/users --compact-array-types
 
 With this option enabled, parent keys can be reported as values such as `Array(String)`, `Array(Number|String)`, or `Array(empty)` instead of just `Array`.
 
@@ -360,6 +376,10 @@ $ mongosh test --quiet --eval "var collection = 'users', persistResults=true, re
 Variety expects keys to be well formed, not having any `.`s in them (MongoDB 2.4 allows dots in certain cases).  Also MongoDB uses the pseudo keys `XX` and keys corresponding to the regex `XX\d+XX.*` for use with arrays.  You can change the string `XX` in these patterns to whatever you like if there is a conflict in your database using the `arrayEscape` parameter.  
 
     $ mongosh test --quiet --eval "var collection = 'users', arrayEscape = 'YY'" variety.js
+
+Via the first-party CLI:
+
+    $ variety test/users --array-escape YY
 
 ## Command Line Interface
 This NPM package publishes a built-in `variety` executable that resolves the bundled `variety.js`, prefers `mongosh` when available, and falls back to the legacy `mongo` shell.

--- a/cli/options.js
+++ b/cli/options.js
@@ -17,11 +17,16 @@ const path = require('path');
 
 /**
  * @typedef {{
+ *   arrayEscape?: string,
+ *   compactArrayTypes?: boolean,
+ *   excludeSubkeys?: string[],
  *   limit?: number,
+ *   logKeysContinuously?: boolean,
  *   maxDepth?: number,
  *   maxExamples?: number,
  *   outputFormat?: string,
  *   query?: Record<string, unknown>,
+ *   showArrayElements?: boolean,
  *   sort?: Record<string, unknown>,
  * }} VarietyOptions
  */
@@ -80,13 +85,21 @@ class CliUsageError extends Error {
 
 const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
 /** @type {Array<keyof VarietyOptions>} */
-const TARGET_OPTION_NAMES = ['query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples'];
+const TARGET_OPTION_NAMES = [
+  'query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples',
+  'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
+];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
+  'array-escape': 'arrayEscape',
   'authentication-database': 'authenticationDatabase',
+  'compact-array-types': 'compactArrayTypes',
+  'exclude-subkeys': 'excludeSubkeys',
+  'log-keys-continuously': 'logKeysContinuously',
   'max-depth': 'maxDepth',
   'max-examples': 'maxExamples',
   'output-format': 'outputFormat',
+  'show-array-elements': 'showArrayElements',
 };
 
 /**
@@ -218,6 +231,19 @@ const parseJsonObject = (optionName, rawValue) => {
 };
 
 /**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {string}
+ */
+const parseNonEmptyString = (optionName, rawValue) => {
+  if (rawValue.length === 0) {
+    throw new CliUsageError(`--${optionName} must not be empty.`);
+  }
+
+  return rawValue;
+};
+
+/**
  * @param {string[]} argv
  * @param {number} currentIndex
  * @param {string | undefined} inlineValue
@@ -334,6 +360,30 @@ const parseCliArguments = (argv) => {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
       parsed.varietyOptions.outputFormat = result.value;
+      break;
+    }
+    case 'showArrayElements':
+      parsed.varietyOptions.showArrayElements = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'compactArrayTypes':
+      parsed.varietyOptions.compactArrayTypes = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'logKeysContinuously':
+      parsed.varietyOptions.logKeysContinuously = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'arrayEscape': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.arrayEscape = parseNonEmptyString(optionName, result.value);
+      break;
+    }
+    case 'excludeSubkeys': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      if (!parsed.varietyOptions.excludeSubkeys) {
+        parsed.varietyOptions.excludeSubkeys = [];
+      }
+      parsed.varietyOptions.excludeSubkeys.push(result.value);
       break;
     }
     case 'host': {
@@ -487,6 +537,11 @@ const formatUsage = () => {
     '  --maxDepth <number>              Maximum traversal depth',
     '  --maxExamples <number>           Number of example values to collect per key',
     '  --outputFormat <value>           Output format, e.g. ascii or json',
+    '  --showArrayElements              Include array element keys in output',
+    '  --compactArrayTypes              Render Array(Type) instead of plain Array',
+    '  --arrayEscape <value>            Custom escape for array index keys (default XX)',
+    '  --excludeSubkeys <path>          Dot-path to skip; repeat to exclude multiple',
+    '  --logKeysContinuously            Stream keys as they arrive',
     '  --quiet                          Pass --quiet through to the Mongo shell',
     '  --host <value>                   Mongo shell host',
     '  --port <number>                  Mongo shell port',

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -278,6 +278,33 @@ describe('bin/variety wrapper', () => {
     assert.equal(stderr, '');
   });
 
+  it('passes array analysis flags through to the mongosh eval arg', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'testdb/events',
+        '--show-array-elements',
+        '--compact-array-types',
+        '--array-escape', 'YY',
+        '--exclude-subkeys', 'meta.tags',
+        '--exclude-subkeys', 'audit.log',
+        '--log-keys-continuously',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "events"; var showArrayElements = true; var compactArrayTypes = true; var arrayEscape = "YY"; var excludeSubkeys = ["meta.tags","audit.log"]; var logKeysContinuously = true',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('fails fast on invalid JSON query input', async () => {
     await assert.rejects(
       () => runBinVariety({

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -24,6 +24,17 @@ const { buildShellInvocation } = mongoShellModule;
 
 const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
 
+/**
+ * @param {unknown} plan
+ * @returns {string}
+ */
+const evalCodeOf = (plan) => {
+  if (!plan || typeof plan !== 'object' || !('evalCode' in plan) || typeof plan['evalCode'] !== 'string') {
+    throw new Error('Expected a runnable execution plan');
+  }
+  return plan['evalCode'];
+};
+
 describe('CLI option parsing', () => {
   it('builds a CLI execution plan with bundled variety.js by default', () => {
     const plan = createExecutionPlan([
@@ -171,5 +182,60 @@ describe('CLI option parsing', () => {
     assert.match(helpText, /variety DB\/COLLECTION \[options\]/);
     assert.match(helpText, /DB=test EVAL_CMDS=/);
     assert.match(helpText, /backwards compatibility/);
+  });
+
+  it('emits showArrayElements when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/users', '--show-array-elements'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var showArrayElements = true');
+  });
+
+  it('emits compactArrayTypes when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/users', '--compact-array-types'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var compactArrayTypes = true');
+  });
+
+  it('emits logKeysContinuously when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/users', '--log-keys-continuously'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var logKeysContinuously = true');
+  });
+
+  it('accepts camelCase boolean flag names as well as kebab aliases', () => {
+    const kebab = createExecutionPlan(['test/users', '--show-array-elements=false'], {});
+    const camel = createExecutionPlan(['test/users', '--showArrayElements=false'], {});
+    assert.equal(evalCodeOf(kebab), evalCodeOf(camel));
+    assert.equal(evalCodeOf(kebab), 'var collection = "users"; var showArrayElements = false');
+  });
+
+  it('emits arrayEscape with the supplied value', () => {
+    const plan = createExecutionPlan(['test/users', '--array-escape', 'YY'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var arrayEscape = "YY"');
+  });
+
+  it('rejects an empty --arrayEscape value', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan(['test/users', '--array-escape', ''], {});
+      },
+      /--arrayEscape must not be empty/
+    );
+  });
+
+  it('accumulates a single --exclude-subkeys path', () => {
+    const plan = createExecutionPlan(['test/users', '--exclude-subkeys', 'meta.tags'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var excludeSubkeys = ["meta.tags"]');
+  });
+
+  it('accumulates multiple --exclude-subkeys paths via repetition', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--exclude-subkeys', 'meta.tags',
+      '--exclude-subkeys', 'audit.log',
+    ], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var excludeSubkeys = ["meta.tags","audit.log"]');
+  });
+
+  it('omits excludeSubkeys from eval when the flag is not passed', () => {
+    const plan = createExecutionPlan(['test/users'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"');
   });
 });


### PR DESCRIPTION
## Summary

Part of #232 (PR1 of 3).

Adds five `variety.js` options that were previously unreachable through the `bin/variety` CLI:

- `--show-array-elements` / `--showArrayElements` — include `tags.XX`-style array element keys in output
- `--compact-array-types` / `--compactArrayTypes` — render `Array(Type)` instead of plain `Array`
- `--array-escape <value>` / `--arrayEscape` — custom escape sequence for array index keys (default `XX`); rejects empty string
- `--exclude-subkeys <path>` / `--excludeSubkeys` — dot-path to skip during analysis; **repeatable**: pass multiple times to build an array (`--exclude-subkeys a --exclude-subkeys b` → `var excludeSubkeys = ["a","b"]`)
- `--log-keys-continuously` / `--logKeysContinuously` — stream keys as they arrive rather than waiting for full completion

Kebab-case aliases are registered in `FLAG_ALIASES` for all multi-word flags. `--excludeSubkeys` is omitted from the eval string entirely when not supplied, preserving the `variety.js` default.

Not included in this PR: `--slaveOk` (tracked separately in #309 as a deprecation concern) and the persistence/plugin options (PR2 and PR3 of this series).

### Documentation

README updated: each of the five affected sections now shows a "Via the first-party CLI:" example alongside the existing `mongosh` invocation, following the pattern established by the `maxExamples` section.

## Test plan

- [x] 30 CLI unit tests pass (was 20) — new tests cover each flag, kebab aliases, `--arrayEscape` empty-string rejection, and `--exclude-subkeys` single/multiple/omitted cases
- [x] New `BinWrapperTest` covers all five flags flowing through to the mongosh `--eval` arg
- [x] Added `evalCodeOf()` narrowing helper to `CliOptionsTest.js` for type-safe `evalCode` access
- [x] All pre-commit hooks pass (ESLint, tsc checkJs, markdownlint, SPDX, build-verify, shellcheck, hadolint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)