### PR TITLE
Extract reusable internal analysis engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,21 +14,25 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 
 ## Repo Layout and the `variety.js` Build
 
-`variety.js` at the repo root is a generated file, assembled from four sources in this order:
+`variety.js` at the repo root is a generated file, assembled from five sources in this order:
 
 - `core/formatters/ascii.js` — built-in ASCII table formatter. Self-contained
   IIFE; registers an `ascii` factory on `shellContext.__varietyFormatters`.
 - `core/formatters/json.js` — built-in JSON formatter. Self-contained IIFE;
   registers a `json` factory on `shellContext.__varietyFormatters`.
-- `core/analyzer.js` — pure, transport-agnostic analysis logic. No runtime
-  dependencies on shell globals, Node I/O, or any other layer. Reads
-  `shellContext.__varietyFormatters` to dispatch output. This is the
-  future `@variety/core` package boundary.
+- `core/engine.js` — pure, side-effect-free analysis logic. No runtime
+  dependencies on shell globals, Node I/O, persistence, or formatting. Exports
+  the reducer/finalization engine used by both the shell-facing analyzer and
+  Node-side tests. This is the future `@variety/core` package boundary.
+- `core/analyzer.js` — shell-adjacent orchestration that traverses the cursor,
+  optionally persists results, dispatches to formatters, and exposes `run()`
+  on top of `core/engine.js`. Depends on `core/formatters/` and `core/engine.js`.
 - `mongo-shell/adapter.js` — the shell-facing layer that reads shell
   globals (`collection`, `plugins`, `secondaryOk`, etc.), loads plugins, and
   hands dependencies to `impl.run()`. The only place in the build that
-  touches `db`, `print`, and `load`. Cleans up both `__varietyImpl` and
-  `__varietyFormatters` after execution so repeated loads are idempotent.
+  touches `db`, `print`, and `load`. Cleans up `__varietyEngine`,
+  `__varietyImpl`, and `__varietyFormatters` after execution so repeated loads
+  are idempotent.
   Depends on `core`; compiled into `variety.js` by `build.js` (not a
   separately published package).
 - `bin/variety` — the published Node entrypoint that implements the main
@@ -42,10 +46,12 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   `@variety/cli` package boundary.
 
 **Dependency directions:** `core/formatters/` has no runtime deps on any other
-layer. `core` depends on `core/formatters/`. `mongo-shell/adapter.js` depends on
-`core`. `mongo-shell/launcher.js` is Node-only (no `core` dep). `cli` depends on
-`core` and `mongo-shell/`. `build.js` composes `core/formatters/` + `core` +
-`mongo-shell/adapter.js` → `variety.js`.
+layer. `core/engine.js` has no runtime deps on any other layer. `core/analyzer.js`
+depends on `core/engine.js` plus `core/formatters/`. `mongo-shell/adapter.js`
+depends on `core/analyzer.js`. `mongo-shell/launcher.js` is Node-only (no `core`
+dep). `cli` depends on `mongo-shell/` and the built script path, not on the
+engine directly. `build.js` composes `core/formatters/` + `core/engine.js` +
+`core/analyzer.js` + `mongo-shell/adapter.js` → `variety.js`.
 
 `build.js` concatenates those source files under a generated-file banner.
 Edit the sources in `core/` or `mongo-shell/adapter.js`, then run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   IIFE; registers an `ascii` factory on `shellContext.__varietyFormatters`.
 - `core/formatters/json.js` — built-in JSON formatter. Self-contained IIFE;
   registers a `json` factory on `shellContext.__varietyFormatters`.
-- `core/engine.js` — pure, side-effect-free analysis logic. No runtime
-  dependencies on shell globals, Node I/O, persistence, or formatting. Exports
-  the reducer/finalization engine used by both the shell-facing analyzer and
+- `core/engine.js` — reusable analysis logic that keeps persistence,
+  formatter dispatch, and output side effects out of the engine. It still
+  tolerates shell/runtime helpers when they are available. Exports the
+  reducer/finalization engine used by both the shell-facing analyzer and
   Node-side tests. This is the future `@variety/core` package boundary.
 - `core/analyzer.js` — shell-adjacent orchestration that traverses the cursor,
   optionally persists results, dispatches to formatters, and exposes `run()`

--- a/build.js
+++ b/build.js
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
 'use strict';
 
-// Assembles variety.js by concatenating the formatter files, core/analyzer.js, and
-// mongo-shell/adapter.js underneath a generated-file banner. The built variety.js
+// Assembles variety.js by concatenating the formatter files, core/engine.js,
+// core/analyzer.js, and mongo-shell/adapter.js underneath a generated-file banner. The built variety.js
 // is committed to the repository so `mongosh variety.js` works from a fresh clone without
 // running a build step first; CI runs this script and fails if the
 // committed file drifts from its sources.
@@ -28,7 +28,7 @@ Please see https://github.com/variety/variety for details. */
 //
 // Assembled by build.js from:
 //   core/formatters/ascii.js, core/formatters/json.js,
-//   core/analyzer.js, mongo-shell/adapter.js.
+//   core/engine.js, core/analyzer.js, mongo-shell/adapter.js.
 // To change behavior, edit those source files and run \`npm run build\`. The
 // build output is committed so \`mongosh variety.js\` works from a fresh clone
 // without a build step; CI verifies the committed file matches its sources.
@@ -44,20 +44,25 @@ Please see https://github.com/variety/variety for details. */
 // See .eslint.config.js for the enforced rule set.
 
 // -----------------------------------------------------------------------------
-// This file is organized in four sections, sourced from four separate files:
+// This file is organized in four sections, sourced from five separate files:
 //
 //   1. FORMATTER SECTION (core/formatters/ascii.js, core/formatters/json.js) —
 //      built-in output formatters. Each is a self-contained IIFE that registers
 //      a factory function on \`shellContext.__varietyFormatters\`. Third-party
 //      formatters can be supplied as plugins instead (see README).
 //
-//   2. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
-//      analysis logic. Functions take their dependencies (config, and where
-//      needed a \`log\` function or a \`deps\` bag holding shell primitives)
-//      as explicit parameters. The section hands a bundle of functions to
-//      the interface section via \`shellContext.__varietyImpl\`.
+//   2. ENGINE SECTION (core/engine.js) — pure, side-effect-free analysis logic.
+//      Functions take their dependencies (config, and where needed a \`log\`
+//      function) as explicit parameters and return structured analysis rows.
+//      The section hands a reusable engine to later sections via
+//      \`shellContext.__varietyEngine\`.
 //
-//   3. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
+//   3. ANALYZER SECTION (core/analyzer.js) — shell-adjacent orchestration for
+//      cursor traversal, optional persistence, and formatter dispatch. Depends
+//      on the engine and hands the combined internal API to the interface
+//      section via \`shellContext.__varietyImpl\`.
+//
+//   4. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
 //      shell globals: reading input (\`collection\`, \`plugins\`, \`__quiet\`,
 //      \`secondaryOk\`, etc.), the config-echo logging, plugin loading via
 //      \`load()\`, input validation, and constructing the dependency bag
@@ -71,12 +76,13 @@ Please see https://github.com/variety/variety for details. */
 const root = __dirname;
 const fmtAscii = fs.readFileSync(path.join(root, 'core', 'formatters', 'ascii.js'), 'utf8');
 const fmtJson  = fs.readFileSync(path.join(root, 'core', 'formatters', 'json.js'), 'utf8');
-const impl     = fs.readFileSync(path.join(root, 'core', 'analyzer.js'), 'utf8');
+const engine   = fs.readFileSync(path.join(root, 'core', 'engine.js'), 'utf8');
+const analyzer = fs.readFileSync(path.join(root, 'core', 'analyzer.js'), 'utf8');
 const iface    = fs.readFileSync(path.join(root, 'mongo-shell', 'adapter.js'), 'utf8');
 
 // HEADER ends with a single \n; each source file ends with a single \n. We
 // want two blank lines (three \n total) between each region in the output.
