### PR TITLE
Expose result-persistence flags in bin/variety CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,10 @@ If the source collection's name is `users`, Variety stores results in the `users
 
     $ mongosh test --quiet --eval "var collection = 'users', persistResults=true" variety.js
 
+Via the first-party CLI:
+
+    $ variety test/users --quiet --persist-results
+
 To persist to an alternate MongoDB database, you may specify the following parameters:
 
 - `resultsDatabase` - The database to store Variety results in. Accepts either a database name or a `host[:port]/database` URL.
@@ -370,6 +374,12 @@ To persist to an alternate MongoDB database, you may specify the following param
 
 ```
 $ mongosh test --quiet --eval "var collection = 'users', persistResults=true, resultsDatabase='db.example.com/variety'" variety.js
+```
+
+Via the first-party CLI:
+
+```bash
+variety test/users --quiet --persist-results --results-database db.example.com/variety --results-collection myKeys --results-user reporter --results-password secret
 ```
 
 ## Reserved Keys

--- a/cli/options.js
+++ b/cli/options.js
@@ -25,7 +25,12 @@ const path = require('path');
  *   maxDepth?: number,
  *   maxExamples?: number,
  *   outputFormat?: string,
+ *   persistResults?: boolean,
  *   query?: Record<string, unknown>,
+ *   resultsCollection?: string,
+ *   resultsDatabase?: string,
+ *   resultsPass?: string,
+ *   resultsUser?: string,
  *   showArrayElements?: boolean,
  *   sort?: Record<string, unknown>,
  * }} VarietyOptions
@@ -88,6 +93,7 @@ const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
 const TARGET_OPTION_NAMES = [
   'query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples',
   'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
+  'persistResults', 'resultsDatabase', 'resultsCollection', 'resultsUser', 'resultsPass',
 ];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
@@ -99,6 +105,11 @@ const FLAG_ALIASES = {
   'max-depth': 'maxDepth',
   'max-examples': 'maxExamples',
   'output-format': 'outputFormat',
+  'persist-results': 'persistResults',
+  'results-collection': 'resultsCollection',
+  'results-database': 'resultsDatabase',
+  'results-password': 'resultsPass',
+  'results-user': 'resultsUser',
   'show-array-elements': 'showArrayElements',
 };
 
@@ -371,6 +382,33 @@ const parseCliArguments = (argv) => {
     case 'logKeysContinuously':
       parsed.varietyOptions.logKeysContinuously = parseBooleanValue(optionName, inlineValue);
       break;
+    case 'persistResults':
+      parsed.varietyOptions.persistResults = parseBooleanValue(optionName, inlineValue);
+      break;
+    case 'resultsDatabase': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsDatabase = result.value;
+      break;
+    }
+    case 'resultsCollection': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsCollection = result.value;
+      break;
+    }
+    case 'resultsUser': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsUser = result.value;
+      break;
+    }
+    case 'resultsPass': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.varietyOptions.resultsPass = result.value;
+      break;
+    }
     case 'arrayEscape': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
@@ -542,6 +580,11 @@ const formatUsage = () => {
     '  --arrayEscape <value>            Custom escape for array index keys (default XX)',
     '  --excludeSubkeys <path>          Dot-path to skip; repeat to exclude multiple',
     '  --logKeysContinuously            Stream keys as they arrive',
+    '  --persistResults                 Write results to MongoDB instead of stdout',
+    '  --resultsDatabase <value>        Target DB for persisted results (name or host:port/db)',
+    '  --resultsCollection <value>      Target collection for persisted results',
+    '  --results-user <value>           MongoDB username for results database',
+    '  --results-password <value>       MongoDB password for results database',
     '  --quiet                          Pass --quiet through to the Mongo shell',
     '  --host <value>                   Mongo shell host',
     '  --port <number>                  Mongo shell port',

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -305,6 +305,32 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes persistence flags through to the mongosh eval arg', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'testdb/orders',
+        '--persist-results',
+        '--results-database', 'db.example.com/variety',
+        '--results-collection', 'orderKeys',
+        '--results-user', 'reporter',
+        '--results-password', 'secret',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "orders"; var persistResults = true; var resultsDatabase = "db.example.com/variety"; var resultsCollection = "orderKeys"; var resultsUser = "reporter"; var resultsPass = "secret"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('fails fast on invalid JSON query input', async () => {
     await assert.rejects(
       () => runBinVariety({

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -238,4 +238,34 @@ describe('CLI option parsing', () => {
     const plan = createExecutionPlan(['test/users'], {});
     assert.equal(evalCodeOf(plan), 'var collection = "users"');
   });
+
+  it('emits persistResults when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/users', '--persist-results'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var persistResults = true');
+  });
+
+  it('emits all persistence options together', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--persist-results',
+      '--results-database', 'db.example.com/variety',
+      '--results-collection', 'myKeys',
+      '--results-user', 'reporter',
+      '--results-password', 'secret',
+    ], {});
+    assert.equal(
+      evalCodeOf(plan),
+      'var collection = "users"; var persistResults = true; var resultsDatabase = "db.example.com/variety"; var resultsCollection = "myKeys"; var resultsUser = "reporter"; var resultsPass = "secret"'
+    );
+  });
+
+  it('emits resultsDatabase alone without requiring persistResults', () => {
+    const plan = createExecutionPlan(['test/users', '--resultsDatabase', 'mydb'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var resultsDatabase = "mydb"');
+  });
+
+  it('maps --results-password to var resultsPass', () => {
+    const plan = createExecutionPlan(['test/users', '--results-password', 'hunter2'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var resultsPass = "hunter2"');
+  });
 });


### PR DESCRIPTION
## Summary

Part of #232 (PR2 of 3). Stacked on #311 — base branch is `cli-parity-pr1-simple-flags`.

Adds the five result-persistence options that were previously unreachable through the `bin/variety` CLI:

- `--persist-results` / `--persistResults` — write results to MongoDB instead of stdout
- `--results-database` / `--resultsDatabase` — target DB (plain name or `host:port/db` URL)
- `--results-collection` / `--resultsCollection` — target collection
- `--results-user` / `--resultsUser` — MongoDB username for results database
- `--results-password` — MongoDB password for results database (maps to `var resultsPass`)

`--results-password` uses the full word for consistency with the existing `--password` flag; it maps to variety.js's `resultsPass` variable via `FLAG_ALIASES`. All five flags are omitted from the eval string when not supplied, preserving variety.js defaults.

### Documentation

README "Save Results in MongoDB For Future Use" section now shows "Via the first-party CLI:" examples for both the basic `--persist-results` case and the full alternate-database form.

## Test plan

- [x] 35 CLI unit/integration tests pass (was 30)
- [x] New unit tests cover: `persistResults` alone, full cluster together, `resultsDatabase` in isolation, `--results-password` → `resultsPass` mapping
- [x] New `BinWrapperTest` verifies all five flags flow through to the mongosh `--eval` arg
- [x] All pre-commit hooks pass (ESLint, tsc checkJs, markdownlint, SPDX, build-verify, shellcheck, hadolint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)