### PR TITLE
Classify vector binary dtype bytes as distinct Variety labels (#318)

### DIFF
--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -43,6 +43,39 @@
     return shellToJson(binData);
   };
 
+  const getVectorDtypeByte = (binData) => {
+    if (!binData) { return undefined; }
+    if (typeof binData.hex === 'function') {
+      const hex = binData.hex();
+      if (typeof hex === 'string' && hex.length >= 2 && /^[0-9a-f]{2}/i.test(hex)) {
+        return parseInt(hex.slice(0, 2), 16);
+      }
+      return undefined;
+    }
+    if (typeof Buffer !== 'undefined' && binData.buffer) {
+      const buf = Buffer.from(binData.buffer);
+      return buf.length > 0 ? buf[0] : undefined;
+    }
+    return undefined;
+  };
+
+  const getVectorDtypeLabel = (binData) => {
+    const dtypeByte = getVectorDtypeByte(binData);
+    if (typeof dtypeByte === 'undefined') {
+      return 'BinData-vector[malformed]';
+    }
+    const dtypeAliases = {
+      0x03: 'INT8',
+      0x10: 'PACKED_BIT',
+      0x27: 'FLOAT32',
+    };
+    const alias = dtypeAliases[dtypeByte];
+    if (alias) {
+      return `BinData-vector[${alias}]`;
+    }
+    return `BinData-vector[0x${dtypeByte.toString(16).padStart(2, '0')}]`;
+  };
+
   const getRawBsonTypeName = (thing) => {
     if (!thing || typeof thing !== 'object') {
       return undefined;
@@ -141,6 +174,10 @@
       } else if (thing instanceof Date) {
         return 'Date';
       } else if (specialType === 'Binary') {
+        const subtype = getBinDataSubtype(thing);
+        if (subtype === 0x09) {
+          return getVectorDtypeLabel(thing);
+        }
         const binDataTypes = {
           0x00: 'generic',
           0x01: 'function',
@@ -151,10 +188,9 @@
           0x06: 'encrypted',
           0x07: 'compressed-column',
           0x08: 'sensitive',
-          0x09: 'vector',
           0x80: 'user',
         };
-        return `BinData-${binDataTypes[getBinDataSubtype(thing)]}`;
+        return `BinData-${binDataTypes[subtype]}`;
       } else if (typeof specialType !== 'undefined') {
         return specialType;
       } else {
@@ -381,6 +417,8 @@
     shellToJson,
     getBinDataSubtype,
     getBinDataHex,
+    getVectorDtypeByte,
+    getVectorDtypeLabel,
     getRawBsonTypeName,
     normalizeBsonTypeName,
     getSpecialTypeName,

--- a/docs/bson-type-inventory.md
+++ b/docs/bson-type-inventory.md
@@ -1,7 +1,7 @@
 # MongoDB BSON Type Inventory
 
 External sources retrieved: 2026-04-21
-Local evidence inspected: 2026-04-22
+Local evidence inspected: 2026-04-23
 
 This document inventories the BSON value types that MongoDB can store or has
 historically recognized, including deprecated types, `$type` aliases, binary
@@ -46,12 +46,16 @@ and test evidence inspected on 2026-04-22.
 Primary local evidence: [V1] tests most BSON-wrapper recognition; [V2], [V3],
 and [V4] cover common application values and arrays; [V5] defines the current
 type mapping; [V6] tests every standard binary subtype plus custom subtype
-`0x80`; and [V7] proves the Variety label for each deprecated top-level BSON
-type.
+`0x80` and vector dtype-specific labels; and [V7] proves the Variety label for
+each deprecated top-level BSON type.
 Current tests recognize BSON `Double` and `Int32` as Variety `Number`, BSON
 JavaScript code and JavaScript-with-scope as Variety `Code`, BSON `Symbol`
-(type 14) as Variety `String` in mongosh, and standard binary subtypes plus
-custom subtype `0x80` under their `BinData-{subtype}` labels.
+(type 14) as Variety `String` in mongosh, standard binary subtypes plus custom
+subtype `0x80` under their `BinData-{subtype}` labels, and vector binary
+subtype `9` values under dtype-specific labels (`BinData-vector[FLOAT32]`,
+`BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`), with unknown dtypes
+reported as `BinData-vector[0xNN]` and malformed payloads as
+`BinData-vector[malformed]`.
 
 ## Top-Level BSON Value Types
 
@@ -101,7 +105,7 @@ specification is the broader authority for the whole user-defined range.
 | `6` / `0x06` | Encrypted BSON value | Current | Tested | Encrypted BSON value, used by MongoDB encryption features. Variety reports this as `BinData-encrypted`. | [S1], [S2], [V6] |
 | `7` / `0x07` | Compressed BSON column / compressed time series data | Current | Tested | BSON spec calls this "Compressed BSON column"; MongoDB docs describe it as compressed time series data and mark it new in MongoDB 5.2. The format uses delta, delta-of-delta, run-length encoding, and sparse-array missing-value encoding. Variety reports this as `BinData-compressed-column`. Coverage is analyzer-level because MongoDB validates compressed-column payloads. | [S1], [S2], [V6] |
 | `8` / `0x08` | Sensitive | Current | Tested | Sensitive data such as a key or secret. MongoDB logs a placeholder rather than the literal binary value. Variety reports this as `BinData-sensitive`. | [S1], [S2], [V6] |
-| `9` / `0x09` | Vector | Current | Tested | Dense numeric vector storage. The binary payload starts with vector metadata bytes before the packed elements. Variety reports this as `BinData-vector`; it does not currently parse dtype-specific vector labels. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6], [V6] |
+| `9` / `0x09` | Vector | Current | Tested | Dense numeric vector storage. The binary payload starts with a dtype byte and padding byte before the packed elements. Variety inspects the dtype byte and reports dtype-specific labels: `BinData-vector[FLOAT32]`, `BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`. Unknown dtypes produce `BinData-vector[0xNN]`; unreadable payloads produce `BinData-vector[malformed]`. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6], [V6] |
 | `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Partial | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety maps subtype `0x80` to `BinData-user` and that subtype is test-backed. Subtypes `0x81` through `0xFF` have no intentional Variety mapping and produce `BinData-undefined`. | [S1], [S2], [V6] |
 
 ## Vector Subtype 9 Dtypes
@@ -117,9 +121,11 @@ validation updates through 2025-06-23.
 
 | Dtype byte | Alias | Bits per vector element | Variety | Meaning | Sources |
 | --- | --- | --- | --- | --- | --- |
-| `0x03` | `INT8` | 8 | Unmapped | Signed 8-bit integer vector elements in the range `-128` through `127`. | [S6] |
-| `0x10` | `PACKED_BIT` | 1 | Unmapped | Binary quantized vector. Logical values are bits, packed into bytes. The padding byte says how many least-significant bits in the final byte should be ignored. | [S6] |
-| `0x27` | `FLOAT32` | 32 | Unmapped | 32-bit floating point vector elements. Payload length after metadata must be a multiple of 4 bytes. | [S6] |
+| `0x03` | `INT8` | 8 | Tested | Signed 8-bit integer vector elements in the range `-128` through `127`. Variety reports this as `BinData-vector[INT8]`. | [S6], [V6] |
+| `0x10` | `PACKED_BIT` | 1 | Tested | Binary quantized vector. Logical values are bits, packed into bytes. The padding byte says how many least-significant bits in the final byte should be ignored. Variety reports this as `BinData-vector[PACKED_BIT]`. | [S6], [V6] |
+| `0x27` | `FLOAT32` | 32 | Tested | 32-bit floating point vector elements. Payload length after metadata must be a multiple of 4 bytes. Variety reports this as `BinData-vector[FLOAT32]`. | [S6], [V6] |
+| any unrecognized byte | — | N/A | Tested | Dtype byte not defined in the current spec. Variety reports this as `BinData-vector[0xNN]` where `NN` is the dtype byte in lowercase zero-padded hex. Coverage is analyzer-level. | [V6] |
+| (no payload) | — | N/A | Tested | Payload too short to contain a dtype byte. Variety reports this as `BinData-vector[malformed]`. Coverage is analyzer-level. | [V6] |
 
 ## Legacy UUID Interpretations
 
@@ -155,7 +161,7 @@ round-trip tests, but they are not extra top-level BSON types.
 | Regular expression, type `11` | Tested | Pattern cstring and options cstring. Options must be stored alphabetically. Supported option characters are `i`, `m`, `s`, `x`, and `u`. | [S1] |
 | String, type `2` | Tested | `int32` byte length, UTF-8 bytes, and trailing null byte. | [S1], [S2] |
 | Timestamp, type `17` | Tested | Serialized as a BSON `uint64`. BSON spec describes the first serialized 4 bytes as increment and the second as timestamp; MongoDB describes the logical value as high 32 bits `time_t` and low 32 bits ordinal, and compares time before ordinal. | [S1], [S2] |
-| Vector binary, subtype `9` | Tested | First byte is dtype, second byte is padding, and the rest is packed vector data using little-endian format. Variety reports this at the subtype level as `BinData-vector`; dtype-specific labels remain unmapped. | [S6], [V6] |
+| Vector binary, subtype `9` | Tested | First byte is dtype, second byte is padding, and the rest is packed vector data using little-endian format. Variety inspects the dtype byte and reports `BinData-vector[FLOAT32]`, `BinData-vector[INT8]`, or `BinData-vector[PACKED_BIT]` for recognized dtypes; `BinData-vector[0xNN]` for unknown dtypes; and `BinData-vector[malformed]` for payloads too short to contain a dtype byte. | [S6], [V6] |
 
 ## Query and Operator Aliases That Are Not Storage Types
 
@@ -186,7 +192,7 @@ round-trip tests, but they are not extra top-level BSON types.
 | Binary subtype `7` | Tested | MongoDB's BSON Types page marks compressed time series data as new in MongoDB 5.2. BSON spec names the subtype "Compressed BSON column". Variety reports this as `BinData-compressed-column`. | [S1], [S2], [V6] |
 | JavaScript code with scope in server-side JavaScript operations | Tested merged | Use of type `15` for `$where` and `mapReduce` functions was deprecated since MongoDB 4.2.1. MongoDB 4.4 removed `mapReduce` support for type `15`; current `$where` docs say `$where` no longer supports it. Variety reports code-with-scope values as `Code`. | [S9], [S10] |
 | Server-side JavaScript functions | Out of scope | Starting in MongoDB 8.0, server-side JavaScript functions such as `$accumulator`, `$function`, and `$where` are deprecated. This is an operational JavaScript execution caveat, not the removal of BSON type `13` from the storage inventory. | [S10] |
-| Vector binary subtype `9` | Tested | The vector subtype specification is accepted, has no minimum server version, and records acceptance on 2024-11-01. It has dtype validation updates through 2025-06-23. Variety reports vector binary values as `BinData-vector`; dtype-specific labels remain unmapped. | [S6], [V6] |
+| Vector binary subtype `9` | Tested | The vector subtype specification is accepted, has no minimum server version, and records acceptance on 2024-11-01. It has dtype validation updates through 2025-06-23. Variety inspects the dtype byte and reports dtype-specific labels: `BinData-vector[FLOAT32]`, `BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`. Unknown dtypes produce `BinData-vector[0xNN]`; malformed payloads produce `BinData-vector[malformed]`. | [S6], [V6] |
 
 ## Source Register
 
@@ -252,10 +258,12 @@ round-trip tests, but they are not extra top-level BSON types.
 - [V6] Variety local test file,
   [test/cases/analysis/BinarySubtypeTest.js](../test/cases/analysis/BinarySubtypeTest.js).
   Added 2026-04-21; updated and inspected in the current working tree on
-  2026-04-22. Essential metadata: integration and analyzer-level tests for
-  every standard BSON binary subtype plus custom subtype `0x80`: generic,
-  function, old, UUID-old, UUID, MD5, encrypted, compressed column, sensitive,
-  vector, and user-defined `0x80`.
+  2026-04-23. Essential metadata: integration and analyzer-level tests for
+  every standard BSON binary subtype plus custom subtype `0x80` and vector
+  dtype-specific labels: generic, function, old, UUID-old, UUID, MD5,
+  encrypted, compressed column, sensitive, user-defined `0x80`, and vector
+  binary with dtype labels for INT8, PACKED_BIT, and FLOAT32, unknown dtype
+  fallback, and malformed payload handling.
 - [V7] Variety local test file,
   [test/cases/analysis/DeprecatedBsonTypesTest.js](../test/cases/analysis/DeprecatedBsonTypesTest.js).
   Added 2026-04-21 and inspected in the current working tree on 2026-04-22.

--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -46,24 +46,27 @@ const test = new VarietyHarness('test', 'bindata_subtypes');
 
 // One document with a field per server-insertable BSON binary subtype that
 // Variety intentionally maps. Subtypes 3 (UUID old) and 4 (UUID) both report
-// as BinData-UUID.
+// as BinData-UUID. Vector subtype 9 fields use dtype-specific labels.
 const doc = {
-  binData_generic:  new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_DEFAULT),
-  binData_function: new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_FUNCTION),
-  binData_old:      new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_BYTE_ARRAY),
-  binData_uuid_old: new Binary(
+  binData_generic:           new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_DEFAULT),
+  binData_function:          new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_FUNCTION),
+  binData_old:               new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), Binary.SUBTYPE_BYTE_ARRAY),
+  binData_uuid_old:          new Binary(
     Uint8Array.from([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
     Binary.SUBTYPE_UUID_OLD
   ),
-  binData_uuid:     new UUID('00112233-4455-6677-8899-aabbccddeeff'),
-  binData_md5:      new Binary(
+  binData_uuid:              new UUID('00112233-4455-6677-8899-aabbccddeeff'),
+  binData_md5:               new Binary(
     Uint8Array.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]),
     Binary.SUBTYPE_MD5
   ),
   binData_encrypted:         new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x06),
   binData_sensitive:         new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x08),
-  binData_vector:            new Binary(Uint8Array.from([0x03, 0x00, 0x01, 0x02, 0x03]), 0x09),
-  binData_user:     new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
+  // Vector dtype payloads: byte 0 = dtype, byte 1 = padding, remaining = elements.
+  binData_vector_int8:       new Binary(Uint8Array.from([0x03, 0x00, 0x01, 0x02, 0x03]), 0x09),
+  binData_vector_packed_bit: new Binary(Uint8Array.from([0x10, 0x00, 0xff]), 0x09),
+  binData_vector_float32:    new Binary(Uint8Array.from([0x27, 0x00, 0x00, 0x00, 0x80, 0x3f]), 0x09),
+  binData_user:              new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
 };
 
 describe('Binary subtype recognition', () => {
@@ -72,23 +75,35 @@ describe('Binary subtype recognition', () => {
 
   it('should report each server-insertable mapped binary subtype under its Variety label', async () => {
     const results = await test.runJsonAnalysis({ collection: 'bindata_subtypes' }, true);
-    results.validateResultsCount(11); // _id plus one field per subtype
-    results.validate('_id',                       1, 100.0, { ObjectId: 1 });
-    results.validate('binData_generic',           1, 100.0, { 'BinData-generic':           1 });
-    results.validate('binData_function',          1, 100.0, { 'BinData-function':          1 });
-    results.validate('binData_old',               1, 100.0, { 'BinData-old':               1 });
+    results.validateResultsCount(13); // _id plus one field per subtype
+    results.validate('_id',                        1, 100.0, { ObjectId: 1 });
+    results.validate('binData_generic',            1, 100.0, { 'BinData-generic':              1 });
+    results.validate('binData_function',           1, 100.0, { 'BinData-function':             1 });
+    results.validate('binData_old',                1, 100.0, { 'BinData-old':                  1 });
     // Subtypes 3 (UUID old) and 4 (UUID) both map to BinData-UUID.
-    results.validate('binData_uuid_old',          1, 100.0, { 'BinData-UUID':              1 });
-    results.validate('binData_uuid',              1, 100.0, { 'BinData-UUID':              1 });
-    results.validate('binData_md5',               1, 100.0, { 'BinData-MD5':               1 });
-    results.validate('binData_encrypted',         1, 100.0, { 'BinData-encrypted':         1 });
-    results.validate('binData_sensitive',         1, 100.0, { 'BinData-sensitive':         1 });
-    results.validate('binData_vector',            1, 100.0, { 'BinData-vector':            1 });
-    results.validate('binData_user',              1, 100.0, { 'BinData-user':              1 });
+    results.validate('binData_uuid_old',           1, 100.0, { 'BinData-UUID':                 1 });
+    results.validate('binData_uuid',               1, 100.0, { 'BinData-UUID':                 1 });
+    results.validate('binData_md5',                1, 100.0, { 'BinData-MD5':                  1 });
+    results.validate('binData_encrypted',          1, 100.0, { 'BinData-encrypted':            1 });
+    results.validate('binData_sensitive',          1, 100.0, { 'BinData-sensitive':            1 });
+    results.validate('binData_vector_int8',        1, 100.0, { 'BinData-vector[INT8]':         1 });
+    results.validate('binData_vector_packed_bit',  1, 100.0, { 'BinData-vector[PACKED_BIT]':   1 });
+    results.validate('binData_vector_float32',     1, 100.0, { 'BinData-vector[FLOAT32]':      1 });
+    results.validate('binData_user',               1, 100.0, { 'BinData-user':                 1 });
   });
 
   it('should report compressed BSON column subtype under its Variety label', () => {
     const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x07));
     assert.equal(result, 'BinData-compressed-column');
+  });
+
+  it('should report an unknown vector dtype byte as BinData-vector[0xNN]', () => {
+    const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x42, 0x00, 0xde, 0xad]), 0x09));
+    assert.equal(result, 'BinData-vector[0x42]');
+  });
+
+  it('should report a malformed vector payload (empty) as BinData-vector[malformed]', () => {
+    const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([]), 0x09));
+    assert.equal(result, 'BinData-vector[malformed]');
   });
 });

--- a/variety.js
+++ b/variety.js
@@ -189,6 +189,39 @@ Please see https://github.com/variety/variety for details. */
     return shellToJson(binData);
   };
 
+  const getVectorDtypeByte = (binData) => {
+    if (!binData) { return undefined; }
+    if (typeof binData.hex === 'function') {
+      const hex = binData.hex();
+      if (typeof hex === 'string' && hex.length >= 2 && /^[0-9a-f]{2}/i.test(hex)) {
+        return parseInt(hex.slice(0, 2), 16);
+      }
+      return undefined;
+    }
+    if (typeof Buffer !== 'undefined' && binData.buffer) {
+      const buf = Buffer.from(binData.buffer);
+      return buf.length > 0 ? buf[0] : undefined;
+    }
+    return undefined;
+  };
+
+  const getVectorDtypeLabel = (binData) => {
+    const dtypeByte = getVectorDtypeByte(binData);
+    if (typeof dtypeByte === 'undefined') {
+      return 'BinData-vector[malformed]';
+    }
+    const dtypeAliases = {
+      0x03: 'INT8',
+      0x10: 'PACKED_BIT',
+      0x27: 'FLOAT32',
+    };
+    const alias = dtypeAliases[dtypeByte];
+    if (alias) {
+      return `BinData-vector[${alias}]`;
+    }
+    return `BinData-vector[0x${dtypeByte.toString(16).padStart(2, '0')}]`;
+  };
+
   const getRawBsonTypeName = (thing) => {
     if (!thing || typeof thing !== 'object') {
       return undefined;
@@ -287,6 +320,10 @@ Please see https://github.com/variety/variety for details. */
       } else if (thing instanceof Date) {
         return 'Date';
       } else if (specialType === 'Binary') {
+        const subtype = getBinDataSubtype(thing);
+        if (subtype === 0x09) {
+          return getVectorDtypeLabel(thing);
+        }
         const binDataTypes = {
           0x00: 'generic',
           0x01: 'function',
@@ -297,10 +334,9 @@ Please see https://github.com/variety/variety for details. */
           0x06: 'encrypted',
           0x07: 'compressed-column',
           0x08: 'sensitive',
-          0x09: 'vector',
           0x80: 'user',
         };
-        return `BinData-${binDataTypes[getBinDataSubtype(thing)]}`;
+        return `BinData-${binDataTypes[subtype]}`;
       } else if (typeof specialType !== 'undefined') {
         return specialType;
       } else {
@@ -527,6 +563,8 @@ Please see https://github.com/variety/variety for details. */
     shellToJson,
     getBinDataSubtype,
     getBinDataHex,
+    getVectorDtypeByte,
+    getVectorDtypeLabel,
     getRawBsonTypeName,
     normalizeBsonTypeName,
     getSpecialTypeName,


### PR DESCRIPTION
## Summary

- Add `getVectorDtypeByte` and `getVectorDtypeLabel` to `core/analyzer.js` to inspect the first payload byte of BSON binary subtype 9 values
- Emit dtype-specific labels: `BinData-vector[FLOAT32]`, `BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`
- Emit `BinData-vector[0xNN]` for unknown but well-formed dtypes (hex byte, lowercase, zero-padded)
- Emit `BinData-vector[malformed]` for payloads too short to contain a dtype byte
- Retire `BinData-vector` as a live output label (intentional backward-incompatible change)
- Update `docs/bson-type-inventory.md`: all three dtype rows move from `Unmapped` to `Tested`; unknown and malformed edge cases added to the table

## Test plan

- [x] Integration test: all three known dtypes (INT8, PACKED_BIT, FLOAT32) inserted into MongoDB 8.2 and validated against their Variety labels
- [x] Unit test: unknown dtype byte (`0x42`) produces `BinData-vector[0x42]`
- [x] Unit test: empty payload produces `BinData-vector[malformed]`
- [x] Full container test suite: 97 passing (3 pre-existing flaky persistence failures unrelated to this change)
- [x] All pre-commit hooks pass: build check, ESLint, jsonlint, markdownlint, js-yaml, hadolint, shellcheck, SPDX, typecheck

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)