### PR TITLE
Update BSON inventory after support tests

### DIFF
--- a/docs/bson-type-inventory.md
+++ b/docs/bson-type-inventory.md
@@ -1,6 +1,7 @@
 # MongoDB BSON Type Inventory
 
-Retrieved: 2026-04-21
+External sources retrieved: 2026-04-21
+Local evidence inspected: 2026-04-22
 
 This document inventories the BSON value types that MongoDB can store or has
 historically recognized, including deprecated types, `$type` aliases, binary
@@ -31,7 +32,7 @@ driver wrapper classes, and query/operator-only aliases.
 ## Variety Status Legend
 
 The "Variety" column summarizes current Variety support status from local code
-and test evidence inspected on 2026-04-21.
+and test evidence inspected on 2026-04-22.
 
 | Status | Meaning |
 | --- | --- |
@@ -44,8 +45,12 @@ and test evidence inspected on 2026-04-21.
 
 Primary local evidence: [V1] tests most BSON-wrapper recognition; [V2], [V3],
 and [V4] cover common application values and arrays; [V5] defines the current
-type mapping. Current tests recognize BSON `Double` and `Int32` as Variety
-`Number`, and BSON JavaScript-with-scope as Variety `Code`.
+type mapping; [V6] tests all binary subtypes with intentional Variety mappings;
+and [V7] proves the Variety label for each deprecated top-level BSON type.
+Current tests recognize BSON `Double` and `Int32` as Variety `Number`, BSON
+JavaScript-with-scope as Variety `Code`, BSON `Symbol` (type 14) as Variety
+`String` in mongosh, and all mapped binary subtypes under their
+`BinData-{subtype}` labels.
 
 ## Top-Level BSON Value Types
 
@@ -60,17 +65,17 @@ column is the string alias accepted by MongoDB `$type` where documented.
 | `2` | String | `string` | Current | Tested | Length-prefixed UTF-8 string. MongoDB drivers generally convert language strings to UTF-8. | [S1], [S2] |
 | `3` | Object / embedded document | `object` | Current | Tested | Embedded BSON document. A top-level MongoDB record is also a BSON document, but it is not preceded by an element type byte unless nested as a value. | [S1], [S2] |
 | `4` | Array | `array` | Current | Tested | Encoded as a BSON document whose keys are sequential integer strings starting at `0`. | [S1], [S2] |
-| `5` | Binary data | `binData` | Current | Partial | Length-prefixed byte array plus a binary subtype byte. Generic and standard UUID binary values are tested; see "BSON Binary Subtypes" for subtype coverage. | [S1], [S2] |
-| `6` | Undefined | `undefined` | Deprecated | Untested | Historical undefined value with no payload. It remains a recognized BSON type and `$type` alias, but should not be used for new data. | [S1], [S2] |
+| `5` | Binary data | `binData` | Current | Tested merged | Length-prefixed byte array plus a binary subtype byte. Variety has no single `Binary data` label; every binary value is reported under a `BinData-{subtype}` label instead. All subtypes with an intentional Variety mapping are test-backed; see "BSON Binary Subtypes" for per-subtype details and unmapped subtypes. | [S1], [S2], [V6] |
+| `6` | Undefined | `undefined` | Deprecated | Tested | Historical undefined value with no payload. It remains a recognized BSON type and `$type` alias, but should not be used for new data. The BSON library deserializes stored type-6 values as JavaScript `undefined`; Variety reports these as `undefined`. Coverage is analyzer-level test evidence against the deserialized value. | [S1], [S2], [V7] |
 | `7` | ObjectId | `objectId` | Current | Tested | 12-byte object identifier. See "Internal Structures and Interpretation Schemes". | [S1], [S2] |
 | `8` | Boolean | `bool` | Current | Tested | One byte: `0` for false, `1` for true. | [S1], [S2] |
 | `9` | Date / UTC datetime | `date` | Current | Tested | Signed 64-bit integer containing milliseconds since the Unix epoch. Before MongoDB 2.0, Date values were incorrectly interpreted as unsigned for some sort, range query, and index behavior. | [S1], [S2] |
 | `10` | Null | `null` | Current | Tested | Null value with no payload. Distinct from a missing field and from deprecated Undefined. | [S1], [S2], [S4] |
 | `11` | Regular expression | `regex` | Current | Tested | Two cstrings: pattern and options. See regex options below. | [S1], [S2] |