-const output = `${HEADER}\n\n${fmtAscii}\n\n${fmtJson}\n\n${impl}\n\n${iface}`;
+const output = `${HEADER}\n\n${fmtAscii}\n\n${fmtJson}\n\n${engine}\n\n${analyzer}\n\n${iface}`;
 
 const outPath = path.join(root, 'variety.js');
 
@@ -85,7 +91,7 @@ if (args.includes('--check')) {
   const existing = fs.readFileSync(outPath, 'utf8');
   if (existing !== output) {
     process.stderr.write(
-      'variety.js is out of date relative to its sources (core/formatters/, core/analyzer.js, mongo-shell/adapter.js).\n' +
+      'variety.js is out of date relative to its sources (core/formatters/, core/engine.js, core/analyzer.js, mongo-shell/adapter.js).\n' +
       'Run `npm run build` and commit the updated variety.js.\n'
     );
     process.exit(1);

--- a/build.js
+++ b/build.js
@@ -51,11 +51,13 @@ Please see https://github.com/variety/variety for details. */
 //      a factory function on \`shellContext.__varietyFormatters\`. Third-party
 //      formatters can be supplied as plugins instead (see README).
 //
-//   2. ENGINE SECTION (core/engine.js) — pure, side-effect-free analysis logic.
-//      Functions take their dependencies (config, and where needed a \`log\`
-//      function) as explicit parameters and return structured analysis rows.
-//      The section hands a reusable engine to later sections via
-//      \`shellContext.__varietyEngine\`.
+//   2. ENGINE SECTION (core/engine.js) — reusable analysis logic that keeps
+//      persistence, formatter dispatch, and output side effects out of the
+//      engine. It still tolerates shell/runtime helpers when they are
+//      available. Functions take their dependencies (config, and where needed
+//      a \`log\` function) as explicit parameters and return structured
+//      analysis rows. The section hands a reusable engine to later sections
+//      via \`shellContext.__varietyEngine\`.
 //
 //   3. ANALYZER SECTION (core/analyzer.js) — shell-adjacent orchestration for
 //      cursor traversal, optional persistence, and formatter dispatch. Depends

--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -1,406 +1,42 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
 // =============================================================================
-// IMPLEMENTATION SECTION
+// ANALYZER SECTION
 // =============================================================================
 (function (shellContext) {
   'use strict';
 
   shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
 
-  const createKeyMap = () => Object.create(null);
+  const engine = shellContext.__varietyEngine ||
+    (typeof module !== 'undefined' && module && module.exports && typeof require === 'function'
+      ? require('./engine.js')
+      : undefined);
+  if (!engine) {
+    throw new Error('Expected core/engine.js to register __varietyEngine.');
+  }
 
-  const shellToJson = (value) => {
-    if (typeof tojson === 'function') {
-      return tojson(value);
+  const persistResults = (config, varietyResults, deps) => {
+    const {db, connect, log} = deps;
+
+    const resultsCollectionName = config.resultsCollection;
+    const resultsDB = !config.resultsDatabase.includes('/')
+      // Local database; don't reconnect.
+      ? db.getMongo().getDB(config.resultsDatabase)
+      // Remote database, establish new connection.
+      : connect(config.resultsDatabase);
+
+    if (config.resultsUser !== null && config.resultsPass !== null) {
+      resultsDB.auth(config.resultsUser, config.resultsPass);
     }
 
-    if (shellContext.EJSON && typeof shellContext.EJSON.stringify === 'function') {
-      return shellContext.EJSON.stringify(value);
-    }
-
-    return JSON.stringify(value);
+    // Replace results collection.
+    log(`replacing results collection: ${resultsCollectionName}`);
+    resultsDB.getCollection(resultsCollectionName).drop();
+    resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
   };
 
-  const getBinDataSubtype = (binData) => {
-    if (!binData) { return undefined; }
-    if (typeof binData.subtype === 'function') {
-      return binData.subtype();
-    }
-    if (typeof binData.sub_type !== 'undefined') {
-      return binData.sub_type;
-    }
-    return undefined;
-  };
-
-  const getBinDataHex = (binData) => {
-    if (binData && typeof binData.hex === 'function') {
-      return binData.hex();
-    }
-    if (binData && typeof Buffer !== 'undefined' && binData.buffer) {
-      return Buffer.from(binData.buffer).toString('hex');
-    }
-    return shellToJson(binData);
-  };
-
-  const getVectorDtypeByte = (binData) => {
-    if (!binData) { return undefined; }
-    if (typeof binData.hex === 'function') {
-      const hex = binData.hex();
-      if (typeof hex === 'string' && hex.length >= 2 && /^[0-9a-f]{2}/i.test(hex)) {
-        return parseInt(hex.slice(0, 2), 16);
-      }
-      return undefined;
-    }
-    if (typeof Buffer !== 'undefined' && binData.buffer) {
-      const buf = Buffer.from(binData.buffer);
-      return buf.length > 0 ? buf[0] : undefined;
-    }
-    return undefined;
-  };
-
-  const getVectorDtypeLabel = (binData) => {
-    const dtypeByte = getVectorDtypeByte(binData);
-    if (typeof dtypeByte === 'undefined') {
-      return 'BinData-vector[malformed]';
-    }
-    const dtypeAliases = {
-      0x03: 'INT8',
-      0x10: 'PACKED_BIT',
-      0x27: 'FLOAT32',
-    };
-    const alias = dtypeAliases[dtypeByte];
-    if (alias) {
-      return `BinData-vector[${alias}]`;
-    }
-    return `BinData-vector[0x${dtypeByte.toString(16).padStart(2, '0')}]`;
-  };
-
-  const getRawBsonTypeName = (thing) => {
-    if (!thing || typeof thing !== 'object') {
-      return undefined;
-    }
-
-    if (typeof thing._bsontype === 'string') {
-      return thing._bsontype;
-    }
-
-    if (thing.constructor && typeof thing.constructor.name === 'string') {
-      return thing.constructor.name;
-    }
-
-    return undefined;
-  };
-
-  const normalizeBsonTypeName = (rawTypeName) => {
-    const typeMap = {
-      Binary: 'Binary',
-      BinData: 'Binary',
-      UUID: 'Binary',
-      Long: 'NumberLong',
-      NumberLong: 'NumberLong',
-      ObjectId: 'ObjectId',
-      Decimal128: 'Decimal128',
-      NumberDecimal: 'Decimal128',
-      Timestamp: 'Timestamp',
-      Code: 'Code',
-      RegExp: 'BSONRegExp',
-      BSONRegExp: 'BSONRegExp',
-      MinKey: 'MinKey',
-      MaxKey: 'MaxKey',
-      DBRef: 'DBRef',
-      Double: 'Double',
-      Int32: 'Int32',
-      BSONSymbol: 'BSONSymbol',
-    };
-
-    return typeMap[rawTypeName];
-  };
-
-  const getSpecialTypeName = (thing) => {
-    // Issue #164 (@vitorcampos-db): BSON wrappers like Decimal128 should not
-    // fall through as plain Object values.
-    const normalizedType = normalizeBsonTypeName(getRawBsonTypeName(thing));
-    if (typeof normalizedType !== 'undefined') {
-      return normalizedType;
-    }
-
-    if (typeof NumberLong !== 'undefined' && thing instanceof NumberLong) {
-      return 'NumberLong';
-    }
-
-    if (typeof ObjectId !== 'undefined' && thing instanceof ObjectId) {
-      return 'ObjectId';
-    }
-
-    if (typeof BinData !== 'undefined' && thing instanceof BinData) {
-      return 'Binary';
-    }
-
-    return undefined;
-  };
-
-  // varietyTypeOf must remain a regular function (not an arrow function) because
-  // the no-argument guard below relies on the function's own `arguments` object,
-  // which arrow functions do not have.
-  const varietyTypeOf = function(config, thing) {
-    if (arguments.length < 2) { throw new Error('varietyTypeOf() requires an argument'); }
-
-    if (typeof thing === 'undefined') {
-      return 'undefined';
-    } else if (typeof thing !== 'object') {
-      // capitalize the first letter so the output matches the other return values. ―JC
-      const typeofThing = typeof thing;
-      return `${typeofThing[0].toUpperCase()}${typeofThing.slice(1)}`;
-    } else {
-      const specialType = getSpecialTypeName(thing);
-      if (Array.isArray(thing)) {
-        if (!config.compactArrayTypes) {
-          return 'Array';
-        }
-
-        if (thing.length === 0) {
-          return 'Array(empty)';
-        }
-
-        const seenElementTypes = Object.create(null);
-        thing.forEach((item) => {
-          seenElementTypes[varietyTypeOf(config, item)] = true;
-        });
-
-        return `Array(${Object.keys(seenElementTypes).sort().join('|')})`;
-      } else if (thing === null) {
-        return 'null';
-      } else if (thing instanceof Date) {
-        return 'Date';
-      } else if (specialType === 'Binary') {
-        const subtype = getBinDataSubtype(thing);
-        if (subtype === 0x09) {
-          return getVectorDtypeLabel(thing);
-        }
-        const binDataTypes = {
-          0x00: 'generic',
-          0x01: 'function',
-          0x02: 'old',
-          0x03: 'UUID',
-          0x04: 'UUID',
-          0x05: 'MD5',
-          0x06: 'encrypted',
-          0x07: 'compressed-column',
-          0x08: 'sensitive',
-          0x80: 'user',
-        };
-        return `BinData-${binDataTypes[subtype]}`;
-      } else if (typeof specialType !== 'undefined') {
-        return specialType;
-      } else {
-        return 'Object';
-      }
-    }
-  };
-
-  // Flattens object keys to 1D. e.g. {'key1':1, 'key2':{'key3':2}} becomes {'key1':1, 'key2.key3':2}.
-  // We assume no '.' characters in the keys, which is an OK assumption for MongoDB.
-  const serializeDoc = (config, doc) => {
-    const result = createKeyMap();
-
-    // Recurse only into plain objects and arrays; BSON wrappers should stay scalar.
-    const isHash = (v) => Array.isArray(v) || varietyTypeOf(config, v) === 'Object';
-
-    const arrayRegex = new RegExp(`\\.${config.arrayEscape}\\d+${config.arrayEscape}\\.`, 'g');
-
-    const serialize = (document, parentKey, depth) => {
-      if (parentKey.replace(arrayRegex, '.') in config.excludeSubkeys) {
-        return;
-      }
-      for (const key of Object.keys(document)) {
-        const value = document[key];
-        // Translate array index from {parent}.{index} to {parent}.arrayEscape{index}arrayEscape.
-        const escapedKey = Array.isArray(document)
-          ? `${config.arrayEscape}${key}${config.arrayEscape}`
-          : key;
-        result[`${parentKey}${escapedKey}`] = value;
-        // Recurse into nested objects only if we have not reached max depth.
-        if (isHash(value) && depth > 1) {
-          serialize(value, `${parentKey}${escapedKey}.`, depth - 1);
-        }
-      }
-    };
-    serialize(doc, '', config.maxDepth);
-    return result;
-  };
-
-  // Convert document to key-value map, where value is always an object with types as keys.
-  const analyseDocument = (config, document) => {
-    const result = createKeyMap();
-    const arrayRegex = new RegExp(`\\.${config.arrayEscape}\\d+${config.arrayEscape}`, 'g');
-    for (const rawKey of Object.keys(document)) {
-      const value = document[rawKey];
-      const key = rawKey.replace(arrayRegex, `.${config.arrayEscape}`);
-      if (typeof result[key] === 'undefined') {
-        result[key] = {};
-      }
-      const type = varietyTypeOf(config, value);
-      result[key][type] = null;
-
-      if (config.lastValue || config.maxExamples > 0) {
-        if (type in {'String': true, 'Boolean': true}) {
-          result[key][type] = value.toString();
-        } else if (type in {'Number': true, 'NumberLong': true}) {
-          result[key][type] = value.valueOf();
-        } else if (type === 'ObjectId') {
-          result[key][type] = typeof value.toHexString === 'function' ? value.toHexString() : value.str;
-        } else if (type === 'Date') {
-          result[key][type] = new Date(value).toISOString();
-        } else if (type.startsWith('BinData')) {
-          result[key][type] = getBinDataHex(value);
-        }
-      }
-    }
-
-    return result;
-  };
-
-  const mergeDocument = (config, docResult, interimResults, log) => {
-    for (const key of Object.keys(docResult)) {
-      if (key in interimResults) {
-        const existing = interimResults[key];
-
-        for (const type of Object.keys(docResult[key])) {
-          if (type in existing.types) {
-            existing.types[type] += 1;
-          } else {
-            existing.types[type] = 1;
-            if (config.logKeysContinuously) {
-              log(`Found new key type "${key}" type "${type}"`);
-            }
-          }
-          if (config.maxExamples > 0 && existing.examples.length < config.maxExamples) {
-            const rawVal = docResult[key][type];
-            existing.examples.push(rawVal !== null ? rawVal : `[${type}]`);
-          }
-        }
-        existing.totalOccurrences += 1;
-      } else {
-        let lastValue = null;
-        let lastType = null;
-        const types = createKeyMap();
-        const examples = [];
-        for (const newType of Object.keys(docResult[key])) {
-          types[newType] = 1;
-          lastValue = docResult[key][newType];
-          lastType = newType;
-          if (config.maxExamples > 0 && examples.length < config.maxExamples) {
-            examples.push(lastValue !== null ? lastValue : `[${newType}]`);
-          }
-          if (config.logKeysContinuously) {
-            log(`Found new key type "${key}" type "${newType}"`);
-          }
-        }
-        interimResults[key] = {types, totalOccurrences: 1};
-        if (config.lastValue) {
-          interimResults[key].lastValue = lastValue ? lastValue : `[${lastType}]`;
-        }
-        if (config.maxExamples > 0) {
-          interimResults[key].examples = examples;
-        }
-      }
-    }
-  };
-
-  const convertResults = (config, interimResults, documentsCount) => {
-    const varietyResults = [];
-    for (const key of Object.keys(interimResults)) {
-      const entry = interimResults[key];
-
-      const obj = {
-        _id: {key},
-        value: {types: {...entry.types}},
-        totalOccurrences: entry.totalOccurrences,
-        percentContaining: entry.totalOccurrences * 100 / documentsCount,
-      };
-
-      if (config.lastValue) {
-        obj.lastValue = entry.lastValue;
-      }
-
-      if (config.maxExamples > 0) {
-        obj.examples = entry.examples;
-      }
-
-      varietyResults.push(obj);
-    }
-    return varietyResults;
-  };
-
-  // Merge the keys and types of current object into accumulator object.
-  const reduceDocuments = (config, accumulator, object, log) => {
-    const docResult = analyseDocument(config, serializeDoc(config, object));
-    mergeDocument(config, docResult, accumulator, log);
-    return accumulator;
-  };
-
-  const reduceCursor = (cursor, callback, initialValue) => {
-    let result = initialValue;
-    cursor.forEach((obj) => {
-      result = callback(result, obj);
-    });
-    return result;
-  };
-
-  // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
-  // since the parent key already captures the Array type. Set showArrayElements:true
-  // to include them — useful for verifying element-type consistency within arrays.
-  const buildResultFilter = (config) => {
-    const arrayRegex = new RegExp(`\\.${config.arrayEscape}$`, 'g');
-    return (item) => config.showArrayElements || !item._id.key.match(arrayRegex);
-  };
-
-  // Sort desc by totalOccurrences, or by key asc if occurrences are equal.
-  const compareResults = (a, b) => {
-    const countsDiff = b.totalOccurrences - a.totalOccurrences;
-    return countsDiff !== 0 ? countsDiff : a._id.key.localeCompare(b._id.key);
-  };
-
-  // Orchestrates a Variety analysis from a parsed config and constructed
-  // pluginsRunner, pulling every shell primitive it needs from `deps`.
-  const run = (config, pluginsRunner, deps) => {
-    const {db, connect, log, print, countMatchingDocuments} = deps;
-
-    // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
-    let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
-    if (config.limit > 0) { cursor = cursor.limit(config.limit); }
-    const interimResults = reduceCursor(
-      cursor,
-      (acc, obj) => reduceDocuments(config, acc, obj, log),
-      createKeyMap()
-    );
-    const varietyResults = convertResults(
-      config,
-      interimResults,
-      countMatchingDocuments(config.collection, config.query, config.limit)
-    )
-      .filter(buildResultFilter(config))
-      .sort(compareResults);
-
-    if (config.persistResults) {
-      const resultsCollectionName = config.resultsCollection;
-      const resultsDB = !config.resultsDatabase.includes('/')
-        // Local database; don't reconnect.
-        ? db.getMongo().getDB(config.resultsDatabase)
-        // Remote database, establish new connection.
-        : connect(config.resultsDatabase);
-
-      if (config.resultsUser !== null && config.resultsPass !== null) {
-        resultsDB.auth(config.resultsUser, config.resultsPass);
-      }
-
-      // Replace results collection.
-      log(`replacing results collection: ${resultsCollectionName}`);
-      resultsDB.getCollection(resultsCollectionName).drop();
-      resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
-    }
-
+  const formatResults = (config, pluginsRunner, varietyResults, print) => {
     const formatterFactory = shellContext.__varietyFormatters[config.outputFormat];
     if (typeof formatterFactory !== 'function') {
       throw new Error(`Unknown outputFormat "${config.outputFormat}". Valid values are: ${Object.keys(shellContext.__varietyFormatters).join(', ')}.`);
@@ -412,23 +48,35 @@
     outputs.forEach((output) => print(output));
   };
 
-  shellContext.__varietyImpl = {
-    createKeyMap,
-    shellToJson,
-    getBinDataSubtype,
-    getBinDataHex,
-    getVectorDtypeByte,
-    getVectorDtypeLabel,
-    getRawBsonTypeName,
-    normalizeBsonTypeName,
-    getSpecialTypeName,
-    varietyTypeOf,
-    serializeDoc,
-    analyseDocument,
-    mergeDocument,
-    convertResults,
-    reduceDocuments,
-    reduceCursor,
-    run,
+  // Orchestrates a Variety analysis from a parsed config and constructed
+  // pluginsRunner, pulling every shell primitive it needs from `deps`.
+  const run = (config, pluginsRunner, deps) => {
+    const {db, connect, log, print, countMatchingDocuments} = deps;
+
+    // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
+    let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
+    if (config.limit > 0) { cursor = cursor.limit(config.limit); }
+    const interimResults = engine.createAnalysisState();
+    cursor.forEach((obj) => {
+      engine.ingestDocument(config, interimResults, obj, log);
+    });
+    const varietyResults = engine.finalizeResults(
+      config,
+      interimResults,
+      countMatchingDocuments(config.collection, config.query, config.limit)
+    );
+
+    if (config.persistResults) {
+      persistResults(config, varietyResults, {db, connect, log});
+    }
+
+    formatResults(config, pluginsRunner, varietyResults, print);
   };
+
+  const impl = Object.assign({}, engine, { run });
+  shellContext.__varietyImpl = impl;
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = impl;
+  }
 }(this));

--- a/core/engine.js
+++ b/core/engine.js
@@ -342,14 +342,6 @@
     return accumulator;
   };
 
-  const reduceCursor = (cursor, callback, initialValue) => {
-    let result = initialValue;
-    cursor.forEach((obj) => {
-      result = callback(result, obj);
-    });
-    return result;
-  };
-
   // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
   // since the parent key already captures the Array type. Set showArrayElements:true
   // to include them — useful for verifying element-type consistency within arrays.
@@ -373,7 +365,11 @@
   /**
    * @param {Record<string, unknown>} config
    * @param {Iterable<Record<string, unknown>>} documents
-   * @param {{ documentsCount?: number, log?: (message: string) => void }} [options]
+   * @param {{
+   *   documentsCount?: number,
+   *   log?: (message: string) => void
+   * }} [options] When documentsCount is provided, percentContaining uses that
+   * value instead of the number of iterated documents.
    */
   const analyzeDocuments = (config, documents, options) => {
     const analysisOptions = options || {};
@@ -410,13 +406,10 @@
     mergeDocument,
     convertResults,
     ingestDocument,
-    reduceCursor,
     buildResultFilter,
     compareResults,
     finalizeResults,
     analyzeDocuments,
-    // Back-compat alias while the adapter/orchestration migrates to the new names.
-    reduceDocuments: ingestDocument,
   };
 
   shellContext.__varietyEngine = engine;

--- a/core/engine.js
+++ b/core/engine.js
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+// =============================================================================
+// ENGINE SECTION
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  const createKeyMap = () => Object.create(null);
+
+  const shellToJson = (value) => {
+    if (typeof tojson === 'function') {
+      return tojson(value);
+    }
+
+    if (shellContext.EJSON && typeof shellContext.EJSON.stringify === 'function') {
+      return shellContext.EJSON.stringify(value);
+    }
+
+    return JSON.stringify(value);
+  };
+
+  const getBinDataSubtype = (binData) => {
+    if (!binData) { return undefined; }
+    if (typeof binData.subtype === 'function') {
+      return binData.subtype();
+    }
+    if (typeof binData.sub_type !== 'undefined') {
+      return binData.sub_type;
+    }
+    return undefined;
+  };
+
+  const getBinDataHex = (binData) => {
+    if (binData && typeof binData.hex === 'function') {
+      return binData.hex();
+    }
+    if (binData && typeof Buffer !== 'undefined' && binData.buffer) {
+      return Buffer.from(binData.buffer).toString('hex');
+    }
+    return shellToJson(binData);
+  };
+
+  const getVectorDtypeByte = (binData) => {
+    if (!binData) { return undefined; }
+    if (typeof binData.hex === 'function') {
+      const hex = binData.hex();
+      if (typeof hex === 'string' && hex.length >= 2 && /^[0-9a-f]{2}/i.test(hex)) {
+        return parseInt(hex.slice(0, 2), 16);
+      }
+      return undefined;
+    }
+    if (typeof Buffer !== 'undefined' && binData.buffer) {
+      const buf = Buffer.from(binData.buffer);
+      return buf.length > 0 ? buf[0] : undefined;
+    }
+    return undefined;
+  };
+
+  const getVectorDtypeLabel = (binData) => {
+    const dtypeByte = getVectorDtypeByte(binData);
+    if (typeof dtypeByte === 'undefined') {
+      return 'BinData-vector[malformed]';
+    }
+    const dtypeAliases = {
+      0x03: 'INT8',
+      0x10: 'PACKED_BIT',
+      0x27: 'FLOAT32',
+    };
+    const alias = dtypeAliases[dtypeByte];
+    if (alias) {
+      return `BinData-vector[${alias}]`;
+    }
+    return `BinData-vector[0x${dtypeByte.toString(16).padStart(2, '0')}]`;
+  };
+
+  const getRawBsonTypeName = (thing) => {
+    if (!thing || typeof thing !== 'object') {
+      return undefined;
+    }
+
+    if (typeof thing._bsontype === 'string') {
+      return thing._bsontype;
+    }
+
+    if (thing.constructor && typeof thing.constructor.name === 'string') {
+      return thing.constructor.name;
+    }
+
+    return undefined;
+  };
+
+  const normalizeBsonTypeName = (rawTypeName) => {
+    const typeMap = {
+      Binary: 'Binary',
+      BinData: 'Binary',
+      UUID: 'Binary',
+      Long: 'NumberLong',
+      NumberLong: 'NumberLong',
+      ObjectId: 'ObjectId',
+      Decimal128: 'Decimal128',
+      NumberDecimal: 'Decimal128',
+      Timestamp: 'Timestamp',
+      Code: 'Code',
+      RegExp: 'BSONRegExp',
+      BSONRegExp: 'BSONRegExp',
+      MinKey: 'MinKey',
+      MaxKey: 'MaxKey',
+      DBRef: 'DBRef',
+      Double: 'Double',
+      Int32: 'Int32',
+      BSONSymbol: 'BSONSymbol',
+    };
+
+    return typeMap[rawTypeName];
+  };
+
+  const getSpecialTypeName = (thing) => {
+    // Issue #164 (@vitorcampos-db): BSON wrappers like Decimal128 should not
+    // fall through as plain Object values.
+    const normalizedType = normalizeBsonTypeName(getRawBsonTypeName(thing));
+    if (typeof normalizedType !== 'undefined') {
+      return normalizedType;
+    }
+
+    if (typeof NumberLong !== 'undefined' && thing instanceof NumberLong) {
+      return 'NumberLong';
+    }
+
+    if (typeof ObjectId !== 'undefined' && thing instanceof ObjectId) {
+      return 'ObjectId';
+    }
+
+    if (typeof BinData !== 'undefined' && thing instanceof BinData) {
+      return 'Binary';
+    }
+
+    return undefined;
+  };
+
+  // varietyTypeOf must remain a regular function (not an arrow function) because
+  // the no-argument guard below relies on the function's own `arguments` object,
+  // which arrow functions do not have.
+  const varietyTypeOf = function(config, thing) {
+    if (arguments.length < 2) { throw new Error('varietyTypeOf() requires an argument'); }
+
+    if (typeof thing === 'undefined') {
+      return 'undefined';
+    } else if (typeof thing !== 'object') {
+      // capitalize the first letter so the output matches the other return values. ―JC
+      const typeofThing = typeof thing;
+      return `${typeofThing[0].toUpperCase()}${typeofThing.slice(1)}`;
+    } else {
+      const specialType = getSpecialTypeName(thing);
+      if (Array.isArray(thing)) {
+        if (!config.compactArrayTypes) {
+          return 'Array';
+        }
+
+        if (thing.length === 0) {
+          return 'Array(empty)';
+        }
+
+        const seenElementTypes = Object.create(null);
+        thing.forEach((item) => {
+          seenElementTypes[varietyTypeOf(config, item)] = true;
+        });
+
+        return `Array(${Object.keys(seenElementTypes).sort().join('|')})`;
+      } else if (thing === null) {
+        return 'null';
+      } else if (thing instanceof Date) {
+        return 'Date';
+      } else if (specialType === 'Binary') {
+        const subtype = getBinDataSubtype(thing);
+        if (subtype === 0x09) {
+          return getVectorDtypeLabel(thing);
+        }
+        const binDataTypes = {
+          0x00: 'generic',
+          0x01: 'function',
+          0x02: 'old',
+          0x03: 'UUID',
+          0x04: 'UUID',
+          0x05: 'MD5',
+          0x06: 'encrypted',
+          0x07: 'compressed-column',
+          0x08: 'sensitive',
+          0x80: 'user',
+        };
+        return `BinData-${binDataTypes[subtype]}`;
+      } else if (typeof specialType !== 'undefined') {
+        return specialType;
+      } else {
+        return 'Object';
+      }
+    }
+  };
+
+  // Flattens object keys to 1D. e.g. {'key1':1, 'key2':{'key3':2}} becomes {'key1':1, 'key2.key3':2}.
+  // We assume no '.' characters in the keys, which is an OK assumption for MongoDB.
+  const serializeDoc = (config, doc) => {
+    const result = createKeyMap();
+
+    // Recurse only into plain objects and arrays; BSON wrappers should stay scalar.
+    const isHash = (v) => Array.isArray(v) || varietyTypeOf(config, v) === 'Object';
+
+    const arrayRegex = new RegExp(`\\.${config.arrayEscape}\\d+${config.arrayEscape}\\.`, 'g');
+
+    const serialize = (document, parentKey, depth) => {
+      if (parentKey.replace(arrayRegex, '.') in config.excludeSubkeys) {
+        return;
+      }
+      for (const key of Object.keys(document)) {
+        const value = document[key];
+        // Translate array index from {parent}.{index} to {parent}.arrayEscape{index}arrayEscape.
+        const escapedKey = Array.isArray(document)
+          ? `${config.arrayEscape}${key}${config.arrayEscape}`
+          : key;
+        result[`${parentKey}${escapedKey}`] = value;
+        // Recurse into nested objects only if we have not reached max depth.
+        if (isHash(value) && depth > 1) {
+          serialize(value, `${parentKey}${escapedKey}.`, depth - 1);
+        }
+      }
+    };
+    serialize(doc, '', config.maxDepth);
+    return result;
+  };
+
+  // Convert document to key-value map, where value is always an object with types as keys.
+  const analyseDocument = (config, document) => {
+    const result = createKeyMap();
+    const arrayRegex = new RegExp(`\\.${config.arrayEscape}\\d+${config.arrayEscape}`, 'g');
+    for (const rawKey of Object.keys(document)) {
+      const value = document[rawKey];
+      const key = rawKey.replace(arrayRegex, `.${config.arrayEscape}`);
+      if (typeof result[key] === 'undefined') {
+        result[key] = {};
+      }
+      const type = varietyTypeOf(config, value);
+      result[key][type] = null;
+
+      if (config.lastValue || config.maxExamples > 0) {
+        if (type in {'String': true, 'Boolean': true}) {
+          result[key][type] = value.toString();
+        } else if (type in {'Number': true, 'NumberLong': true}) {
+          result[key][type] = value.valueOf();
+        } else if (type === 'ObjectId') {
+          result[key][type] = typeof value.toHexString === 'function' ? value.toHexString() : value.str;
+        } else if (type === 'Date') {
+          result[key][type] = new Date(value).toISOString();
+        } else if (type.startsWith('BinData')) {
+          result[key][type] = getBinDataHex(value);
+        }
+      }
+    }
+
+    return result;
+  };
+
+  const mergeDocument = (config, docResult, interimResults, log) => {
+    for (const key of Object.keys(docResult)) {
+      if (key in interimResults) {
+        const existing = interimResults[key];
+
+        for (const type of Object.keys(docResult[key])) {
+          if (type in existing.types) {
+            existing.types[type] += 1;
+          } else {
+            existing.types[type] = 1;
+            if (config.logKeysContinuously) {
+              log(`Found new key type "${key}" type "${type}"`);
+            }
+          }
+          if (config.maxExamples > 0 && existing.examples.length < config.maxExamples) {
+            const rawVal = docResult[key][type];
+            existing.examples.push(rawVal !== null ? rawVal : `[${type}]`);
+          }
+        }
+        existing.totalOccurrences += 1;
+      } else {
+        let lastValue = null;
+        let lastType = null;
+        const types = createKeyMap();
+        const examples = [];
+        for (const newType of Object.keys(docResult[key])) {
+          types[newType] = 1;
+          lastValue = docResult[key][newType];
+          lastType = newType;
+          if (config.maxExamples > 0 && examples.length < config.maxExamples) {
+            examples.push(lastValue !== null ? lastValue : `[${newType}]`);
+          }
+          if (config.logKeysContinuously) {
+            log(`Found new key type "${key}" type "${newType}"`);
+          }
+        }
+        interimResults[key] = {types, totalOccurrences: 1};
+        if (config.lastValue) {
+          interimResults[key].lastValue = lastValue ? lastValue : `[${lastType}]`;
+        }
+        if (config.maxExamples > 0) {
+          interimResults[key].examples = examples;
+        }
+      }
+    }
+  };
+
+  const convertResults = (config, interimResults, documentsCount) => {
+    const varietyResults = [];
+    for (const key of Object.keys(interimResults)) {
+      const entry = interimResults[key];
+
+      const obj = {
+        _id: {key},
+        value: {types: {...entry.types}},
+        totalOccurrences: entry.totalOccurrences,
+        percentContaining: entry.totalOccurrences * 100 / documentsCount,
+      };
+
+      if (config.lastValue) {
+        obj.lastValue = entry.lastValue;
+      }
+
+      if (config.maxExamples > 0) {
+        obj.examples = entry.examples;
+      }
+
+      varietyResults.push(obj);
+    }
+    return varietyResults;
+  };
+
+  const createAnalysisState = () => createKeyMap();
+
+  // Merge the keys and types of current object into accumulator object.
+  const ingestDocument = (config, accumulator, object, log) => {
+    const docResult = analyseDocument(config, serializeDoc(config, object));
+    mergeDocument(config, docResult, accumulator, log);
+    return accumulator;
+  };
+
+  const reduceCursor = (cursor, callback, initialValue) => {
+    let result = initialValue;
+    cursor.forEach((obj) => {
+      result = callback(result, obj);
+    });
+    return result;
+  };
+
+  // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
+  // since the parent key already captures the Array type. Set showArrayElements:true
+  // to include them — useful for verifying element-type consistency within arrays.
+  const buildResultFilter = (config) => {
+    const arrayRegex = new RegExp(`\\.${config.arrayEscape}$`, 'g');
+    return (item) => config.showArrayElements || !item._id.key.match(arrayRegex);
+  };
+
+  // Sort desc by totalOccurrences, or by key asc if occurrences are equal.
+  const compareResults = (a, b) => {
+    const countsDiff = b.totalOccurrences - a.totalOccurrences;
+    return countsDiff !== 0 ? countsDiff : a._id.key.localeCompare(b._id.key);
+  };
+
+  const finalizeResults = (config, interimResults, documentsCount) => {
+    return convertResults(config, interimResults, documentsCount)
+      .filter(buildResultFilter(config))
+      .sort(compareResults);
+  };
+
+  /**
+   * @param {Record<string, unknown>} config
+   * @param {Iterable<Record<string, unknown>>} documents
+   * @param {{ documentsCount?: number, log?: (message: string) => void }} [options]
+   */
+  const analyzeDocuments = (config, documents, options) => {
+    const analysisOptions = options || {};
+    const log = typeof analysisOptions.log === 'function' ? analysisOptions.log : () => {};
+    const interimResults = createAnalysisState();
+    let documentsCount = 0;
+
+    for (const document of documents) {
+      ingestDocument(config, interimResults, document, log);
+      documentsCount += 1;
+    }
+
+    if (typeof analysisOptions.documentsCount === 'number') {
+      documentsCount = analysisOptions.documentsCount;
+    }
+
+    return finalizeResults(config, interimResults, documentsCount);
+  };
+
+  const engine = {
+    createAnalysisState,
+    createKeyMap,
+    shellToJson,
+    getBinDataSubtype,
+    getBinDataHex,
+    getVectorDtypeByte,
+    getVectorDtypeLabel,
+    getRawBsonTypeName,
+    normalizeBsonTypeName,
+    getSpecialTypeName,
+    varietyTypeOf,
+    serializeDoc,
+    analyseDocument,
+    mergeDocument,
+    convertResults,
+    ingestDocument,
+    reduceCursor,
+    buildResultFilter,
+    compareResults,
+    finalizeResults,
+    analyzeDocuments,
+    // Back-compat alias while the adapter/orchestration migrates to the new names.
+    reduceDocuments: ingestDocument,
+  };
+
+  shellContext.__varietyEngine = engine;
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = engine;
+  }
+}(this));

--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -169,6 +169,7 @@
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.
+  delete shellContext.__varietyEngine;
   delete shellContext.__varietyImpl;
   delete shellContext.__varietyFormatters;
 }(this)); // end strict mode

