### PR TITLE
Add CLI `--uri` support for MongoDB connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,19 +492,31 @@ details through the built-in CLI:
 variety app/users --host db.example.com --port 27017 --username report_reader --password secret --authenticationDatabase admin --quiet
 ```
 
-The equivalent direct Mongo shell invocation uses the remote database in the
+The built-in CLI also supports MongoDB connection strings directly:
+
+```bash
+variety app/users --uri "mongodb://report_reader:secret@db.example.com:27017/app?authSource=admin" --quiet
+```
+
+`--uri` accepts both `mongodb://` and `mongodb+srv://` connection strings while
+keeping the existing `DB/COLLECTION` target syntax:
+
+- If the URI omits a database name, Variety uses the positional `DB`.
+- If the URI includes a database name, it must match the positional `DB`.
+- `--uri` cannot be combined with `--host`, `--port`, `--username`,
+  `--password`, or `--authenticationDatabase`.
+
+The equivalent direct Mongo shell invocation uses the connection string as the
 shell target and sets the collection through `--eval`:
 
 ```bash
-mongosh "mongodb://db.example.com:27017/app" --username "report_reader" --password "secret" --authenticationDatabase "admin" --quiet --eval "var collection = 'users'" variety.js
+mongosh "mongodb://report_reader:secret@db.example.com:27017/app?authSource=admin" --quiet --eval "var collection = 'users'" variety.js
 ```
 
