### PR TITLE
Map remaining standard BSON binary subtypes

### DIFF
--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -148,6 +148,10 @@
           0x03: 'UUID',
           0x04: 'UUID',
           0x05: 'MD5',
+          0x06: 'encrypted',
+          0x07: 'compressed-column',
+          0x08: 'sensitive',
+          0x09: 'vector',
           0x80: 'user',
         };
         return `BinData-${binDataTypes[getBinDataSubtype(thing)]}`;

--- a/docs/bson-type-inventory.md
+++ b/docs/bson-type-inventory.md
@@ -45,12 +45,13 @@ and test evidence inspected on 2026-04-22.
 
 Primary local evidence: [V1] tests most BSON-wrapper recognition; [V2], [V3],
 and [V4] cover common application values and arrays; [V5] defines the current
-type mapping; [V6] tests all binary subtypes with intentional Variety mappings;
-and [V7] proves the Variety label for each deprecated top-level BSON type.
+type mapping; [V6] tests every standard binary subtype plus custom subtype
+`0x80`; and [V7] proves the Variety label for each deprecated top-level BSON
+type.
 Current tests recognize BSON `Double` and `Int32` as Variety `Number`, BSON
 JavaScript-with-scope as Variety `Code`, BSON `Symbol` (type 14) as Variety
-`String` in mongosh, and all mapped binary subtypes under their
-`BinData-{subtype}` labels.
+`String` in mongosh, and standard binary subtypes plus custom subtype `0x80`
+under their `BinData-{subtype}` labels.
 
 ## Top-Level BSON Value Types
 
@@ -65,7 +66,7 @@ column is the string alias accepted by MongoDB `$type` where documented.
 | `2` | String | `string` | Current | Tested | Length-prefixed UTF-8 string. MongoDB drivers generally convert language strings to UTF-8. | [S1], [S2] |
 | `3` | Object / embedded document | `object` | Current | Tested | Embedded BSON document. A top-level MongoDB record is also a BSON document, but it is not preceded by an element type byte unless nested as a value. | [S1], [S2] |
 | `4` | Array | `array` | Current | Tested | Encoded as a BSON document whose keys are sequential integer strings starting at `0`. | [S1], [S2] |
-| `5` | Binary data | `binData` | Current | Tested merged | Length-prefixed byte array plus a binary subtype byte. Variety has no single `Binary data` label; every binary value is reported under a `BinData-{subtype}` label instead. All subtypes with an intentional Variety mapping are test-backed; see "BSON Binary Subtypes" for per-subtype details and unmapped subtypes. | [S1], [S2], [V6] |
+| `5` | Binary data | `binData` | Current | Tested merged | Length-prefixed byte array plus a binary subtype byte. Variety has no single `Binary data` label; every binary value is reported under a `BinData-{subtype}` label instead. Every standard binary subtype plus custom subtype `0x80` is test-backed; see "BSON Binary Subtypes" for per-subtype details and partially mapped custom subtypes. | [S1], [S2], [V6] |
 | `6` | Undefined | `undefined` | Deprecated | Tested | Historical undefined value with no payload. It remains a recognized BSON type and `$type` alias, but should not be used for new data. The BSON library deserializes stored type-6 values as JavaScript `undefined`; Variety reports these as `undefined`. Coverage is analyzer-level test evidence against the deserialized value. | [S1], [S2], [V7] |
 | `7` | ObjectId | `objectId` | Current | Tested | 12-byte object identifier. See "Internal Structures and Interpretation Schemes". | [S1], [S2] |
 | `8` | Boolean | `bool` | Current | Tested | One byte: `0` for false, `1` for true. | [S1], [S2] |
@@ -97,10 +98,10 @@ specification is the broader authority for the whole user-defined range.
 | `3` / `0x03` | UUID (old) | Deprecated | Tested | Legacy UUID storage. Deprecated in favor of subtype `4`. The bytes do not identify which legacy driver byte order was used. Variety maps subtype `3` to `BinData-UUID` together with subtype `4`; both are test-backed. See "Legacy UUID Interpretations". | [S1], [S2], [S7], [V6] |
 | `4` / `0x04` | UUID | Current | Tested | Standard UUID binary subtype. Drivers use this for standardized UUID byte order. Variety reports this as `BinData-UUID`. | [S1], [S2], [S7], [V6] |
 | `5` / `0x05` | MD5 | Current / historical | Tested | MD5 binary subtype. Mostly encountered in older schemas or protocol/tooling contexts. Variety reports this as `BinData-MD5`. | [S1], [S2], [V6] |
