### PR TITLE
Skip pre-commit tooling checks when package.json is absent

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# gh-pages branch has no npm project — nothing to lint.
+if [ ! -f package.json ]; then
+  echo "→ No package.json — skipping all tooling checks"
+  exit 0
+fi
+
 # If every staged change is a modification (not add/delete) to an existing .md
 # file, skip the non-Markdown checks — they have nothing to verify.
 staged=$(git diff --cached --name-status)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ Variety keeps its repository checks split into a few layers so it is clear which
 
 Pre-commit hooks are managed by [Husky](https://typicode.github.io/husky/) and installed automatically on `npm install`. Each commit is blocked if any applicable check fails.
 
+If no `package.json` is present in the working tree (e.g. on the `gh-pages` branch), all tooling checks are skipped automatically.
+
 If every staged change is a modification to an existing `.md` file (no new or deleted files), only `npm run lint:markdown` runs — all other checks are skipped as they have nothing to verify.
 
 Otherwise all of the following run:


### PR DESCRIPTION
## Summary

- Adds an early-exit guard to `.husky/pre-commit`: if no `package.json` exists in the working tree, all tooling checks are skipped. This is needed by the new `gh-pages` branch, which is a bare HTML redirect with no npm project.
- Documents this behaviour in `CONTRIBUTING.md` under the Pre-commit Hooks section.

## Context

Fixes the pre-commit hook so commits to the `gh-pages` branch (added as part of resolving #251) don't fail every check with `ENOENT: package.json not found`.

## Test plan

- [ ] Commit a change on the `gh-pages` branch and confirm the hook prints `→ No package.json — skipping all tooling checks` and exits 0
- [ ] Commit a change on `main` and confirm all checks still run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)