-| `12` | DBPointer | `dbPointer` | Deprecated | Unmapped | Historical database pointer: namespace string plus a 12-byte ObjectId. Deprecated. Do not confuse this BSON type with the later DBRef convention, which is a normal document shape rather than a BSON type. | [S1], [S2] |
+| `12` | DBPointer | `dbPointer` | Deprecated | Tested merged | Historical database pointer: namespace string plus a 12-byte ObjectId. Deprecated. Do not confuse this BSON type with the later DBRef convention, which is a normal document shape rather than a BSON type. The BSON library maps stored type-12 values to a DBRef object; Variety reports these as `DBRef`, the broader label shared with the DBRef convention. Coverage is analyzer-level test evidence against the deserialized value. | [S1], [S2], [V7] |
 | `13` | JavaScript code | `javascript` | Current BSON type, operationally discouraged | Untested | JavaScript source code stored as a string. Server-side JavaScript functions are deprecated starting in MongoDB 8.0, but this BSON storage type remains in the BSON type inventory. | [S1], [S2], [S10] |
-| `14` | Symbol | `symbol` | Deprecated | Untested | Historical symbol value stored as a string. Deprecated. | [S1], [S2] |
-| `15` | JavaScript code with scope | `javascriptWithScope` | Deprecated | Tested merged | Code-with-scope value containing total length, JavaScript source string, and a scope document. Variety's test reports this as `Code`. `$where` no longer supports this type; its use with `$where` was deprecated since MongoDB 4.2.1. `mapReduce` function support was removed in MongoDB 4.4 after the same deprecation. | [S1], [S2], [S9], [S10] |
+| `14` | Symbol | `symbol` | Deprecated | Tested merged | Historical symbol value stored as a string. Deprecated. Mongosh promotes stored type-14 values to plain JavaScript strings; Variety reports these as `String`, the broader label shared with BSON String (type 2). The analyzer also has a `BSONSymbol` path for BSONSymbol objects. | [S1], [S2], [V1], [V7] |
+| `15` | JavaScript code with scope | `javascriptWithScope` | Deprecated | Tested merged | Code-with-scope value containing total length, JavaScript source string, and a scope document. Variety reports this as `Code`. `$where` no longer supports this type; its use with `$where` was deprecated since MongoDB 4.2.1. `mapReduce` function support was removed in MongoDB 4.4 after the same deprecation. | [S1], [S2], [S9], [S10], [V1], [V7] |
 | `16` | 32-bit integer | `int` | Current | Tested merged | Signed 32-bit integer. Variety's integration test currently observes this as `Number`. | [S1], [S2] |
 | `17` | Timestamp | `timestamp` | Current, mostly internal | Tested | 64-bit timestamp used internally by MongoDB replication and sharding. MongoDB compares the time portion before the increment portion. Use BSON Date for application timestamps in most cases. | [S1], [S2] |
 | `18` | 64-bit integer | `long` | Current | Tested | Signed 64-bit integer. Variety reports this as `NumberLong`. | [S1], [S2] |
@@ -86,17 +91,17 @@ specification is the broader authority for the whole user-defined range.
 
 | Subtype | Name | Status | Variety | Meaning and caveats | Sources |
 | --- | --- | --- | --- | --- | --- |