-First-class MongoDB URI support in the built-in CLI is being discussed in
-[issue #270](https://github.com/variety/variety/issues/270). Hat tip:
-[@YNX940214](https://github.com/YNX940214)
-([#152](https://github.com/variety/variety/issues/152)).
-
-Structured flags such as `--query` and `--sort` accept strict JSON. Connection flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationDatabase`, and `--quiet` are passed through to the Mongo shell. `--eval` remains available as an escape hatch when you need to append raw JavaScript assignments.
+Structured flags such as `--query` and `--sort` accept strict JSON. Connection
+flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationDatabase`,
+`--uri`, and `--quiet` shape the Mongo shell invocation. `--eval` remains
+available as an escape hatch when you need to append raw JavaScript assignments.
 
 When you invoke `variety` with no CLI arguments, the documented compatibility environment variables remain supported:
 

--- a/cli/options.js
+++ b/cli/options.js
@@ -16,6 +16,7 @@ const {
  *   password?: string,
  *   port?: number,
  *   quiet?: boolean,
+ *   uri?: string,
  *   username?: string,
  * }} ShellOptions
  */
@@ -79,6 +80,7 @@ class CliUsageError extends Error {
 }
 
 const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
+const MONGODB_URI_PREFIXES = ['mongodb://', 'mongodb+srv://'];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
   'array-escape': 'arrayEscape',
@@ -242,6 +244,20 @@ const parseNonEmptyString = (optionName, rawValue) => {
 };
 
 /**
+ * @param {string} optionName
+ * @param {string} rawValue
+ * @returns {string}
+ */
+const parseMongoUri = (optionName, rawValue) => {
+  const value = parseNonEmptyString(optionName, rawValue);
+  if (!MONGODB_URI_PREFIXES.some((prefix) => value.startsWith(prefix))) {
+    throw new CliUsageError(`--${optionName} must start with "mongodb://" or "mongodb+srv://".`);
+  }
+
+  return value;
+};
+
+/**
  * @param {string[]} argv
  * @param {number} currentIndex
  * @param {string | undefined} inlineValue
@@ -278,6 +294,115 @@ const parseTarget = (rawTarget) => {
     collection: rawTarget.slice(separatorIndex + 1),
     database: rawTarget.slice(0, separatorIndex),
   };
+};
+
+/**
+ * @typedef {{
+ *   beforePath: string,
+ *   database: string | null,
+ *   suffix: string,
+ * }} ParsedMongoUri
+ */
+
+/**
+ * @param {string} rawUri
+ * @returns {ParsedMongoUri}
+ */
+const parseMongoUriParts = (rawUri) => {
+  const authorityStart = rawUri.indexOf('://') + 3;
+  const queryIndex = rawUri.indexOf('?', authorityStart);
+  const fragmentIndex = rawUri.indexOf('#', authorityStart);
+  let suffixStart = rawUri.length;
+  if (queryIndex !== -1 && queryIndex < suffixStart) {
+    suffixStart = queryIndex;
+  }
+  if (fragmentIndex !== -1 && fragmentIndex < suffixStart) {
+    suffixStart = fragmentIndex;
+  }
+
+  const pathStart = rawUri.indexOf('/', authorityStart);
+  if (pathStart === -1 || pathStart >= suffixStart) {
+    return {
+      beforePath: rawUri.slice(0, suffixStart),
+      database: null,
+      suffix: rawUri.slice(suffixStart),
+    };
+  }
+
+  const rawDatabase = rawUri.slice(pathStart + 1, suffixStart);
+  if (rawDatabase.length === 0) {
+    return {
+      beforePath: rawUri.slice(0, pathStart),
+      database: null,
+      suffix: rawUri.slice(suffixStart),
+    };
+  }
+
+  try {
+    return {
+      beforePath: rawUri.slice(0, pathStart),
+      database: decodeURIComponent(rawDatabase),
+      suffix: rawUri.slice(suffixStart),
+    };
+  } catch {
+    throw new CliUsageError('--uri contains an invalid percent-encoded database path.');
+  }
+};
+
+/**
+ * @param {string} rawUri
+ * @param {TargetSelection} target
+ * @returns {string}
+ */
+const resolveMongoUriForTarget = (rawUri, target) => {
+  const parsedUri = parseMongoUriParts(rawUri);
+  if (parsedUri.database === null) {
+    return `${parsedUri.beforePath}/${encodeURIComponent(target.database)}${parsedUri.suffix}`;
+  }
+
+  if (parsedUri.database !== target.database) {
+    throw new CliUsageError(`--uri database ${JSON.stringify(parsedUri.database)} does not match positional DB ${JSON.stringify(target.database)}.`);
+  }
+
+  return rawUri;
+};
+
+/**
+ * @param {ShellOptions} shellOptions
+ * @param {TargetSelection} target
+ * @returns {ShellOptions}
+ */
+const resolveShellOptions = (shellOptions, target) => {
+  /** @type {ShellOptions} */
+  const resolved = { ...shellOptions };
+
+  if (typeof resolved.uri === 'undefined') {
+    return resolved;
+  }
+
+  const conflictingFlags = [];
+  if (Object.hasOwn(resolved, 'host')) {
+    conflictingFlags.push('--host');
+  }
+  if (typeof resolved.port === 'number') {
+    conflictingFlags.push('--port');
+  }
+  if (Object.hasOwn(resolved, 'username')) {
+    conflictingFlags.push('--username');
+  }
+  if (Object.hasOwn(resolved, 'password')) {
+    conflictingFlags.push('--password');
+  }
+  if (Object.hasOwn(resolved, 'authenticationDatabase')) {
+    conflictingFlags.push('--authenticationDatabase');
+  }
+
+  if (conflictingFlags.length > 0) {
+    throw new CliUsageError(`--uri cannot be combined with ${conflictingFlags.join(', ')}.`);
+  }
+
+  resolved.uri = resolveMongoUriForTarget(resolved.uri, target);
+  return resolved;
 };
 
 /**
@@ -446,6 +571,12 @@ const parseCliArguments = (argv) => {
       parsed.shellOptions.authenticationDatabase = result.value;
       break;
     }
+    case 'uri': {
+      const result = readOptionValue(argv, index, inlineValue, optionName);
+      index = result.nextIndex;
+      parsed.shellOptions.uri = parseMongoUri(optionName, result.value);
+      break;
+    }
     case 'port': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
@@ -559,7 +690,7 @@ const createCliPlan = (argv, env) => {
     evalCode: buildEvalCode(parsedCliArguments),
     mode: 'cli',
     scriptPath: resolveCliScriptPath(env),
-    shellOptions: parsedCliArguments.shellOptions,
+    shellOptions: resolveShellOptions(parsedCliArguments.shellOptions, parsedCliArguments.target),
   };
 };
 
@@ -612,6 +743,7 @@ const formatUsage = () => {
     '  --quiet                          Pass --quiet through to the Mongo shell',
     '  --host <value>                   Mongo shell host',
     '  --port <number>                  Mongo shell port',
+    '  --uri <mongodb-uri>              MongoDB connection string for the shell target',
     '  --username <value>               MongoDB username',
     '  --password <value>               MongoDB password',
     '  --authenticationDatabase <value> Authentication database',

--- a/mongo-shell/launcher.js
+++ b/mongo-shell/launcher.js
@@ -13,6 +13,7 @@ const path = require('path');
  *   password?: string,
  *   port?: number,
  *   quiet?: boolean,
+ *   uri?: string,
  *   username?: string,
  * }} ShellOptions
  */
@@ -113,7 +114,9 @@ const buildShellInvocation = (plan, env) => {
     args.push('--port', String(shellOptions.port));
   }
 
-  if (plan.database) {
+  if (shellOptions.uri) {
+    args.push(shellOptions.uri);
+  } else if (plan.database) {
     args.push(plan.database);
   }
 

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -161,6 +161,30 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes --uri through to the shell target and injects the positional database', async () => {
+    const { invocation } = await runBinVariety({
+      args: [
+        'app/users',
+        '--uri', 'mongodb://db.example.com/?authSource=admin',
+        '--quiet',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'mongodb://db.example.com/app?authSource=admin',
+        '--quiet',
+        '--eval',
+        'var collection = "users"',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+  });
+
   it('prefers mongosh and preserves the documented DB plus EVAL_CMDS compatibility mode', async () => {
     const { invocation, stdout, stderr } = await runBinVariety({
       shells: ['mongosh', 'mongo'],
@@ -401,6 +425,34 @@ describe('bin/variety wrapper', () => {
       (error) => {
         assert.equal(error.code, 2);
         assert.match(String(error.stderr || ''), /--query must be strict JSON/);
+        return true;
+      }
+    );
+  });
+
+  it('fails fast when --uri names a different database than the positional target', async () => {
+    await assert.rejects(
+      () => runBinVariety({
+        args: ['app/users', '--uri', 'mongodb://db.example.com/other'],
+      }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 2);
+        assert.match(String(error.stderr || ''), /does not match positional DB "app"/);
+        return true;
+      }
+    );
+  });
+
+  it('fails fast when --uri is combined with host flags', async () => {
+    await assert.rejects(
+      () => runBinVariety({
+        args: ['app/users', '--uri', 'mongodb://db.example.com/app', '--host', 'localhost'],
+      }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 2);
+        assert.match(String(error.stderr || ''), /--uri cannot be combined with --host/);
         return true;
       }
     );

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -152,6 +152,39 @@ describe('CLI option parsing', () => {
     })();
   });
 
+  it('renders Mongo shell URI arguments in the expected order', () => {
+    return (async () => {
+      const shellDir = await mkdtemp(path.join(tmpdir(), 'variety-cli-options-uri-'));
+      const shellPath = path.join(shellDir, 'mongosh');
+
+      try {
+        await writeFile(shellPath, '#!/bin/sh\nexit 0\n');
+        await chmod(shellPath, 0o755);
+
+        const invocation = buildShellInvocation({
+          database: 'app',
+          evalCode: 'var collection = "users"',
+          scriptPath: '/tmp/variety.js',
+          shellOptions: {
+            quiet: true,
+            uri: 'mongodb://db.example.com/app?authSource=admin',
+          },
+        }, {
+          PATH: shellDir,
+        });
+
+        assert.deepEqual(invocation.args, [
+          'mongodb://db.example.com/app?authSource=admin',
+          '--quiet',
+          '--eval', 'var collection = "users"',
+          '/tmp/variety.js',
+        ]);
+      } finally {
+        await rm(shellDir, { recursive: true, force: true });
+      }
+    })();
+  });
+
   it('throws a usage error when the target is missing', () => {
     assert.throws(
       () => {
@@ -182,6 +215,81 @@ describe('CLI option parsing', () => {
     assert.match(helpText, /variety DB\/COLLECTION \[options\]/);
     assert.match(helpText, /DB=test EVAL_CMDS=/);
     assert.match(helpText, /backwards compatibility/);
+    assert.match(helpText, /--uri <mongodb-uri>/);
+  });
+
+  it('supports --uri and injects the positional database when the URI omits one', () => {
+    const plan = createExecutionPlan([
+      'app/users',
+      '--uri', 'mongodb+srv://cluster.example.com/?retryWrites=true&w=majority',
+      '--quiet',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'app',
+      evalCode: 'var collection = "users"',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {
+        quiet: true,
+        uri: 'mongodb+srv://cluster.example.com/app?retryWrites=true&w=majority',
+      },
+    });
+  });
+
+  it('accepts a --uri whose database already matches the positional target', () => {
+    const plan = createExecutionPlan([
+      'app/users',
+      '--uri', 'mongodb://db.example.com/app?authSource=admin',
+    ], {});
+
+    assert.deepEqual(plan, {
+      database: 'app',
+      evalCode: 'var collection = "users"',
+      mode: 'cli',
+      scriptPath: path.join(repoRoot, 'variety.js'),
+      shellOptions: {
+        uri: 'mongodb://db.example.com/app?authSource=admin',
+      },
+    });
+  });
+
+  it('rejects --uri when its database disagrees with the positional target', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan([
+          'app/users',
+          '--uri', 'mongodb://db.example.com/other?authSource=admin',
+        ], {});
+      },
+      /does not match positional DB "app"/
+    );
+  });
+
+  it('rejects combining --uri with host or auth flags', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan([
+          'app/users',
+          '--uri', 'mongodb://db.example.com/app',
+          '--host', 'localhost',
+        ], {});
+      },
+      /--uri cannot be combined with --host/
+    );
+
+    assert.throws(
+      () => {
+        createExecutionPlan([
+          'app/users',
+          '--uri', 'mongodb://db.example.com/app',
+          '--username', 'alice',
+          '--password', 'secret',
+          '--authenticationDatabase', 'admin',
+        ], {});
+      },
+      /--uri cannot be combined with --username, --password, --authenticationDatabase/
+    );
   });
 
   it('emits showArrayElements when the flag is passed', () => {


### PR DESCRIPTION
## Summary
- add `--uri` support to the built-in `variety DB/COLLECTION [options]` CLI
- keep `DB/COLLECTION` required by injecting its DB into URIs that omit one and erroring when a URI names a different DB
- reject mixing `--uri` with `--host`, `--port`, `--username`, `--password`, or `--authenticationDatabase`
- document the new URI syntax and cover it with CLI option and bin-wrapper tests

## Notes
- targets `codex/centralize-analysis-config` because this work builds on PR #339

Refs #270. Reported by @YNX940214.

## Validation
- `/home/j/variety/node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/cli/CliOptionsTest.js test/cases/cli/BinWrapperTest.js`
- `/home/j/variety/node_modules/.bin/eslint --config .eslint.config.js cli/options.js mongo-shell/launcher.js test/cases/cli/CliOptionsTest.js test/cases/cli/BinWrapperTest.js`
- `/home/j/variety/node_modules/.bin/tsc --project .tsconfig.checkjs.json`
- `/home/j/variety/node_modules/.bin/markdownlint README.md CONTRIBUTING.md`