### PR TITLE
Map user-defined binary subtypes 0x80-0xFF to BinData-user[0xNN]; add BinData-reserved for spec-reserved range

### DIFF
--- a/core/engine.js
+++ b/core/engine.js
@@ -178,6 +178,12 @@
         if (subtype === 0x09) {
           return getVectorDtypeLabel(thing);
         }
+        if (subtype >= 0x80) {
+          return `BinData-user[0x${subtype.toString(16).padStart(2, '0')}]`;
+        }
+        if (subtype >= 0x0a) {
+          return 'BinData-reserved';
+        }
         const binDataTypes = {
           0x00: 'generic',
           0x01: 'function',
@@ -188,7 +194,6 @@
           0x06: 'encrypted',
           0x07: 'compressed-column',
           0x08: 'sensitive',
-          0x80: 'user',
         };
         return `BinData-${binDataTypes[subtype]}`;
       } else if (typeof specialType !== 'undefined') {

--- a/docs/bson-type-inventory.md
+++ b/docs/bson-type-inventory.md
@@ -50,12 +50,13 @@ type mapping; [V6] tests every standard binary subtype plus custom subtype
 each deprecated top-level BSON type.
 Current tests recognize BSON `Double` and `Int32` as Variety `Number`, BSON
 JavaScript code and JavaScript-with-scope as Variety `Code`, BSON `Symbol`
-(type 14) as Variety `String` in mongosh, standard binary subtypes plus custom
-subtype `0x80` under their `BinData-{subtype}` labels, and vector binary
-subtype `9` values under dtype-specific labels (`BinData-vector[FLOAT32]`,
-`BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`), with unknown dtypes
-reported as `BinData-vector[0xNN]` and malformed payloads as
-`BinData-vector[malformed]`.
+(type 14) as Variety `String` in mongosh, standard binary subtypes under their
+`BinData-{subtype}` labels, user-defined binary subtypes `0x80` through `0xFF`
+as `BinData-user[0xNN]`, BSON-reserved binary subtypes `0x0A` through `0x7F`
+as `BinData-reserved`, and vector binary subtype `9` values under dtype-specific
+labels (`BinData-vector[FLOAT32]`, `BinData-vector[INT8]`,
+`BinData-vector[PACKED_BIT]`), with unknown dtypes reported as
+`BinData-vector[0xNN]` and malformed payloads as `BinData-vector[malformed]`.
 
 ## Top-Level BSON Value Types
 
@@ -106,7 +107,8 @@ specification is the broader authority for the whole user-defined range.
 | `7` / `0x07` | Compressed BSON column / compressed time series data | Current | Tested | BSON spec calls this "Compressed BSON column"; MongoDB docs describe it as compressed time series data and mark it new in MongoDB 5.2. The format uses delta, delta-of-delta, run-length encoding, and sparse-array missing-value encoding. Variety reports this as `BinData-compressed-column`. Coverage is analyzer-level because MongoDB validates compressed-column payloads. | [S1], [S2], [V6] |
 | `8` / `0x08` | Sensitive | Current | Tested | Sensitive data such as a key or secret. MongoDB logs a placeholder rather than the literal binary value. Variety reports this as `BinData-sensitive`. | [S1], [S2], [V6] |
 | `9` / `0x09` | Vector | Current | Tested | Dense numeric vector storage. The binary payload starts with a dtype byte and padding byte before the packed elements. Variety inspects the dtype byte and reports dtype-specific labels: `BinData-vector[FLOAT32]`, `BinData-vector[INT8]`, `BinData-vector[PACKED_BIT]`. Unknown dtypes produce `BinData-vector[0xNN]`; unreadable payloads produce `BinData-vector[malformed]`. See "Vector Subtype 9 Dtypes". | [S1], [S2], [S6], [V6] |
-| `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Partial | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety maps subtype `0x80` to `BinData-user` and that subtype is test-backed. Subtypes `0x81` through `0xFF` have no intentional Variety mapping and produce `BinData-undefined`. | [S1], [S2], [V6] |
+| `10` / `0x0A` through `127` / `0x7F` | Reserved | Reserved by BSON spec | Tested | Subtype range not assigned by the BSON specification. These subtypes cannot be inserted into MongoDB. Variety reports any value with a subtype in this range as `BinData-reserved`. Coverage is analyzer-level. | [S1], [V6] |
+| `128` / `0x80` through `255` / `0xFF` | User-defined / custom | Current | Tested | User-defined binary subtype range. MongoDB's BSON Types page lists `128` as custom data; the BSON spec reserves the full `128` through `255` range for user-defined subtypes. Variety reports each subtype in this range as `BinData-user[0xNN]` where `NN` is the subtype byte in lowercase zero-padded hex (e.g. `BinData-user[0x80]`, `BinData-user[0x81]`). The former flat label `BinData-user` is retired. Integration coverage for `0x80` and `0x81`; analyzer-level coverage for `0xff`. | [S1], [S2], [V6] |
 
 ## Vector Subtype 9 Dtypes
 
@@ -259,9 +261,10 @@ round-trip tests, but they are not extra top-level BSON types.
   [test/cases/analysis/BinarySubtypeTest.js](../test/cases/analysis/BinarySubtypeTest.js).
   Added 2026-04-21; updated and inspected in the current working tree on
   2026-04-23. Essential metadata: integration and analyzer-level tests for
-  every standard BSON binary subtype plus custom subtype `0x80` and vector
-  dtype-specific labels: generic, function, old, UUID-old, UUID, MD5,
-  encrypted, compressed column, sensitive, user-defined `0x80`, and vector
+  every standard BSON binary subtype, user-defined subtypes `0x80` and `0x81`
+  (integration) and `0xff` (analyzer-level), spec-reserved subtype `0x0a`
+  (analyzer-level), and vector dtype-specific labels: generic, function, old,
+  UUID-old, UUID, MD5, encrypted, compressed column, sensitive, and vector
   binary with dtype labels for INT8, PACKED_BIT, and FLOAT32, unknown dtype
   fallback, and malformed payload handling.
 - [V7] Variety local test file,

--- a/docs/bson-type-inventory.md
+++ b/docs/bson-type-inventory.md
@@ -45,9 +45,9 @@ and test evidence inspected on 2026-04-22.
 
 Primary local evidence: [V1] tests most BSON-wrapper recognition; [V2], [V3],
 and [V4] cover common application values and arrays; [V5] defines the current
-type mapping; [V6] tests every standard binary subtype plus custom subtype
-`0x80` and vector dtype-specific labels; and [V7] proves the Variety label for
-each deprecated top-level BSON type.
+type mapping; [V6] tests every standard binary subtype, representative
+reserved/user-defined-range cases, and vector dtype-specific labels; and [V7]
+proves the Variety label for each deprecated top-level BSON type.
 Current tests recognize BSON `Double` and `Int32` as Variety `Number`, BSON
 JavaScript code and JavaScript-with-scope as Variety `Code`, BSON `Symbol`
 (type 14) as Variety `String` in mongosh, standard binary subtypes under their
@@ -71,7 +71,7 @@ column is the string alias accepted by MongoDB `$type` where documented.
 | `2` | String | `string` | Current | Tested | Length-prefixed UTF-8 string. MongoDB drivers generally convert language strings to UTF-8. | [S1], [S2] |
 | `3` | Object / embedded document | `object` | Current | Tested | Embedded BSON document. A top-level MongoDB record is also a BSON document, but it is not preceded by an element type byte unless nested as a value. | [S1], [S2] |
 | `4` | Array | `array` | Current | Tested | Encoded as a BSON document whose keys are sequential integer strings starting at `0`. | [S1], [S2] |
-| `5` | Binary data | `binData` | Current | Tested merged | Length-prefixed byte array plus a binary subtype byte. Variety has no single `Binary data` label; every binary value is reported under a `BinData-{subtype}` label instead. Every standard binary subtype plus custom subtype `0x80` is test-backed; see "BSON Binary Subtypes" for per-subtype details and partially mapped custom subtypes. | [S1], [S2], [V6] |
+| `5` | Binary data | `binData` | Current | Tested merged | Length-prefixed byte array plus a binary subtype byte. Variety has no single `Binary data` label; every binary value is reported under a `BinData-{subtype}` label instead. Every standard binary subtype is test-backed, and the reserved/user-defined ranges now have representative test coverage with intentional range-wide mappings; see "BSON Binary Subtypes" for per-subtype details. | [S1], [S2], [V6] |
 | `6` | Undefined | `undefined` | Deprecated | Tested | Historical undefined value with no payload. It remains a recognized BSON type and `$type` alias, but should not be used for new data. The BSON library deserializes stored type-6 values as JavaScript `undefined`; Variety reports these as `undefined`. Coverage is analyzer-level test evidence against the deserialized value. | [S1], [S2], [V7] |
 | `7` | ObjectId | `objectId` | Current | Tested | 12-byte object identifier. See "Internal Structures and Interpretation Schemes". | [S1], [S2] |
 | `8` | Boolean | `bool` | Current | Tested | One byte: `0` for false, `1` for true. | [S1], [S2] |

--- a/test/cases/analysis/BinarySubtypeTest.js
+++ b/test/cases/analysis/BinarySubtypeTest.js
@@ -62,7 +62,8 @@ const doc = {
   binData_vector_int8:       new Binary(Uint8Array.from([0x03, 0x00, 0x01, 0x02, 0x03]), 0x09),
   binData_vector_packed_bit: new Binary(Uint8Array.from([0x10, 0x00, 0xff]), 0x09),
   binData_vector_float32:    new Binary(Uint8Array.from([0x27, 0x00, 0x00, 0x00, 0x80, 0x3f]), 0x09),
-  binData_user:              new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
+  binData_user_0x80:         new Binary(Uint8Array.from([0x01, 0x02, 0x03]), Binary.SUBTYPE_USER_DEFINED),
+  binData_user_0x81:         new Binary(Uint8Array.from([0x01, 0x02, 0x03]), 0x81),
 };
 
 describe('Binary subtype recognition', () => {
@@ -71,7 +72,7 @@ describe('Binary subtype recognition', () => {
 
   it('should report each server-insertable mapped binary subtype under its Variety label', async () => {
     const results = await test.runJsonAnalysis({ collection: 'bindata_subtypes' }, true);
-    results.validateResultsCount(13); // _id plus one field per subtype
+    results.validateResultsCount(14); // _id plus one field per subtype
     results.validate('_id',                        1, 100.0, { ObjectId: 1 });
     results.validate('binData_generic',            1, 100.0, { 'BinData-generic':              1 });
     results.validate('binData_function',           1, 100.0, { 'BinData-function':             1 });
@@ -85,12 +86,23 @@ describe('Binary subtype recognition', () => {
     results.validate('binData_vector_int8',        1, 100.0, { 'BinData-vector[INT8]':         1 });
     results.validate('binData_vector_packed_bit',  1, 100.0, { 'BinData-vector[PACKED_BIT]':   1 });
     results.validate('binData_vector_float32',     1, 100.0, { 'BinData-vector[FLOAT32]':      1 });
-    results.validate('binData_user',               1, 100.0, { 'BinData-user':                 1 });
+    results.validate('binData_user_0x80',          1, 100.0, { 'BinData-user[0x80]':           1 });
+    results.validate('binData_user_0x81',          1, 100.0, { 'BinData-user[0x81]':           1 });
   });
 
   it('should report compressed BSON column subtype under its Variety label', () => {
     const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x01, 0x02, 0x03, 0x04]), 0x07));
     assert.equal(result, 'BinData-compressed-column');
+  });
+
+  it('should report a user-defined subtype at the top of the range as BinData-user[0xff]', () => {
+    const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x01]), 0xff));
+    assert.equal(result, 'BinData-user[0xff]');
+  });
+
+  it('should report a spec-reserved subtype as BinData-reserved', () => {
+    const result = impl.varietyTypeOf(config, new Binary(Uint8Array.from([0x01]), 0x0a));
+    assert.equal(result, 'BinData-reserved');
   });
 
   it('should report an unknown vector dtype byte as BinData-vector[0xNN]', () => {

--- a/variety.js
+++ b/variety.js
@@ -331,6 +331,12 @@ Please see https://github.com/variety/variety for details. */
         if (subtype === 0x09) {
           return getVectorDtypeLabel(thing);
         }
+        if (subtype >= 0x80) {
+          return `BinData-user[0x${subtype.toString(16).padStart(2, '0')}]`;
+        }
+        if (subtype >= 0x0a) {
+          return 'BinData-reserved';
+        }
         const binDataTypes = {
           0x00: 'generic',
           0x01: 'function',
@@ -341,7 +347,6 @@ Please see https://github.com/variety/variety for details. */
           0x06: 'encrypted',
           0x07: 'compressed-column',
           0x08: 'sensitive',
-          0x80: 'user',
         };
         return `BinData-${binDataTypes[subtype]}`;
       } else if (typeof specialType !== 'undefined') {


### PR DESCRIPTION
## Summary

- Emits `BinData-user[0xNN]` for the full `0x80–0xFF` user-defined subtype range, giving each subtype a distinct label (analogous to the `BinData-vector[dtype]` pattern from #329). Retires the former flat label `BinData-user`.
- Emits `BinData-reserved` for the `0x0A–0x7F` BSON-spec-reserved range (these subtypes cannot be stored in MongoDB; coverage is analyzer-level).
- Retires `BinData-undefined` as a live label for any reachable binary subtype.
- Adds integration fixtures for subtypes `0x80` and `0x81`, plus unit tests for `0xFF` and reserved subtype `0x0A`.
- Updates `docs/bson-type-inventory.md`: adds a reserved-range row, updates the user-defined row to reflect per-subtype labels, and revises the preamble summary.

## Test plan

- [x] Integration test: `binData_user_0x80` → `BinData-user[0x80]` and `binData_user_0x81` → `BinData-user[0x81]` in MongoDB 8.2
- [x] Unit test: subtype `0xff` → `BinData-user[0xff]`
- [x] Unit test: spec-reserved subtype `0x0a` → `BinData-reserved`
- [x] Full container test suite: 89 passing (7 pre-existing flaky failures unrelated to this change)
- [x] All pre-commit hooks pass: build check, ESLint, jsonlint, markdownlint, js-yaml, hadolint, shellcheck, SPDX, typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)