-| `0` / `0x00` | Generic binary | Current | Tested | Default generic binary subtype for arbitrary bytes. Variety reports this as `BinData-generic`. | [S1], [S2] |
-| `1` / `0x01` | Function | Current / historical | Untested | Function data. Rare in modern application schemas. Variety has a mapping for `BinData-function`, but no current test case. | [S1], [S2] |
-| `2` / `0x02` | Binary (old) | Deprecated | Untested | Old binary format, deprecated in favor of subtype `0`. Its payload nests an additional `int32` length before the bytes. Variety has a mapping for `BinData-old`, but no current test case. | [S1], [S2] |
-| `3` / `0x03` | UUID (old) | Deprecated | Untested | Legacy UUID storage. Deprecated in favor of subtype `4`. The bytes do not identify which legacy driver byte order was used. Variety maps this to `BinData-UUID`, but no current test case covers subtype `3`. See "Legacy UUID Interpretations". | [S1], [S2], [S7] |
-| `4` / `0x04` | UUID | Current | Tested | Standard UUID binary subtype. Drivers use this for standardized UUID byte order. Variety reports this as `BinData-UUID`. | [S1], [S2], [S7] |
-| `5` / `0x05` | MD5 | Current / historical | Untested | MD5 binary subtype. Mostly encountered in older schemas or protocol/tooling contexts. Variety has a mapping for `BinData-MD5`, but no current test case. | [S1], [S2] |
+| `0` / `0x00` | Generic binary | Current | Tested | Default generic binary subtype for arbitrary bytes. Variety reports this as `BinData-generic`. | [S1], [S2], [V6] |
+| `1` / `0x01` | Function | Current / historical | Tested | Function data. Rare in modern application schemas. Variety reports this as `BinData-function`. | [S1], [S2], [V6] |
+| `2` / `0x02` | Binary (old) | Deprecated | Tested | Old binary format, deprecated in favor of subtype `0`. Its payload nests an additional `int32` length before the bytes. Variety reports this as `BinData-old`. | [S1], [S2], [V6] |
+| `3` / `0x03` | UUID (old) | Deprecated | Tested | Legacy UUID storage. Deprecated in favor of subtype `4`. The bytes do not identify which legacy driver byte order was used. Variety maps subtype `3` to `BinData-UUID` together with subtype `4`; both are test-backed. See "Legacy UUID Interpretations". | [S1], [S2], [S7], [V6] |
+| `4` / `0x04` | UUID | Current | Tested | Standard UUID binary subtype. Drivers use this for standardized UUID byte order. Variety reports this as `BinData-UUID`. | [S1], [S2], [S7], [V6] |
+| `5` / `0x05` | MD5 | Current / historical | Tested | MD5 binary subtype. Mostly encountered in older schemas or protocol/tooling contexts. Variety reports this as `BinData-MD5`. | [S1], [S2], [V6] |
 | `6` / `0x06` | Encrypted BSON value | Current | Unmapped | Encrypted BSON value, used by MongoDB encryption features. | [S1], [S2] |
 | `7` / `0x07` | Compressed BSON column / compressed time series data | Current | Unmapped | BSON spec calls this "Compressed BSON column"; MongoDB docs describe it as compressed time series data and mark it new in MongoDB 5.2. The format uses delta, delta-of-delta, run-length encoding, and sparse-array missing-value encoding. | [S1], [S2] |
 | `8` / `0x08` | Sensitive | Current | Unmapped | Sensitive data such as a key or secret. MongoDB logs a placeholder rather than the literal binary value. | [S1], [S2] |
 | `9` / `0x09` | Vector | Current | Unmapped | Dense numeric vector storage. The binary payload starts with vector metadata bytes before the packed elements. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6] |
-| `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Untested | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety maps subtype `0x80` to `BinData-user`, but does not map the rest of the user-defined range and has no current test case. | [S1], [S2] |
+| `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Partial | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety maps subtype `0x80` to `BinData-user` and that subtype is test-backed. Subtypes `0x81` through `0xFF` have no intentional Variety mapping and produce `BinData-undefined`. | [S1], [S2], [V6] |
 
 ## Vector Subtype 9 Dtypes
 
@@ -124,10 +129,10 @@ standard UUIDs.
 
 | Representation | Stored subtype | Variety | Byte order / behavior | Sources |
 | --- | --- | --- | --- | --- |
