### PR TITLE
Add `--hideFrequencyColumns` ASCII output toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,33 @@ Select a format with the `outputFormat` option:
 
 Passing an unrecognised value throws an error listing the valid options.
 
+### Hide Frequency Columns in ASCII Output
+
+If you only care about schema shape and type coverage, set `hideFrequencyColumns`
+to `true` to remove the `occurrences` and `percents` columns from the built-in
+ASCII table:
+
+    $ mongosh test --eval "var collection = 'users', hideFrequencyColumns = true" variety.js
+
+Via the first-party CLI:
+
+    $ variety test/users --hide-frequency-columns
+
+    +-------------------------------------------+
+    | key                | types                |
+    | ------------------ | -------------------- |
+    | _id                | ObjectId             |
+    | name               | String               |
+    | bio                | String               |
+    | birthday           | Date                 |
+    | pets               | String (1),Array (1) |
+    | someBinData        | BinData-old          |
+    | someWeirdLegacyKey | String               |
+    +-------------------------------------------+
+
+This option affects only built-in ASCII output. JSON output and persisted
+results still include `totalOccurrences` and `percentContaining`.
+
 ### Plugins
 
 A plugin is a `.js` file that exports a plain object with lifecycle hooks. Load one with the `plugins` option (comma-separated for multiple):

