### PR TITLE
Expose --last-value flag in bin/variety CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,11 @@ One can apply a `sort` constraint, which analyzes documents in the specified ord
 One can also apply a `lastValue` constraint to capture one representative value for each key.
 
     $ mongosh test --eval "var collection = 'orders', lastValue = true" variety.js
-    
+
+Via the first-party CLI:
+
+    $ variety test/orders --last-value
+
     +--------------------------------------------------------------------------------------------+
     | key             | types        | occurrences | percents | lastValue                        |
     | --------------- | ------------ | ----------- | -------- | -------------------------------- |

--- a/cli/options.js
+++ b/cli/options.js
@@ -20,6 +20,7 @@ const path = require('path');
  *   arrayEscape?: string,
  *   compactArrayTypes?: boolean,
  *   excludeSubkeys?: string[],
+ *   lastValue?: boolean,
  *   limit?: number,
  *   logKeysContinuously?: boolean,
  *   maxDepth?: number,
@@ -93,13 +94,14 @@ const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
 /** @type {Array<keyof VarietyOptions>} */
 const TARGET_OPTION_NAMES = [
   'query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples',
-  'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
+  'lastValue', 'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
   'persistResults', 'resultsDatabase', 'resultsCollection', 'resultsUser', 'resultsPass',
 ];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
   'array-escape': 'arrayEscape',
   'authentication-database': 'authenticationDatabase',
+  'last-value': 'lastValue',
   'compact-array-types': 'compactArrayTypes',
   'exclude-subkeys': 'excludeSubkeys',
   'log-keys-continuously': 'logKeysContinuously',
@@ -375,6 +377,9 @@ const parseCliArguments = (argv) => {
       parsed.varietyOptions.outputFormat = result.value;
       break;
     }
+    case 'lastValue':
+      parsed.varietyOptions.lastValue = parseBooleanValue(optionName, inlineValue);
+      break;
     case 'showArrayElements':
       parsed.varietyOptions.showArrayElements = parseBooleanValue(optionName, inlineValue);
       break;
@@ -589,6 +594,7 @@ const formatUsage = () => {
     '  --limit <number>                 Limit documents analyzed',
     '  --maxDepth <number>              Maximum traversal depth',
     '  --maxExamples <number>           Number of example values to collect per key',
+    '  --lastValue                      Capture one representative value per key',
     '  --outputFormat <value>           Output format, e.g. ascii or json',
     '  --showArrayElements              Include array element keys in output',
     '  --compactArrayTypes              Render Array(Type) instead of plain Array',

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -354,6 +354,25 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes --last-value through to the mongosh eval arg', async () => {
+    const { invocation } = await runBinVariety({
+      args: ['testdb/orders', '--last-value'],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "orders"; var lastValue = true',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('fails fast on invalid JSON query input', async () => {
     await assert.rejects(
       () => runBinVariety({

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -292,4 +292,14 @@ describe('CLI option parsing', () => {
     const plan = createExecutionPlan(['test/users'], {});
     assert.equal(evalCodeOf(plan), 'var collection = "users"');
   });
+
+  it('emits lastValue when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/orders', '--last-value'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "orders"; var lastValue = true');
+  });
+
+  it('accepts --lastValue camelCase alias', () => {
+    const plan = createExecutionPlan(['test/orders', '--lastValue=false'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "orders"; var lastValue = false');
+  });
 });


### PR DESCRIPTION
## Summary

Part of #232. Stacked on #314 — base branch is `cli-parity-pr3-plugins`.

Adds `--last-value` / `--lastValue`, which was missed in the original parity audit. Captures one representative value per key in the output.

```bash
variety test/orders --last-value
variety test/orders --lastValue=false
```

Maps directly to `var lastValue = true/false` in the mongosh eval string, following the same boolean flag pattern as `--show-array-elements`, `--compact-array-types`, and `--log-keys-continuously`.

### Documentation

README "Include Last Value" section now shows a "Via the first-party CLI:" example alongside the existing `mongosh` invocation.

## Test plan

- [x] 43 CLI unit/integration tests pass (was 40)
- [x] New unit tests: bare flag, `=false` override, camelCase alias
- [x] New `BinWrapperTest` verifies the flag flows through to mongosh `--eval`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)