--- a/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
+++ b/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
@@ -32,7 +32,7 @@ const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.
  *     config: AnalyzerConfig,
  *     interimResults: Record<string, InterimResult>,
  *     documentsCount: number
- *   ) => VarietyResultRow[]
+ *   ) => VarietyResultRow[],
  *   analyzeDocuments: (
  *     config: AnalyzerConfig,
  *     documents: Iterable<FuzzDocument>,

--- a/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
+++ b/test/cases/analysis/AnalyzerPropertyFuzzingTest.js
@@ -6,8 +6,7 @@ import { fileURLToPath } from 'url';
 import fc from 'fast-check';
 
 const require = createRequire(import.meta.url);
-const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
-require(analyzerPath);
+const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.url));
 
 /**
  * @typedef {Record<string, unknown>} FuzzDocument
@@ -22,26 +21,28 @@ require(analyzerPath);
  *   logKeysContinuously: boolean
  * }} AnalyzerConfig
  * @typedef {{
- *   createKeyMap: () => Record<string, InterimResult>,
- *   reduceDocuments: (
+ *   createAnalysisState: () => Record<string, InterimResult>,
+ *   ingestDocument: (
  *     config: AnalyzerConfig,
  *     accumulator: Record<string, InterimResult>,
  *     object: FuzzDocument,
  *     log: (message: string) => void
  *   ) => Record<string, InterimResult>,
- *   convertResults: (
+ *   finalizeResults: (
  *     config: AnalyzerConfig,
  *     interimResults: Record<string, InterimResult>,
  *     documentsCount: number
  *   ) => VarietyResultRow[]
+ *   analyzeDocuments: (
+ *     config: AnalyzerConfig,
+ *     documents: Iterable<FuzzDocument>,
+ *     options?: { documentsCount?: number, log?: (message: string) => void }
+ *   ) => VarietyResultRow[]
  * }} VarietyImpl
  */
 