-| `STANDARD` | `4` | Tested | Standard UUID representation using BSON binary subtype `4`. Variety reports this as `BinData-UUID`. | [S7] |
-| `PYTHON_LEGACY` | `3` | Untested | Legacy PyMongo representation. Uses the standard RFC 4122 byte order but stores it under old UUID subtype `3`. | [S7] |
-| `JAVA_LEGACY` | `3` | Untested | Legacy Java driver byte order under old UUID subtype `3`. | [S7] |
-| `CSHARP_LEGACY` | `3` | Untested | Legacy .NET/C# driver byte order under old UUID subtype `3`. | [S7] |
+| `STANDARD` | `4` | Tested | Standard UUID representation using BSON binary subtype `4`. Variety reports this as `BinData-UUID`. | [S7], [V6] |
+| `PYTHON_LEGACY` | `3` | Tested | Legacy PyMongo representation. Uses the standard RFC 4122 byte order but stores it under old UUID subtype `3`. Variety maps any subtype `3` value to `BinData-UUID` without examining byte order. | [S7], [V6] |
+| `JAVA_LEGACY` | `3` | Tested | Legacy Java driver byte order under old UUID subtype `3`. Variety maps any subtype `3` value to `BinData-UUID` without examining byte order. | [S7], [V6] |
+| `CSHARP_LEGACY` | `3` | Tested | Legacy .NET/C# driver byte order under old UUID subtype `3`. Variety maps any subtype `3` value to `BinData-UUID` without examining byte order. | [S7], [V6] |
 | `UNSPECIFIED` | Not a storage format | Out of scope | Driver configuration state: do not automatically encode native UUIDs, and decode UUID binary values as raw Binary objects unless a representation is supplied. | [S7] |
 
 ## Internal Structures and Interpretation Schemes
@@ -139,10 +144,10 @@ round-trip tests, but they are not extra top-level BSON types.
 | BSON value | Variety | Internal structure | Sources |
 | --- | --- | --- | --- |
 | Array | Tested | Encoded as a BSON document whose field names are sequential integer strings beginning with `0`. | [S1] |
-| Binary old, subtype `2` | Untested | The binary payload itself contains an `int32` length followed by bytes. This is in addition to the outer binary length field. | [S1] |
+| Binary old, subtype `2` | Tested | The binary payload itself contains an `int32` length followed by bytes. This is in addition to the outer binary length field. Variety reports this as `BinData-old`. | [S1], [V6] |
 | Boolean | Tested | Single byte: `0` means false and `1` means true. | [S1] |
-| Code with scope, type `15` | Tested merged | Total byte length, JavaScript source string, and scope document mapping identifiers to values. Variety reports this as `Code`. | [S1] |
-| DBPointer, type `12` | Unmapped | Namespace string and 12-byte ObjectId. | [S1] |
+| Code with scope, type `15` | Tested merged | Total byte length, JavaScript source string, and scope document mapping identifiers to values. Variety reports this as `Code`. | [S1], [V7] |
+| DBPointer, type `12` | Tested merged | Namespace string and 12-byte ObjectId. The BSON library deserializes type-12 to a DBRef object; Variety reports `DBRef`. | [S1], [V7] |
 | Date, type `9` | Tested | Signed 64-bit integer containing UTC milliseconds since the Unix epoch. MongoDB notes old pre-2.0 unsigned interpretation bugs for dates before 1970. | [S1], [S2] |
 | Decimal128, type `19` | Tested | IEEE 754-2008 128-bit decimal floating point. MongoDB stores Decimal128 using binary integer decimal encoding and requires exact value preservation on round trip. | [S2], [S8] |
 | ObjectId, type `7` | Tested | 12 bytes: 4-byte timestamp in seconds, 5-byte process-random value, and 3-byte counter. MongoDB notes ObjectIds are approximately ordered but not strictly monotonic. | [S2] |
@@ -174,7 +179,7 @@ round-trip tests, but they are not extra top-level BSON types.
 
 | Item | Variety | Version note | Sources |
 | --- | --- | --- | --- |
