### PR TITLE
Expose --plugin flag in bin/variety CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,21 @@ A plugin is a `.js` file that exports a plain object with lifecycle hooks. Load 
 
     $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-plugin.js'" variety.js
 
+Via the first-party CLI (use `--plugin` once per plugin):
+
+    $ variety test/users --quiet --plugin /path/to/my-plugin.js
+
 Pass per-plugin configuration by appending `|key=value` after the path:
 
     $ mongosh test --quiet --eval "var collection='users', plugins='/path/to/my-plugin.js|delimiter=;'" variety.js
+
+Via the first-party CLI (use `?key=value` instead of `|`, and `&` between multiple params):
+
+    $ variety test/users --quiet --plugin '/path/to/my-plugin.js?delimiter=;'
+
+For multiple plugins, repeat the flag:
+
+    $ variety test/users --quiet --plugin /path/to/formatter.js --plugin '/path/to/other.js?key=val'
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full hook reference and a guide to writing and testing plugins.
 

--- a/cli/options.js
+++ b/cli/options.js
@@ -47,6 +47,7 @@ const path = require('path');
  * @typedef {{
  *   extraEval: string[],
  *   help?: boolean,
+ *   pluginEntries: string[],
  *   shellOptions: ShellOptions,
  *   target: TargetSelection | null,
  *   varietyOptions: VarietyOptions,
@@ -301,6 +302,7 @@ const parseCliArguments = (argv) => {
   /** @type {ParsedCliArguments} */
   const parsed = {
     extraEval: [],
+    pluginEntries: [],
     shellOptions: {},
     target: null,
     varietyOptions: {},
@@ -460,6 +462,12 @@ const parseCliArguments = (argv) => {
       parsed.extraEval.push(result.value);
       break;
     }
+    case 'plugin': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.pluginEntries.push(result.value);
+      break;
+    }
     default:
       throw new CliUsageError(`Unknown option --${rawOptionName}.`);
     }
@@ -496,6 +504,13 @@ const buildEvalCode = (parsedCliArguments) => {
       statements.push(renderVarAssignment(name, parsedCliArguments.varietyOptions[name]));
     }
   });
+
+  if (parsedCliArguments.pluginEntries.length > 0) {
+    const pluginsValue = parsedCliArguments.pluginEntries
+      .map((entry) => entry.replace('?', '|'))
+      .join(',');
+    statements.push(renderVarAssignment('plugins', pluginsValue));
+  }
 
   return statements.concat(parsedCliArguments.extraEval).join('; ');
 };
@@ -591,6 +606,7 @@ const formatUsage = () => {
     '  --username <value>               MongoDB username',
     '  --password <value>               MongoDB password',
     '  --authenticationDatabase <value> Authentication database',
+    '  --plugin <path[?cfg]>            Plugin file to load; repeat for multiple plugins',
     '  --eval <javascript>              Extra JavaScript appended after CLI assignments',
     '  --help                           Show this help',
     '  --version                        Show the Variety package version',

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -331,6 +331,29 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes --plugin flags through to the mongosh eval arg', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'testdb/users',
+        '--plugin', '/path/to/formatter.js',
+        '--plugin', '/path/to/other.js?key=val&extra=x',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "users"; var plugins = "/path/to/formatter.js,/path/to/other.js|key=val&extra=x"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('fails fast on invalid JSON query input', async () => {
     await assert.rejects(
       () => runBinVariety({

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -268,4 +268,28 @@ describe('CLI option parsing', () => {
     const plan = createExecutionPlan(['test/users', '--results-password', 'hunter2'], {});
     assert.equal(evalCodeOf(plan), 'var collection = "users"; var resultsPass = "hunter2"');
   });
+
+  it('emits var plugins for a single --plugin without config', () => {
+    const plan = createExecutionPlan(['test/users', '--plugin', '/path/to/plugin.js'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var plugins = "/path/to/plugin.js"');
+  });
+
+  it('converts ? to | when emitting var plugins', () => {
+    const plan = createExecutionPlan(['test/users', '--plugin', '/path/to/plugin.js?delimiter=;'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var plugins = "/path/to/plugin.js|delimiter=;"');
+  });
+
+  it('joins multiple --plugin entries with commas', () => {
+    const plan = createExecutionPlan([
+      'test/users',
+      '--plugin', '/path/to/a.js',
+      '--plugin', '/path/to/b.js?key=val&other=x',
+    ], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var plugins = "/path/to/a.js,/path/to/b.js|key=val&other=x"');
+  });
+
+  it('omits var plugins when no --plugin flag is passed', () => {
+    const plan = createExecutionPlan(['test/users'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #232 (PR3 of 3). Stacked on #312 — base branch is `cli-parity-pr2-persistence`.

Adds first-class plugin support to the `bin/variety` CLI via a repeatable `--plugin` flag.

### Syntax

```bash
# Single plugin, no config
variety test/users --plugin /path/to/plugin.js

# Single plugin with config (? separates path from params, & between params)
variety test/users --plugin '/path/to/plugin.js?delimiter=;'

# Multiple plugins — repeat the flag
variety test/users --plugin /path/to/formatter.js --plugin '/path/to/other.js?key=val&extra=x'
```

### Design notes

- **`--plugin` (singular)** rather than `--plugins`, following CLI convention for repeatable flags.
- **`?`/`&` config syntax** instead of the `|` separator used in direct `variety.js` invocations. The `?` syntax is more recognisable (HTTP query-string style) and avoids shell pipe ambiguity. The CLI translates `?` → `|` internally in `buildEvalCode` before producing `var plugins = "..."`.
- Internally, `pluginEntries` is tracked in `ParsedCliArguments` (not `VarietyOptions`) since the final value is a joined string, not a direct array assignment.

### Documentation

README Plugins section now shows "Via the first-party CLI:" examples for single-plugin, config-string, and multi-plugin forms.

## Test plan

- [x] 40 CLI unit/integration tests pass (was 35)
- [x] New unit tests: single plugin, `?`→`|` config translation, multi-plugin comma-joining, omission when flag absent
- [x] New `BinWrapperTest` verifies two-plugin invocation reaching mongosh `--eval` with correct translation
- [x] All pre-commit hooks pass (ESLint, tsc checkJs, markdownlint, SPDX, build-verify, shellcheck, hadolint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)