-const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
-const impl = analyzerGlobal.__varietyImpl;
-if (typeof impl === 'undefined') {
-  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
-}
+const rawImpl = /** @type {unknown} */ (require(enginePath));
+const impl = /** @type {VarietyImpl} */ (rawImpl);
 
 const noop = () => {};
 
@@ -89,11 +90,11 @@ const makeConfig = (options) => ({
  * @returns {VarietyResultRow[]}
  */
 const analyzeDocuments = (documents, config) => {
-  const accumulator = impl.createKeyMap();
+  const accumulator = impl.createAnalysisState();
   for (const document of documents) {
-    impl.reduceDocuments(config, accumulator, document, noop);
+    impl.ingestDocument(config, accumulator, document, noop);
   }
-  return impl.convertResults(config, accumulator, documents.length);
+  return impl.finalizeResults(config, accumulator, documents.length);
 };
 
 /**
@@ -172,6 +173,36 @@ describe('Analyzer property fuzzing', () => {
       }),
       { numRuns: 200, seed: 29104 }
     );
+  });
+
+  it('should infer the document count for non-array iterables', () => {
+    /** @type {FuzzDocument[]} */
+    const documents = [
+      { common: 1, onlyFirst: true },
+      { common: 2 },
+    ];
+    const config = makeConfig({ compactArrayTypes: false, maxDepth: 5 });
+    function* generator() {
+      yield* documents;
+    }
+
+    const results = impl.analyzeDocuments(config, generator(), { log: noop });
+    const normalized = normalizeResults(results);
+
+    assert.deepEqual(normalized, [
+      {
+        key: 'common',
+        totalOccurrences: 2,
+        percentContaining: 100,
+        types: { Number: 2 },
+      },
+      {
+        key: 'onlyFirst',
+        totalOccurrences: 1,
+        percentContaining: 50,
+        types: { Boolean: 1 },
+      },
+    ]);
   });
 
 });