-| Deprecated top-level BSON types | Partial | Undefined (`6`), DBPointer (`12`), Symbol (`14`), and JavaScript code with scope (`15`) are still listed and recognized, but deprecated. Only JavaScript code with scope has current Variety test coverage among these deprecated top-level entries. | [S1], [S2] |
+| Deprecated top-level BSON types | Tested merged | Undefined (`6`), DBPointer (`12`), Symbol (`14`), and JavaScript code with scope (`15`) are still listed and recognized, but deprecated. All four now have test-backed Variety behavior: Undefined is labeled `undefined`, DBPointer is labeled `DBRef`, Symbol is labeled `String` in mongosh, and code with scope is labeled `Code`. DBPointer, Symbol, and code with scope are reported under broader or merged labels, making this grouping `Tested merged`. | [S1], [S2], [V1], [V7] |
 | Date signedness | Tested | Before MongoDB 2.0, Date values were incorrectly interpreted as unsigned integers in some sort, range query, and index behavior. Variety has current Date tests, but no historical pre-2.0 behavioral test. | [S2] |
 | Decimal128 | Tested | MongoDB 3.4 introduced BSON Decimal128, type code `19` / `0x13`. | [S8] |
 | Binary subtype `7` | Unmapped | MongoDB's BSON Types page marks compressed time series data as new in MongoDB 5.2. BSON spec names the subtype "Compressed BSON column". | [S1], [S2] |
@@ -225,20 +230,32 @@ round-trip tests, but they are not extra top-level BSON types.
   `$where` support for BSON String and JavaScript but not JavaScript with scope.
 - [V1] Variety local test file,
   [test/cases/analysis/DatatypeRecognitionTest.js](../test/cases/analysis/DatatypeRecognitionTest.js).
-  Inspected in the current working tree on 2026-04-21. Essential metadata:
+  Inspected in the current working tree on 2026-04-22. Essential metadata:
   integration test for current BSON-wrapper recognition.
 - [V2] Variety local test file,
   [test/cases/analysis/BasicAnalysisTest.js](../test/cases/analysis/BasicAnalysisTest.js).
-  Inspected in the current working tree on 2026-04-21. Essential metadata:
+  Inspected in the current working tree on 2026-04-22. Essential metadata:
   integration test for common seed-data type recognition and value examples.
 - [V3] Variety local fixture file,
   [test/fixtures/seed-data.js](../test/fixtures/seed-data.js). Inspected in the
-  current working tree on 2026-04-21. Essential metadata: seed data used by
+  current working tree on 2026-04-22. Essential metadata: seed data used by
   common analysis, formatter, persistence, and plugin tests.
 - [V4] Variety local test file,
   [test/cases/analysis/ShowArrayElementsTest.js](../test/cases/analysis/ShowArrayElementsTest.js).
-  Inspected in the current working tree on 2026-04-21. Essential metadata:
+  Inspected in the current working tree on 2026-04-22. Essential metadata:
   array element and nested-array analysis tests.
 - [V5] Variety local source file, [core/analyzer.js](../core/analyzer.js).
-  Inspected in the current working tree on 2026-04-21. Essential metadata:
+  Inspected in the current working tree on 2026-04-22. Essential metadata:
   current Variety type-detection and binary-subtype mapping implementation.
+- [V6] Variety local test file,
+  [test/cases/analysis/BinarySubtypeTest.js](../test/cases/analysis/BinarySubtypeTest.js).
+  Added 2026-04-21 and inspected in the current working tree on 2026-04-22.
+  Essential metadata: integration test for all seven BSON binary subtypes that
+  Variety maps intentionally: generic, function, old, UUID-old, UUID, MD5, and
+  user-defined `0x80`.
+- [V7] Variety local test file,
+  [test/cases/analysis/DeprecatedBsonTypesTest.js](../test/cases/analysis/DeprecatedBsonTypesTest.js).
+  Added 2026-04-21 and inspected in the current working tree on 2026-04-22.
+  Essential metadata: analyzer-level test proving the Variety label for each
+  deprecated top-level BSON type: Undefined/type 6, DBPointer/type 12,
+  Symbol/type 14, and JavaScript code with scope/type 15.


### PR DESCRIPTION
## Summary
- update docs/bson-type-inventory.md to reflect main after #302 and #305 were merged
- mark the newly tested deprecated BSON types and intentionally mapped binary subtypes according to the merged test evidence
- add local evidence entries for the new binary subtype and deprecated BSON type tests

## Validation
- npm run lint:markdown
- git diff --check
- checked README.md and CONTRIBUTING.md; no updates needed for this doc-only change