-| `6` / `0x06` | Encrypted BSON value | Current | Unmapped | Encrypted BSON value, used by MongoDB encryption features. | [S1], [S2] |
-| `7` / `0x07` | Compressed BSON column / compressed time series data | Current | Unmapped | BSON spec calls this "Compressed BSON column"; MongoDB docs describe it as compressed time series data and mark it new in MongoDB 5.2. The format uses delta, delta-of-delta, run-length encoding, and sparse-array missing-value encoding. | [S1], [S2] |
-| `8` / `0x08` | Sensitive | Current | Unmapped | Sensitive data such as a key or secret. MongoDB logs a placeholder rather than the literal binary value. | [S1], [S2] |
-| `9` / `0x09` | Vector | Current | Unmapped | Dense numeric vector storage. The binary payload starts with vector metadata bytes before the packed elements. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6] |
+| `6` / `0x06` | Encrypted BSON value | Current | Tested | Encrypted BSON value, used by MongoDB encryption features. Variety reports this as `BinData-encrypted`. | [S1], [S2], [V6] |
+| `7` / `0x07` | Compressed BSON column / compressed time series data | Current | Tested | BSON spec calls this "Compressed BSON column"; MongoDB docs describe it as compressed time series data and mark it new in MongoDB 5.2. The format uses delta, delta-of-delta, run-length encoding, and sparse-array missing-value encoding. Variety reports this as `BinData-compressed-column`. Coverage is analyzer-level because MongoDB validates compressed-column payloads. | [S1], [S2], [V6] |
+| `8` / `0x08` | Sensitive | Current | Tested | Sensitive data such as a key or secret. MongoDB logs a placeholder rather than the literal binary value. Variety reports this as `BinData-sensitive`. | [S1], [S2], [V6] |
+| `9` / `0x09` | Vector | Current | Tested | Dense numeric vector storage. The binary payload starts with vector metadata bytes before the packed elements. Variety reports this as `BinData-vector`; it does not currently parse dtype-specific vector labels. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6], [V6] |
 | `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Partial | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety maps subtype `0x80` to `BinData-user` and that subtype is test-backed. Subtypes `0x81` through `0xFF` have no intentional Variety mapping and produce `BinData-undefined`. | [S1], [S2], [V6] |
 
 ## Vector Subtype 9 Dtypes
@@ -154,7 +155,7 @@ round-trip tests, but they are not extra top-level BSON types.
 | Regular expression, type `11` | Tested | Pattern cstring and options cstring. Options must be stored alphabetically. Supported option characters are `i`, `m`, `s`, `x`, and `u`. | [S1] |
 | String, type `2` | Tested | `int32` byte length, UTF-8 bytes, and trailing null byte. | [S1], [S2] |
 | Timestamp, type `17` | Tested | Serialized as a BSON `uint64`. BSON spec describes the first serialized 4 bytes as increment and the second as timestamp; MongoDB describes the logical value as high 32 bits `time_t` and low 32 bits ordinal, and compares time before ordinal. | [S1], [S2] |
-| Vector binary, subtype `9` | Unmapped | First byte is dtype, second byte is padding, and the rest is packed vector data using little-endian format. | [S6] |
+| Vector binary, subtype `9` | Tested | First byte is dtype, second byte is padding, and the rest is packed vector data using little-endian format. Variety reports this at the subtype level as `BinData-vector`; dtype-specific labels remain unmapped. | [S6], [V6] |
 
 ## Query and Operator Aliases That Are Not Storage Types
 
@@ -182,10 +183,10 @@ round-trip tests, but they are not extra top-level BSON types.
 | Deprecated top-level BSON types | Tested merged | Undefined (`6`), DBPointer (`12`), Symbol (`14`), and JavaScript code with scope (`15`) are still listed and recognized, but deprecated. All four now have test-backed Variety behavior: Undefined is labeled `undefined`, DBPointer is labeled `DBRef`, Symbol is labeled `String` in mongosh, and code with scope is labeled `Code`. DBPointer, Symbol, and code with scope are reported under broader or merged labels, making this grouping `Tested merged`. | [S1], [S2], [V1], [V7] |
 | Date signedness | Tested | Before MongoDB 2.0, Date values were incorrectly interpreted as unsigned integers in some sort, range query, and index behavior. Variety has current Date tests, but no historical pre-2.0 behavioral test. | [S2] |
 | Decimal128 | Tested | MongoDB 3.4 introduced BSON Decimal128, type code `19` / `0x13`. | [S8] |
-| Binary subtype `7` | Unmapped | MongoDB's BSON Types page marks compressed time series data as new in MongoDB 5.2. BSON spec names the subtype "Compressed BSON column". | [S1], [S2] |
+| Binary subtype `7` | Tested | MongoDB's BSON Types page marks compressed time series data as new in MongoDB 5.2. BSON spec names the subtype "Compressed BSON column". Variety reports this as `BinData-compressed-column`. | [S1], [S2], [V6] |
 | JavaScript code with scope in server-side JavaScript operations | Tested merged | Use of type `15` for `$where` and `mapReduce` functions was deprecated since MongoDB 4.2.1. MongoDB 4.4 removed `mapReduce` support for type `15`; current `$where` docs say `$where` no longer supports it. Variety reports code-with-scope values as `Code`. | [S9], [S10] |
 | Server-side JavaScript functions | Out of scope | Starting in MongoDB 8.0, server-side JavaScript functions such as `$accumulator`, `$function`, and `$where` are deprecated. This is an operational JavaScript execution caveat, not the removal of BSON type `13` from the storage inventory. | [S10] |
-| Vector binary subtype `9` | Unmapped | The vector subtype specification is accepted, has no minimum server version, and records acceptance on 2024-11-01. It has dtype validation updates through 2025-06-23. | [S6] |
+| Vector binary subtype `9` | Tested | The vector subtype specification is accepted, has no minimum server version, and records acceptance on 2024-11-01. It has dtype validation updates through 2025-06-23. Variety reports vector binary values as `BinData-vector`; dtype-specific labels remain unmapped. | [S6], [V6] |
 
 ## Source Register
 
@@ -249,10 +250,11 @@ round-trip tests, but they are not extra top-level BSON types.
   current Variety type-detection and binary-subtype mapping implementation.
 - [V6] Variety local test file,
   [test/cases/analysis/BinarySubtypeTest.js](../test/cases/analysis/BinarySubtypeTest.js).
-  Added 2026-04-21 and inspected in the current working tree on 2026-04-22.
-  Essential metadata: integration test for all seven BSON binary subtypes that
-  Variety maps intentionally: generic, function, old, UUID-old, UUID, MD5, and
-  user-defined `0x80`.
+  Added 2026-04-21; updated and inspected in the current working tree on
+  2026-04-22. Essential metadata: integration and analyzer-level tests for
+  every standard BSON binary subtype plus custom subtype `0x80`: generic,
+  function, old, UUID-old, UUID, MD5, encrypted, compressed column, sensitive,
+  vector, and user-defined `0x80`.
 - [V7] Variety local test file,
   [test/cases/analysis/DeprecatedBsonTypesTest.js](../test/cases/analysis/DeprecatedBsonTypesTest.js).
   Added 2026-04-21 and inspected in the current working tree on 2026-04-22.

--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -1,12 +1,52 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert/strict';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 import { Binary, UUID } from 'mongodb';
 import VarietyHarness from '../../helpers/VarietyHarness.js';
 
+const require = createRequire(import.meta.url);
+const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
+require(analyzerPath);
+
+/**
+ * @typedef {{
+ *   arrayEscape: string,
+ *   excludeSubkeys: Record<string, true>,
+ *   maxDepth: number,
+ *   compactArrayTypes: boolean,
+ *   lastValue: boolean,
+ *   logKeysContinuously: boolean,
+ *   maxExamples: number,
+ * }} AnalyzerConfig
+ * @typedef {{
+ *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+ * }} VarietyImpl
+ */
+
+const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
+const impl = analyzerGlobal.__varietyImpl;
+if (typeof impl === 'undefined') {
+  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
+}
+
+/** @type {AnalyzerConfig} */
+const config = {
+  arrayEscape: 'XX',
+  excludeSubkeys: /** @type {Record<string, true>} */ ({}),
+  maxDepth: 5,
+  compactArrayTypes: false,
+  lastValue: false,
+  logKeysContinuously: false,
+  maxExamples: 0,
+};
+
 const test = new VarietyHarness('test', 'bindata_subtypes');
 
-// One document with a field per BSON binary subtype that Variety intentionally
-// maps. Subtypes 3 (UUID old) and 4 (UUID) both report as BinData-UUID.
+// One document with a field per server-insertable BSON binary subtype that
+// Variety intentionally maps. Subtypes 3 (UUID old) and 4 (UUID) both report
+// as BinData-UUID.
 const doc = {
   binData_generic:  new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_DEFAULT),
   binData_function: new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_FUNCTION),
@@ -20,6 +60,9 @@ const doc = {
     Uint8Array.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]),
     Binary.SUBTYPE_MD5
   ),
+  binData_encrypted:         new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x06),
+  binData_sensitive:         new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x08),
+  binData_vector:            new Binary(Uint8Array.from([0x03, 0x00, 0x01, 0x02, 0x03]), 0x09),
   binData_user:     new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
 };
 
@@ -27,17 +70,25 @@ describe('Binary subtype recognition', () => {
   beforeEach(() => test.init([doc]));
   afterEach(() => test.cleanUp());
 
-  it('should report each mapped binary subtype under its Variety label', async () => {
+  it('should report each server-insertable mapped binary subtype under its Variety label', async () => {
     const results = await test.runJsonAnalysis({ collection: 'bindata_subtypes' }, true);
-    results.validateResultsCount(8); // _id plus one field per subtype
-    results.validate('_id',              1, 100.0, { ObjectId: 1 });
-    results.validate('binData_generic',  1, 100.0, { 'BinData-generic':  1 });
-    results.validate('binData_function', 1, 100.0, { 'BinData-function': 1 });
-    results.validate('binData_old',      1, 100.0, { 'BinData-old':      1 });
+    results.validateResultsCount(11); // _id plus one field per subtype
+    results.validate('_id',                       1, 100.0, { ObjectId: 1 });
+    results.validate('binData_generic',           1, 100.0, { 'BinData-generic':           1 });
+    results.validate('binData_function',          1, 100.0, { 'BinData-function':          1 });
+    results.validate('binData_old',               1, 100.0, { 'BinData-old':               1 });
     // Subtypes 3 (UUID old) and 4 (UUID) both map to BinData-UUID.
-    results.validate('binData_uuid_old', 1, 100.0, { 'BinData-UUID':     1 });
-    results.validate('binData_uuid',     1, 100.0, { 'BinData-UUID':     1 });
-    results.validate('binData_md5',      1, 100.0, { 'BinData-MD5':      1 });
-    results.validate('binData_user',     1, 100.0, { 'BinData-user':     1 });
+    results.validate('binData_uuid_old',          1, 100.0, { 'BinData-UUID':              1 });
+    results.validate('binData_uuid',              1, 100.0, { 'BinData-UUID':              1 });
+    results.validate('binData_md5',               1, 100.0, { 'BinData-MD5':               1 });
+    results.validate('binData_encrypted',         1, 100.0, { 'BinData-encrypted':         1 });
+    results.validate('binData_sensitive',         1, 100.0, { 'BinData-sensitive':         1 });
+    results.validate('binData_vector',            1, 100.0, { 'BinData-vector':            1 });
+    results.validate('binData_user',              1, 100.0, { 'BinData-user':              1 });
+  });
+
+  it('should report compressed BSON column subtype under its Variety label', () => {
+    const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x07));
+    assert.equal(result, 'BinData-compressed-column');
   });
 });

--- a/variety.js
+++ b/variety.js
@@ -294,6 +294,10 @@ Please see https://github.com/variety/variety for details. */
           0x03: 'UUID',
           0x04: 'UUID',
           0x05: 'MD5',
+          0x06: 'encrypted',
+          0x07: 'compressed-column',
+          0x08: 'sensitive',
+          0x09: 'vector',
           0x80: 'user',
         };
         return `BinData-${binDataTypes[getBinDataSubtype(thing)]}`;


### PR DESCRIPTION
## Summary
- add intentional Variety labels for BSON binary subtypes 0x06 through 0x09: encrypted, compressed-column, sensitive, and vector
- extend binary subtype coverage, using integration coverage for server-insertable fixtures and analyzer-level coverage for compressed BSON column
- update docs/bson-type-inventory.md so the standard binary subtype rows now reflect the tested subtype-level support while vector dtype-specific labels remain unmapped

## Validation
- pre-commit hook: verify:build, ESLint, jsonlint, markdownlint, js-yaml, hadolint, shellcheck, SPDX, typecheck
- Podman focused MongoDB test: `npm run test:mocha -- --grep "Binary subtype recognition"` inside the test image via Bash entrypoint; 2 passing
- `git diff --check`
- checked README.md and CONTRIBUTING.md; no updates needed

Note: running `npm run test:container` directly from this `/tmp` worktree hit `Permission denied` on the mounted `docker/init.sh` entrypoint. The focused Podman validation used the same image with `/bin/bash` as entrypoint so Bash read the mounted script instead of executing it from the bind mount.