--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -7,8 +7,7 @@ import { Binary, UUID } from 'mongodb';
 import VarietyHarness from '../../helpers/VarietyHarness.js';
 
 const require = createRequire(import.meta.url);
-const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
-require(analyzerPath);
+const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.url));
 
 /**
  * @typedef {{
@@ -21,15 +20,12 @@ require(analyzerPath);
  *   maxExamples: number,
  * }} AnalyzerConfig
  * @typedef {{
- *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+   *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
  * }} VarietyImpl
  */
 
-const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
-const impl = analyzerGlobal.__varietyImpl;
-if (typeof impl === 'undefined') {
-  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
-}
+const rawImpl = /** @type {unknown} */ (require(enginePath));
+const impl = /** @type {VarietyImpl} */ (rawImpl);
 
 /** @type {AnalyzerConfig} */
 const config = {

--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -20,7 +20,7 @@ const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.
  *   maxExamples: number,
  * }} AnalyzerConfig
  * @typedef {{
-   *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+ *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
  * }} VarietyImpl
  */
 

--- a/test/cases/analysis/DeprecatedBsonTypesTest.js
+++ b/test/cases/analysis/DeprecatedBsonTypesTest.js
@@ -6,8 +6,7 @@ import { fileURLToPath } from 'url';
 import { BSONSymbol, Code, DBRef, ObjectId } from 'mongodb';
 
 const require = createRequire(import.meta.url);