--- a/cli/options.js
+++ b/cli/options.js
@@ -86,6 +86,7 @@ const FLAG_ALIASES = {
   'last-value': 'lastValue',
   'compact-array-types': 'compactArrayTypes',
   'exclude-subkeys': 'excludeSubkeys',
+  'hide-frequency-columns': 'hideFrequencyColumns',
   'log-keys-continuously': 'logKeysContinuously',
   'max-depth': 'maxDepth',
   'max-examples': 'maxExamples',
@@ -361,6 +362,9 @@ const parseCliArguments = (argv) => {
       parsed.varietyOptions.outputFormat = result.value;
       break;
     }
+    case 'hideFrequencyColumns':
+      parsed.varietyOptions.hideFrequencyColumns = parseBooleanValue(optionName, inlineValue);
+      break;
     case 'lastValue':
       parsed.varietyOptions.lastValue = parseBooleanValue(optionName, inlineValue);
       break;
@@ -594,6 +598,7 @@ const formatUsage = () => {
     '  --lastValue                      Capture one representative value per key',
     '  --secondary-ok                   Read from a secondary by setting read preference',
     '  --outputFormat <value>           Output format, e.g. ascii or json',
+    '  --hideFrequencyColumns           Hide the occurrences and percents columns in ASCII output',
     '  --showArrayElements              Include array element keys in output',
     '  --compactArrayTypes              Render Array(Type) instead of plain Array',
     '  --arrayEscape <value>            Custom escape for array index keys (default XX)',

--- a/core/config.js
+++ b/core/config.js
@@ -14,6 +14,7 @@
    *   arrayEscape?: string,
    *   compactArrayTypes?: boolean,
    *   excludeSubkeys?: string[],
+   *   hideFrequencyColumns?: boolean,
    *   lastValue?: boolean,
    *   limit?: number,
    *   logKeysContinuously?: boolean,
@@ -36,6 +37,7 @@
    *   arrayEscape: string,
    *   compactArrayTypes: boolean,
    *   excludeSubkeys: string[],
+   *   hideFrequencyColumns: boolean,
    *   lastValue: boolean,
    *   limit: number,
    *   logKeysContinuously: boolean,
@@ -95,6 +97,7 @@
     'maxDepth',
     'sort',
     'outputFormat',
+    'hideFrequencyColumns',
     'persistResults',
     'resultsDatabase',
     'resultsCollection',
@@ -259,6 +262,10 @@
       validated.maxExamples = validateNonNegativeIntegerOption('maxExamples', source['maxExamples']);
     }
 
+    if (hasOwn(source, 'hideFrequencyColumns') && typeof source['hideFrequencyColumns'] !== 'undefined') {
+      validated.hideFrequencyColumns = validateBooleanOption('hideFrequencyColumns', source['hideFrequencyColumns']);
+    }
+
     if (hasOwn(source, 'lastValue') && typeof source['lastValue'] !== 'undefined') {
       validated.lastValue = validateBooleanOption('lastValue', source['lastValue']);
     }
@@ -352,6 +359,9 @@
       arrayEscape: hasOwn(validated, 'arrayEscape') ? /** @type {string} */ (validated.arrayEscape) : 'XX',
       compactArrayTypes: hasOwn(validated, 'compactArrayTypes') ? /** @type {boolean} */ (validated.compactArrayTypes) : false,
       excludeSubkeys: hasOwn(validated, 'excludeSubkeys') ? /** @type {string[]} */ (validated.excludeSubkeys) : [],
+      hideFrequencyColumns: hasOwn(validated, 'hideFrequencyColumns')
+        ? /** @type {boolean} */ (validated.hideFrequencyColumns)
+        : false,
       lastValue: hasOwn(validated, 'lastValue') ? /** @type {boolean} */ (validated.lastValue) : false,
       limit: hasOwn(validated, 'limit') ? /** @type {number} */ (validated.limit) : resolveDefaultLimit(query, context),
       logKeysContinuously: hasOwn(validated, 'logKeysContinuously') ? /** @type {boolean} */ (validated.logKeysContinuously) : false,
@@ -395,6 +405,7 @@
       arrayEscape: resolved.arrayEscape,
       compactArrayTypes: resolved.compactArrayTypes,
       excludeSubkeys: createExcludeSubkeysMap(resolved.excludeSubkeys),
+      hideFrequencyColumns: resolved.hideFrequencyColumns,
       lastValue: resolved.lastValue,
       limit: resolved.limit,
       logKeysContinuously: resolved.logKeysContinuously,

--- a/core/formatters/ascii.js
+++ b/core/formatters/ascii.js
@@ -12,12 +12,16 @@
 
   /**
    * Returns a formatter that renders results as a padded ASCII table.
-   * @param {object} config - The parsed Variety config (uses config.lastValue, config.maxExamples, and config.arrayEscape).
+   * @param {object} config - The parsed Variety config (uses config.hideFrequencyColumns, config.lastValue, config.maxExamples, and config.arrayEscape).
    * @returns {{ formatResults: function(Array): string }}
    */
   shellContext.__varietyFormatters.ascii = (config) => {
     const formatResults = (results) => {
-      const headers = ['key', 'types', 'occurrences', 'percents'];
+      const showFrequencyColumns = !config.hideFrequencyColumns;
+      const headers = ['key', 'types'];
+      if (showFrequencyColumns) {
+        headers.push('occurrences', 'percents');
+      }
       if (config.lastValue) {
         headers.push('lastValue');
       }
@@ -41,7 +45,10 @@
           ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
           : typeKeys;
 
-        const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
+        const rawArray = [row._id.key, types];
+        if (showFrequencyColumns) {
+          rawArray.push(row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20)));
+        }
         if (config.lastValue && row.lastValue) {
           rawArray.push(row.lastValue);
         }

--- a/test/cases/analysis/ConfigTest.js
+++ b/test/cases/analysis/ConfigTest.js
@@ -33,6 +33,7 @@ describe('Shared analysis config', () => {
       'maxDepth',
       'sort',
       'outputFormat',
+      'hideFrequencyColumns',
       'persistResults',
       'resultsDatabase',
       'resultsCollection',
@@ -50,6 +51,7 @@ describe('Shared analysis config', () => {
       arrayEscape: 'XX',
       compactArrayTypes: false,
       excludeSubkeys: ['meta.tags'],
+      hideFrequencyColumns: false,
       lastValue: false,
       limit: 5,
       logKeysContinuously: false,
@@ -70,6 +72,7 @@ describe('Shared analysis config', () => {
       arrayEscape: 'XX',
       compactArrayTypes: false,
       excludeSubkeys: { 'meta.tags.': true },
+      hideFrequencyColumns: false,
       lastValue: false,
       limit: 5,
       logKeysContinuously: false,
@@ -112,6 +115,13 @@ describe('Shared analysis config', () => {
         validateAnalysisOptions({ maxExamples: -1 });
       },
       /maxExamples must be a non-negative integer/
+    );
+
+    assert.throws(
+      () => {
+        validateAnalysisOptions(/** @type {any} */ ({ hideFrequencyColumns: 'yes' }));
+      },
+      /hideFrequencyColumns must be a boolean/
     );
 
     assert.throws(

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -189,6 +189,11 @@ describe('CLI option parsing', () => {
     assert.equal(evalCodeOf(plan), 'var collection = "users"; var showArrayElements = true');
   });
 
+  it('emits hideFrequencyColumns when the flag is passed', () => {
+    const plan = createExecutionPlan(['test/users', '--hide-frequency-columns'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; var hideFrequencyColumns = true');
+  });
+
   it('emits compactArrayTypes when the flag is passed', () => {
     const plan = createExecutionPlan(['test/users', '--compact-array-types'], {});
     assert.equal(evalCodeOf(plan), 'var collection = "users"; var compactArrayTypes = true');
@@ -204,6 +209,13 @@ describe('CLI option parsing', () => {
     const camel = createExecutionPlan(['test/users', '--showArrayElements=false'], {});
     assert.equal(evalCodeOf(kebab), evalCodeOf(camel));
     assert.equal(evalCodeOf(kebab), 'var collection = "users"; var showArrayElements = false');
+  });
+
+  it('accepts --hideFrequencyColumns camelCase alias', () => {
+    const kebab = createExecutionPlan(['test/users', '--hide-frequency-columns=false'], {});
+    const camel = createExecutionPlan(['test/users', '--hideFrequencyColumns=false'], {});
+    assert.equal(evalCodeOf(kebab), evalCodeOf(camel));
+    assert.equal(evalCodeOf(kebab), 'var collection = "users"; var hideFrequencyColumns = false');
   });
 
   it('emits arrayEscape with the supplied value', () => {

--- a/test/cases/cli/ParametersParsingTest.js
+++ b/test/cases/cli/ParametersParsingTest.js
@@ -17,6 +17,7 @@ const mongodbPort = Number(process.env['MONGODB_PORT'] || 27017);
  *   maxExamples?: unknown,
  *   sort?: unknown,
  *   outputFormat?: unknown,
+ *   hideFrequencyColumns?: unknown,
  *   persistResults?: unknown,
  *   resultsDatabase?: unknown,
  *   resultsCollection?: unknown,
@@ -43,6 +44,7 @@ const setParsedParam = (params, key, parsedValue) => {
   case 'maxExamples':
   case 'sort':
   case 'outputFormat':
+  case 'hideFrequencyColumns':
   case 'persistResults':
   case 'resultsDatabase':
   case 'resultsCollection':
@@ -96,6 +98,7 @@ describe('Parameters parsing', () => {
     assert.equal(params.maxExamples, 0);
     assert.deepEqual(params.sort, {'_id':-1});
     assert.equal(params.outputFormat, 'ascii');
+    assert.equal(params.hideFrequencyColumns, false);
     assert.equal(params.persistResults, false);
     assert.equal(params.resultsDatabase, 'varietyResults');
     assert.equal(params.resultsCollection, 'usersKeys');
@@ -122,6 +125,12 @@ describe('Parameters parsing', () => {
     assert.equal(params.maxDepth, 5);
     assert.deepEqual(params.sort, {name:1});
     assert.deepEqual(params.query, {name:'Harry'});
+  });
+
+  it('should parse hideFrequencyColumns when enabled', async () => {
+    const results = await test.runAnalysis({collection: 'users', hideFrequencyColumns: true});
+    const params = parseParams(results);
+    assert.equal(params.hideFrequencyColumns, true);
   });
 
   it('should recognize unknown collection', async () => {

--- a/test/cases/formatters/FormattersTest.js
+++ b/test/cases/formatters/FormattersTest.js
@@ -6,6 +6,19 @@ import sampleData from '../../fixtures/seed-data.js';
 import expectedAscii from '../../fixtures/ascii-output-fixture.js';
 
 const test = new VarietyHarness('test', 'users');
+const expectedAsciiWithoutFrequencyColumns = [
+  `+${'-'.repeat(43)}+`,
+  '| key                | types                |',
+  '| ------------------ | -------------------- |',
+  '| _id                | ObjectId             |',
+  '| name               | String               |',
+  '| bio                | String               |',
+  '| birthday           | Date                 |',
+  '| pets               | String (1),Array (1) |',
+  '| someBinData        | BinData-generic      |',
+  '| someWeirdLegacyKey | String               |',
+  `+${'-'.repeat(43)}+`,
+].join('\n');
 
 describe('Formatter registry dispatch', () => {
 
@@ -21,6 +34,11 @@ describe('Formatter registry dispatch', () => {
     const results = await test.runJsonAnalysis({collection: 'users'}, true);
     results.validateResultsCount(7);
     results.validate('_id', 5, 100.0, {ObjectId: 5});
+  });
+
+  it('hides the frequency columns in ASCII output when requested', async () => {
+    const output = await test.runAnalysis({collection: 'users', hideFrequencyColumns: true}, true);
+    assert.equal(output, expectedAsciiWithoutFrequencyColumns);
   });
 
   it('throws for an unknown outputFormat', async () => {

--- a/variety.js
+++ b/variety.js
@@ -79,12 +79,16 @@ Please see https://github.com/variety/variety for details. */
 
   /**
    * Returns a formatter that renders results as a padded ASCII table.
-   * @param {object} config - The parsed Variety config (uses config.lastValue, config.maxExamples, and config.arrayEscape).
+   * @param {object} config - The parsed Variety config (uses config.hideFrequencyColumns, config.lastValue, config.maxExamples, and config.arrayEscape).
    * @returns {{ formatResults: function(Array): string }}
    */
   shellContext.__varietyFormatters.ascii = (config) => {
     const formatResults = (results) => {
-      const headers = ['key', 'types', 'occurrences', 'percents'];
+      const showFrequencyColumns = !config.hideFrequencyColumns;
+      const headers = ['key', 'types'];
+      if (showFrequencyColumns) {
+        headers.push('occurrences', 'percents');
+      }
       if (config.lastValue) {
         headers.push('lastValue');
       }
@@ -108,7 +112,10 @@ Please see https://github.com/variety/variety for details. */
           ? typeKeys.map((type) => `${type} (${row.value.types[type]})`)
           : typeKeys;
 
-        const rawArray = [row._id.key, types, row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20))];
+        const rawArray = [row._id.key, types];
+        if (showFrequencyColumns) {
+          rawArray.push(row.totalOccurrences, row.percentContaining.toFixed(Math.min(maxDigits, 20)));
+        }
         if (config.lastValue && row.lastValue) {
           rawArray.push(row.lastValue);
         }
@@ -171,6 +178,7 @@ Please see https://github.com/variety/variety for details. */
    *   arrayEscape?: string,
    *   compactArrayTypes?: boolean,
    *   excludeSubkeys?: string[],
+   *   hideFrequencyColumns?: boolean,
    *   lastValue?: boolean,
    *   limit?: number,
    *   logKeysContinuously?: boolean,
@@ -193,6 +201,7 @@ Please see https://github.com/variety/variety for details. */
    *   arrayEscape: string,
    *   compactArrayTypes: boolean,
    *   excludeSubkeys: string[],
+   *   hideFrequencyColumns: boolean,
    *   lastValue: boolean,
    *   limit: number,
    *   logKeysContinuously: boolean,
@@ -252,6 +261,7 @@ Please see https://github.com/variety/variety for details. */
     'maxDepth',
     'sort',
     'outputFormat',
+    'hideFrequencyColumns',
     'persistResults',
     'resultsDatabase',
     'resultsCollection',
@@ -416,6 +426,10 @@ Please see https://github.com/variety/variety for details. */
       validated.maxExamples = validateNonNegativeIntegerOption('maxExamples', source['maxExamples']);
     }
 
+    if (hasOwn(source, 'hideFrequencyColumns') && typeof source['hideFrequencyColumns'] !== 'undefined') {
+      validated.hideFrequencyColumns = validateBooleanOption('hideFrequencyColumns', source['hideFrequencyColumns']);
+    }
+
     if (hasOwn(source, 'lastValue') && typeof source['lastValue'] !== 'undefined') {
       validated.lastValue = validateBooleanOption('lastValue', source['lastValue']);
     }
@@ -509,6 +523,9 @@ Please see https://github.com/variety/variety for details. */
       arrayEscape: hasOwn(validated, 'arrayEscape') ? /** @type {string} */ (validated.arrayEscape) : 'XX',
       compactArrayTypes: hasOwn(validated, 'compactArrayTypes') ? /** @type {boolean} */ (validated.compactArrayTypes) : false,
       excludeSubkeys: hasOwn(validated, 'excludeSubkeys') ? /** @type {string[]} */ (validated.excludeSubkeys) : [],
+      hideFrequencyColumns: hasOwn(validated, 'hideFrequencyColumns')
+        ? /** @type {boolean} */ (validated.hideFrequencyColumns)
+        : false,
       lastValue: hasOwn(validated, 'lastValue') ? /** @type {boolean} */ (validated.lastValue) : false,
       limit: hasOwn(validated, 'limit') ? /** @type {number} */ (validated.limit) : resolveDefaultLimit(query, context),
       logKeysContinuously: hasOwn(validated, 'logKeysContinuously') ? /** @type {boolean} */ (validated.logKeysContinuously) : false,
@@ -552,6 +569,7 @@ Please see https://github.com/variety/variety for details. */
       arrayEscape: resolved.arrayEscape,
       compactArrayTypes: resolved.compactArrayTypes,
       excludeSubkeys: createExcludeSubkeysMap(resolved.excludeSubkeys),
+      hideFrequencyColumns: resolved.hideFrequencyColumns,
       lastValue: resolved.lastValue,
       limit: resolved.limit,
       logKeysContinuously: resolved.logKeysContinuously,


### PR DESCRIPTION
## Summary
- add a shared `hideFrequencyColumns` option that hides the occurrences and percents columns in built-in ASCII output
- thread the option through shared config resolution, CLI parsing, shell logging, and the generated `variety.js` bundle
- document the new ASCII-only toggle and cover it with config, CLI, parameter, and formatter tests

Refs #236.

## Validation
- `npm run build`
- `npm run verify:build`
- `/home/j/variety/node_modules/.bin/eslint --config .eslint.config.js cli/options.js core/config.js core/formatters/ascii.js test/cases/analysis/ConfigTest.js test/cases/cli/CliOptionsTest.js test/cases/cli/ParametersParsingTest.js test/cases/formatters/FormattersTest.js`
- `/home/j/variety/node_modules/.bin/markdownlint README.md CONTRIBUTING.md`
- targeted mocha pass inside the repo test image for `ConfigTest.js`, `CliOptionsTest.js`, `ParametersParsingTest.js`, and `FormattersTest.js`

## Notes
- left a composition note on #235 for pairing this with `breakOutSubObjects`
- JSON output and persisted results are unchanged
- `npm run test:container` hit an existing-looking `MongoNetworkError: read ECONNRESET` in `QueryLimitedAnalysisTest`, after which later suites timed out
