### PR TITLE
Replace slaveOk with secondaryOk

### DIFF
--- a/.eslint.config.js
+++ b/.eslint.config.js
@@ -68,7 +68,7 @@ module.exports = (async () => {
           ...globals.mocha,
           ...globals.mongo,
           __quiet: 'readonly',
-          slaveOk: 'readonly',
+          secondaryOk: 'readonly',
           collection: 'readonly',
           DBQuery: 'readonly',
           BinData: 'readonly',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   `shellContext.__varietyFormatters` to dispatch output. This is the
   future `@variety/core` package boundary.
 - `mongo-shell/adapter.js` — the shell-facing layer that reads shell
-  globals (`collection`, `plugins`, `slaveOk`, etc.), loads plugins, and
+  globals (`collection`, `plugins`, `secondaryOk`, etc.), loads plugins, and
   hands dependencies to `impl.run()`. The only place in the build that
   touches `db`, `print`, and `load`. Cleans up both `__varietyImpl` and
   `__varietyFormatters` after execution so repeated loads are idempotent.

--- a/README.md
+++ b/README.md
@@ -365,10 +365,16 @@ This option is complementary to `showArrayElements`: `compactArrayTypes` makes t
 _Thanks to [@oufeng](https://github.com/oufeng) for suggesting this feature ([#166](https://github.com/variety/variety/issues/166))._
 
 ### Secondary Reads
-Analyzing a large collection on a busy replica set primary could take a lot longer than if you read from a secondary. To do so, we have to tell MongoDB it's okay to perform secondary reads
-by setting the `slaveOk` property to `true`:
+Analyzing a large collection on a busy replica set primary could take a lot longer than if you read from a secondary. To do so, tell MongoDB to use the `secondary` read preference
+by setting the `secondaryOk` property to `true`:
 
-    $ mongosh secondary.replicaset.member:31337/somedb --eval "var collection = 'users', slaveOk = true" variety.js
+    $ mongosh secondary.replicaset.member:31337/somedb --eval "var collection = 'users', secondaryOk = true" variety.js
+
+Via the first-party CLI:
+
+    $ variety somedb/users --host secondary.replicaset.member --port 31337 --secondary-ok
+
+`secondaryOk` replaces the old `slaveOk` name; see [issue #309](https://github.com/variety/variety/issues/309).
 
 ## Save Results in MongoDB For Future Use
 By default, Variety prints results only to standard output and does not store them in MongoDB itself. If you want to persist them automatically in MongoDB for later usage, you can set the `persistResults` parameter.

--- a/build.js
+++ b/build.js
@@ -59,7 +59,7 @@ Please see https://github.com/variety/variety for details. */
 //
 //   3. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
 //      shell globals: reading input (\`collection\`, \`plugins\`, \`__quiet\`,
-//      \`slaveOk\`, etc.), the config-echo logging, plugin loading via
+//      \`secondaryOk\`, etc.), the config-echo logging, plugin loading via
 //      \`load()\`, input validation, and constructing the dependency bag
 //      passed to \`impl.run()\`.
 //

--- a/cli/options.js
+++ b/cli/options.js
@@ -32,6 +32,7 @@ const path = require('path');
  *   resultsDatabase?: string,
  *   resultsPass?: string,
  *   resultsUser?: string,
+ *   secondaryOk?: boolean,
  *   showArrayElements?: boolean,
  *   sort?: Record<string, unknown>,
  * }} VarietyOptions
@@ -94,7 +95,7 @@ const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
 /** @type {Array<keyof VarietyOptions>} */
 const TARGET_OPTION_NAMES = [
   'query', 'sort', 'limit', 'maxDepth', 'outputFormat', 'maxExamples',
-  'lastValue', 'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
+  'lastValue', 'secondaryOk', 'showArrayElements', 'compactArrayTypes', 'arrayEscape', 'excludeSubkeys', 'logKeysContinuously',
   'persistResults', 'resultsDatabase', 'resultsCollection', 'resultsUser', 'resultsPass',
 ];
 /** @type {Record<string, string>} */
@@ -113,6 +114,7 @@ const FLAG_ALIASES = {
   'results-database': 'resultsDatabase',
   'results-password': 'resultsPass',
   'results-user': 'resultsUser',
+  'secondary-ok': 'secondaryOk',
   'show-array-elements': 'showArrayElements',
 };
 
@@ -380,6 +382,9 @@ const parseCliArguments = (argv) => {
     case 'lastValue':
       parsed.varietyOptions.lastValue = parseBooleanValue(optionName, inlineValue);
       break;
+    case 'secondaryOk':
+      parsed.varietyOptions.secondaryOk = parseBooleanValue(optionName, inlineValue);
+      break;
     case 'showArrayElements':
       parsed.varietyOptions.showArrayElements = parseBooleanValue(optionName, inlineValue);
       break;
@@ -595,6 +600,7 @@ const formatUsage = () => {
     '  --maxDepth <number>              Maximum traversal depth',
     '  --maxExamples <number>           Number of example values to collect per key',
     '  --lastValue                      Capture one representative value per key',
+    '  --secondary-ok                   Read from a secondary by setting read preference',
     '  --outputFormat <value>           Output format, e.g. ascii or json',
     '  --showArrayElements              Include array element keys in output',
     '  --compactArrayTypes              Render Array(Type) instead of plain Array',

--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -36,9 +36,9 @@
   log('Variety: A MongoDB Schema Analyzer');
   log('Version 1.5.2, released 30 September 2025');
 
-  if (typeof slaveOk !== 'undefined') {
-    if (slaveOk === true) {
-      db.getMongo().setSlaveOk();
+  if (typeof secondaryOk !== 'undefined') {
+    if (secondaryOk === true) {
+      db.getMongo().setReadPref('secondary');
     }
   }
 

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -373,6 +373,25 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes --secondary-ok through to the mongosh eval arg', async () => {
+    const { invocation } = await runBinVariety({
+      args: ['testdb/users', '--secondary-ok'],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'testdb',
+        '--eval',
+        'var collection = "users"; var secondaryOk = true',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('fails fast on invalid JSON query input', async () => {
     await assert.rejects(
       () => runBinVariety({

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -302,4 +302,12 @@ describe('CLI option parsing', () => {
     const plan = createExecutionPlan(['test/orders', '--lastValue=false'], {});
     assert.equal(evalCodeOf(plan), 'var collection = "orders"; var lastValue = false');
   });
+
+  it('emits secondaryOk and accepts the camelCase alias', () => {
+    const kebab = createExecutionPlan(['test/users', '--secondary-ok'], {});
+    const camel = createExecutionPlan(['test/users', '--secondaryOk=false'], {});
+
+    assert.equal(evalCodeOf(kebab), 'var collection = "users"; var secondaryOk = true');
+    assert.equal(evalCodeOf(camel), 'var collection = "users"; var secondaryOk = false');
+  });
 });

--- a/test/cases/mongo-shell/AdapterValidationTest.js
+++ b/test/cases/mongo-shell/AdapterValidationTest.js
@@ -16,7 +16,7 @@ const adapterSource = fs.readFileSync(adapterPath, 'utf8');
  *   adminCommand(command: string): FakeListDatabasesResult,
  *   getCollection(name: string): FakeCollection,
  *   getCollectionNames(): string[],
- *   getMongo(): { setSlaveOk(): void },
+ *   getMongo(): { setReadPref(mode: string): void },
  *   getName(): string,
  *   getSisterDB(name: string): never,
  * }} FakeDb
@@ -24,9 +24,10 @@ const adapterSource = fs.readFileSync(adapterPath, 'utf8');
 
 /**
  * @param {string[]} sisterDbCalls
+ * @param {{ setReadPref(mode: string): void }} [mongoConnection]
  * @returns {FakeDb}
  */
-const createDb = (sisterDbCalls) => ({
+const createDb = (sisterDbCalls, mongoConnection = { setReadPref() {} }) => ({
   adminCommand(command) {
     assert.equal(command, 'listDatabases');
     return {
@@ -51,9 +52,7 @@ const createDb = (sisterDbCalls) => ({
     return ['users'];
   },
   getMongo() {
-    return {
-      setSlaveOk() {},
-    };
+    return mongoConnection;
   },
   getName() {
     return 'test';
@@ -65,6 +64,39 @@ const createDb = (sisterDbCalls) => ({
 });
 
 describe('Mongo shell adapter validation', () => {
+  it('sets the secondary read preference before startup reads when secondaryOk is true', () => {
+    /** @type {string[]} */
+    const readPreferenceModes = [];
+    /** @type {string[]} */
+    const sisterDbCalls = [];
+    let analyzerRan = false;
+
+    const context = {
+      __varietyImpl: {
+        createKeyMap: () => ({}),
+        run: () => {
+          analyzerRan = true;
+        },
+        shellToJson: JSON.stringify,
+      },
+      collection: 'users',
+      db: createDb(sisterDbCalls, {
+        setReadPref(mode) {
+          assert.equal(analyzerRan, false);
+          readPreferenceModes.push(mode);
+        },
+      }),
+      print: () => {},
+      secondaryOk: true,
+    };
+
+    vm.createContext(context);
+    vm.runInContext(adapterSource, context, { filename: adapterPath });
+
+    assert.deepEqual(readPreferenceModes, ['secondary']);
+    assert.equal(analyzerRan, true);
+  });
+
   it('does not enumerate collections for unrelated databases during startup', () => {
     /** @type {unknown[]} */
     const runConfigs = [];

--- a/test/cases/mongo-shell/SecondaryReadsTest.js
+++ b/test/cases/mongo-shell/SecondaryReadsTest.js
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert';
+import { fileURLToPath } from 'url';
+import sampleData from '../../fixtures/seed-data.js';
+import VarietyHarness from '../../helpers/VarietyHarness.js';
+
+const test = new VarietyHarness('test', 'users');
+
+const getPluginPath = () => fileURLToPath(new URL('../../fixtures/plugins/read-pref-plugin.js', import.meta.url));
+
+describe('Secondary reads', () => {
+  beforeEach(() => test.init(sampleData));
+  afterEach(() => test.cleanUp());
+
+  it('sets the Mongo shell read preference to secondary when secondaryOk is true', async () => {
+    const output = await test.runAnalysis({
+      collection: 'users',
+      plugins: getPluginPath(),
+      secondaryOk: true,
+    }, true);
+
+    assert.equal(output.includes('someWeirdLegacyKey'), true);
+  });
+});

--- a/test/fixtures/plugins/read-pref-plugin.js
+++ b/test/fixtures/plugins/read-pref-plugin.js
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+/**
+ * @typedef {{ getMongo(): { getReadPrefMode(): string } }} ShellDb
+ */
+
+var shellContext = /** @type {{ db: ShellDb }} */ (
+  /** @type {unknown} */ (typeof globalThis !== 'undefined' ? globalThis : this)
+);
+
+module.exports = {
+  onConfig() {
+    var readPreferenceMode = shellContext.db.getMongo().getReadPrefMode();
+    if (readPreferenceMode !== 'secondary') {
+      throw new Error(`Expected secondary read preference, received ${readPreferenceMode}.`);
+    }
+  },
+};

--- a/variety.js
+++ b/variety.js
@@ -45,7 +45,7 @@ Please see https://github.com/variety/variety for details. */
 //
 //   3. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
 //      shell globals: reading input (`collection`, `plugins`, `__quiet`,
-//      `slaveOk`, etc.), the config-echo logging, plugin loading via
+//      `secondaryOk`, etc.), the config-echo logging, plugin loading via
 //      `load()`, input validation, and constructing the dependency bag
 //      passed to `impl.run()`.
 //
@@ -580,9 +580,9 @@ Please see https://github.com/variety/variety for details. */
   log('Variety: A MongoDB Schema Analyzer');
   log('Version 1.5.2, released 30 September 2025');
 
-  if (typeof slaveOk !== 'undefined') {
-    if (slaveOk === true) {
-      db.getMongo().setSlaveOk();
+  if (typeof secondaryOk !== 'undefined') {
+    if (secondaryOk === true) {
+      db.getMongo().setReadPref('secondary');
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the deprecated `slaveOk` shell global with `secondaryOk` backed by `db.getMongo().setReadPref("secondary")`
- expose `--secondary-ok` and `--secondaryOk` through the packaged CLI
- update README/CONTRIBUTING/build docs and rebuild `variety.js`
- add unit, CLI, and real `mongosh` integration coverage for the secondary read preference path

Refs #309.

## Root cause
The documented `slaveOk = true` path called `db.getMongo().setSlaveOk()`, which throws under the modern `mongosh` environment tested during the issue audit. No test previously exercised that documented option against the real shell interface.

## Validation
- `npm run verify:build`
- `npm run lint`
- `npm run typecheck`
- `npm run lint:markdown`
- `npm run lint:spdx`
- `npm run test:mocha -- --grep "Mongo shell adapter validation|CLI option parsing|bin/variety wrapper"`
- focused MongoDB 8.2 / `mongosh` container run for `Secondary reads|Mongo shell adapter validation`: 3 passing

## Note
I attempted the full local container suite twice, but MongoDB reset mid-suite with `MongoNetworkError: read ECONNRESET` before the new secondary-read test body ran. The focused real-shell coverage passed locally; CI should provide the clean full-matrix signal on fresh runners.