-const analyzerPath = fileURLToPath(new URL('../../../core/analyzer.js', import.meta.url));
-require(analyzerPath);
+const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.url));
 
 /**
  * @typedef {{
@@ -20,15 +19,12 @@ require(analyzerPath);
  *   maxExamples: number,
  * }} AnalyzerConfig
  * @typedef {{
- *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+   *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
  * }} VarietyImpl
  */
 
-const analyzerGlobal = /** @type {typeof globalThis & { __varietyImpl?: VarietyImpl }} */ (globalThis);
-const impl = analyzerGlobal.__varietyImpl;
-if (typeof impl === 'undefined') {
-  throw new Error('Expected core/analyzer.js to register __varietyImpl.');
-}
+const rawImpl = /** @type {unknown} */ (require(enginePath));
+const impl = /** @type {VarietyImpl} */ (rawImpl);
 
 /** @type {AnalyzerConfig} */
 const config = {

--- a/test/cases/analysis/DeprecatedBsonTypesTest.js
+++ b/test/cases/analysis/DeprecatedBsonTypesTest.js
@@ -19,7 +19,7 @@ const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.
  *   maxExamples: number,
  * }} AnalyzerConfig
  * @typedef {{
-   *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
+ *   varietyTypeOf: (config: AnalyzerConfig, thing: unknown) => string
  * }} VarietyImpl
  */
 

--- a/variety.js
+++ b/variety.js
@@ -37,11 +37,13 @@ Please see https://github.com/variety/variety for details. */
 //      a factory function on `shellContext.__varietyFormatters`. Third-party
 //      formatters can be supplied as plugins instead (see README).
 //
-//   2. ENGINE SECTION (core/engine.js) — pure, side-effect-free analysis logic.
-//      Functions take their dependencies (config, and where needed a `log`
-//      function) as explicit parameters and return structured analysis rows.
-//      The section hands a reusable engine to later sections via
-//      `shellContext.__varietyEngine`.
+//   2. ENGINE SECTION (core/engine.js) — reusable analysis logic that keeps
+//      persistence, formatter dispatch, and output side effects out of the
+//      engine. It still tolerates shell/runtime helpers when they are
+//      available. Functions take their dependencies (config, and where needed
+//      a `log` function) as explicit parameters and return structured
+//      analysis rows. The section hands a reusable engine to later sections
+//      via `shellContext.__varietyEngine`.
 //
 //   3. ANALYZER SECTION (core/analyzer.js) — shell-adjacent orchestration for
 //      cursor traversal, optional persistence, and formatter dispatch. Depends
@@ -493,14 +495,6 @@ Please see https://github.com/variety/variety for details. */
     return accumulator;
   };
 
-  const reduceCursor = (cursor, callback, initialValue) => {
-    let result = initialValue;
-    cursor.forEach((obj) => {
-      result = callback(result, obj);
-    });
-    return result;
-  };
-
   // By default, keys ending in an array index (e.g. "tags.XX") are suppressed,
   // since the parent key already captures the Array type. Set showArrayElements:true
   // to include them — useful for verifying element-type consistency within arrays.
@@ -524,7 +518,11 @@ Please see https://github.com/variety/variety for details. */
   /**
    * @param {Record<string, unknown>} config
    * @param {Iterable<Record<string, unknown>>} documents
-   * @param {{ documentsCount?: number, log?: (message: string) => void }} [options]
+   * @param {{
+   *   documentsCount?: number,
+   *   log?: (message: string) => void
+   * }} [options] When documentsCount is provided, percentContaining uses that
+   * value instead of the number of iterated documents.
    */
   const analyzeDocuments = (config, documents, options) => {
     const analysisOptions = options || {};
@@ -561,13 +559,10 @@ Please see https://github.com/variety/variety for details. */
     mergeDocument,
     convertResults,
     ingestDocument,
-    reduceCursor,
     buildResultFilter,
     compareResults,
     finalizeResults,
     analyzeDocuments,
-    // Back-compat alias while the adapter/orchestration migrates to the new names.
-    reduceDocuments: ingestDocument,
   };
 
   shellContext.__varietyEngine = engine;

--- a/variety.js
+++ b/variety.js
@@ -14,7 +14,7 @@ Please see https://github.com/variety/variety for details. */
 //
 // Assembled by build.js from:
 //   core/formatters/ascii.js, core/formatters/json.js,
-//   core/analyzer.js, mongo-shell/adapter.js.
+//   core/engine.js, core/analyzer.js, mongo-shell/adapter.js.
 // To change behavior, edit those source files and run `npm run build`. The
 // build output is committed so `mongosh variety.js` works from a fresh clone
 // without a build step; CI verifies the committed file matches its sources.
@@ -30,20 +30,25 @@ Please see https://github.com/variety/variety for details. */
 // See .eslint.config.js for the enforced rule set.
 
 // -----------------------------------------------------------------------------
-// This file is organized in four sections, sourced from four separate files:
+// This file is organized in four sections, sourced from five separate files:
 //
 //   1. FORMATTER SECTION (core/formatters/ascii.js, core/formatters/json.js) —
 //      built-in output formatters. Each is a self-contained IIFE that registers
 //      a factory function on `shellContext.__varietyFormatters`. Third-party
 //      formatters can be supplied as plugins instead (see README).
 //
-//   2. IMPLEMENTATION SECTION (core/analyzer.js) — pure, transport-agnostic
-//      analysis logic. Functions take their dependencies (config, and where
-//      needed a `log` function or a `deps` bag holding shell primitives)
-//      as explicit parameters. The section hands a bundle of functions to
-//      the interface section via `shellContext.__varietyImpl`.
+//   2. ENGINE SECTION (core/engine.js) — pure, side-effect-free analysis logic.
+//      Functions take their dependencies (config, and where needed a `log`
+//      function) as explicit parameters and return structured analysis rows.
+//      The section hands a reusable engine to later sections via
+//      `shellContext.__varietyEngine`.
 //
-//   3. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
+//   3. ANALYZER SECTION (core/analyzer.js) — shell-adjacent orchestration for
+//      cursor traversal, optional persistence, and formatter dispatch. Depends
+//      on the engine and hands the combined internal API to the interface
+//      section via `shellContext.__varietyImpl`.
+//
+//   4. INTERFACE SECTION (mongo-shell/adapter.js) — everything that touches
 //      shell globals: reading input (`collection`, `plugins`, `__quiet`,
 //      `secondaryOk`, etc.), the config-echo logging, plugin loading via
 //      `load()`, input validation, and constructing the dependency bag
@@ -147,7 +152,7 @@ Please see https://github.com/variety/variety for details. */
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
 // =============================================================================
-// IMPLEMENTATION SECTION
+// ENGINE SECTION
 // =============================================================================
 (function (shellContext) {
   'use strict';
@@ -479,8 +484,10 @@ Please see https://github.com/variety/variety for details. */
     return varietyResults;
   };
 
+  const createAnalysisState = () => createKeyMap();
+
   // Merge the keys and types of current object into accumulator object.
-  const reduceDocuments = (config, accumulator, object, log) => {
+  const ingestDocument = (config, accumulator, object, log) => {
     const docResult = analyseDocument(config, serializeDoc(config, object));
     mergeDocument(config, docResult, accumulator, log);
     return accumulator;
@@ -508,57 +515,37 @@ Please see https://github.com/variety/variety for details. */
     return countsDiff !== 0 ? countsDiff : a._id.key.localeCompare(b._id.key);
   };
 
-  // Orchestrates a Variety analysis from a parsed config and constructed
-  // pluginsRunner, pulling every shell primitive it needs from `deps`.
-  const run = (config, pluginsRunner, deps) => {
-    const {db, connect, log, print, countMatchingDocuments} = deps;
-
-    // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
-    let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
-    if (config.limit > 0) { cursor = cursor.limit(config.limit); }
-    const interimResults = reduceCursor(
-      cursor,
-      (acc, obj) => reduceDocuments(config, acc, obj, log),
-      createKeyMap()
-    );
-    const varietyResults = convertResults(
-      config,
-      interimResults,
-      countMatchingDocuments(config.collection, config.query, config.limit)
-    )
+  const finalizeResults = (config, interimResults, documentsCount) => {
+    return convertResults(config, interimResults, documentsCount)
       .filter(buildResultFilter(config))
       .sort(compareResults);
-
-    if (config.persistResults) {
-      const resultsCollectionName = config.resultsCollection;
-      const resultsDB = !config.resultsDatabase.includes('/')
-        // Local database; don't reconnect.
-        ? db.getMongo().getDB(config.resultsDatabase)
-        // Remote database, establish new connection.
-        : connect(config.resultsDatabase);
-
-      if (config.resultsUser !== null && config.resultsPass !== null) {
-        resultsDB.auth(config.resultsUser, config.resultsPass);
-      }
-
-      // Replace results collection.
-      log(`replacing results collection: ${resultsCollectionName}`);
-      resultsDB.getCollection(resultsCollectionName).drop();
-      resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
-    }
-
-    const formatterFactory = shellContext.__varietyFormatters[config.outputFormat];
-    if (typeof formatterFactory !== 'function') {
-      throw new Error(`Unknown outputFormat "${config.outputFormat}". Valid values are: ${Object.keys(shellContext.__varietyFormatters).join(', ')}.`);
-    }
-    const builtInFormatter = formatterFactory(config);
-
-    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
-    const outputs = pluginsOutput.length > 0 ? pluginsOutput : [builtInFormatter.formatResults(varietyResults)];
-    outputs.forEach((output) => print(output));
   };
 
-  shellContext.__varietyImpl = {
+  /**
+   * @param {Record<string, unknown>} config
+   * @param {Iterable<Record<string, unknown>>} documents
+   * @param {{ documentsCount?: number, log?: (message: string) => void }} [options]
+   */
+  const analyzeDocuments = (config, documents, options) => {
+    const analysisOptions = options || {};
+    const log = typeof analysisOptions.log === 'function' ? analysisOptions.log : () => {};
+    const interimResults = createAnalysisState();
+    let documentsCount = 0;
+
+    for (const document of documents) {
+      ingestDocument(config, interimResults, document, log);
+      documentsCount += 1;
+    }
+
+    if (typeof analysisOptions.documentsCount === 'number') {
+      documentsCount = analysisOptions.documentsCount;
+    }
+
+    return finalizeResults(config, interimResults, documentsCount);
+  };
+
+  const engine = {
+    createAnalysisState,
     createKeyMap,
     shellToJson,
     getBinDataSubtype,
@@ -573,10 +560,105 @@ Please see https://github.com/variety/variety for details. */
     analyseDocument,
     mergeDocument,
     convertResults,
-    reduceDocuments,
+    ingestDocument,
     reduceCursor,
-    run,
+    buildResultFilter,
+    compareResults,
+    finalizeResults,
+    analyzeDocuments,
+    // Back-compat alias while the adapter/orchestration migrates to the new names.
+    reduceDocuments: ingestDocument,
   };
+
+  shellContext.__varietyEngine = engine;
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = engine;
+  }
+}(this));
+
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+// =============================================================================
+// ANALYZER SECTION
+// =============================================================================
+(function (shellContext) {
+  'use strict';
+
+  shellContext = typeof globalThis !== 'undefined' ? globalThis : shellContext;
+
+  const engine = shellContext.__varietyEngine ||
+    (typeof module !== 'undefined' && module && module.exports && typeof require === 'function'
+      ? require('./engine.js')
+      : undefined);
+  if (!engine) {
+    throw new Error('Expected core/engine.js to register __varietyEngine.');
+  }
+
+  const persistResults = (config, varietyResults, deps) => {
+    const {db, connect, log} = deps;
+
+    const resultsCollectionName = config.resultsCollection;
+    const resultsDB = !config.resultsDatabase.includes('/')
+      // Local database; don't reconnect.
+      ? db.getMongo().getDB(config.resultsDatabase)
+      // Remote database, establish new connection.
+      : connect(config.resultsDatabase);
+
+    if (config.resultsUser !== null && config.resultsPass !== null) {
+      resultsDB.auth(config.resultsUser, config.resultsPass);
+    }
+
+    // Replace results collection.
+    log(`replacing results collection: ${resultsCollectionName}`);
+    resultsDB.getCollection(resultsCollectionName).drop();
+    resultsDB.getCollection(resultsCollectionName).insert(varietyResults);
+  };
+
+  const formatResults = (config, pluginsRunner, varietyResults, print) => {
+    const formatterFactory = shellContext.__varietyFormatters[config.outputFormat];
+    if (typeof formatterFactory !== 'function') {
+      throw new Error(`Unknown outputFormat "${config.outputFormat}". Valid values are: ${Object.keys(shellContext.__varietyFormatters).join(', ')}.`);
+    }
+    const builtInFormatter = formatterFactory(config);
+
+    const pluginsOutput = pluginsRunner.execute('formatResults', varietyResults);
+    const outputs = pluginsOutput.length > 0 ? pluginsOutput : [builtInFormatter.formatResults(varietyResults)];
+    outputs.forEach((output) => print(output));
+  };
+
+  // Orchestrates a Variety analysis from a parsed config and constructed
+  // pluginsRunner, pulling every shell primitive it needs from `deps`.
+  const run = (config, pluginsRunner, deps) => {
+    const {db, connect, log, print, countMatchingDocuments} = deps;
+
+    // limit(0) meant "no limit" in MongoDB ≤7 but is rejected by MongoDB 8+; guard against it.
+    let cursor = db.getCollection(config.collection).find(config.query).sort(config.sort);
+    if (config.limit > 0) { cursor = cursor.limit(config.limit); }
+    const interimResults = engine.createAnalysisState();
+    cursor.forEach((obj) => {
+      engine.ingestDocument(config, interimResults, obj, log);
+    });
+    const varietyResults = engine.finalizeResults(
+      config,
+      interimResults,
+      countMatchingDocuments(config.collection, config.query, config.limit)
+    );
+
+    if (config.persistResults) {
+      persistResults(config, varietyResults, {db, connect, log});
+    }
+
+    formatResults(config, pluginsRunner, varietyResults, print);
+  };
+
+  const impl = Object.assign({}, engine, { run });
+  shellContext.__varietyImpl = impl;
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = impl;
+  }
 }(this));
 
 
@@ -751,6 +833,7 @@ Please see https://github.com/variety/variety for details. */
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.
+  delete shellContext.__varietyEngine;
   delete shellContext.__varietyImpl;
   delete shellContext.__varietyFormatters;
 }(this)); // end strict mode


### PR DESCRIPTION
## Summary
- split the pure document-reduction and result-finalization logic out of `core/analyzer.js` into new `core/engine.js`
- keep `core/analyzer.js` focused on cursor traversal, optional persistence, and formatter dispatch
- update the build docs, generated `variety.js`, and direct engine tests around the new internal seam

## Why
- move Variety toward the reusable internal engine needed for #263 and #264
- make future Node.js and interactive Mongo shell APIs share one analysis core instead of duplicating logic

## Impact
- no intended user-facing behavior change
- creates an internal reducer/finalization API that future work can reuse without shell globals or formatter side effects

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run verify:build`
- `npm run lint:markdown`
- `npm run lint:spdx`
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/analysis/AnalyzerPropertyFuzzingTest.js test/cases/analysis/DeprecatedBsonTypesTest.js test/cases/mongo-shell/AdapterValidationTest.js`
- Mongo-backed Podman validation from this worktree:
  - targeted previously failing suite slice passed under a controlled `podman run ... --volume ...:Z --entrypoint bash ...` invocation
  - full `npm run test:mocha` inside the same container image was mostly green but not fully stable from this `/tmp` worktree mount because the default container entrypoint path handling differs there; the failures were late, transient Mongo availability errors rather than analysis-engine assertion regressions

Refs #263 and #264.