### PR TITLE
Handle `--eval` values that begin with `--`

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ flags such as `--host`, `--port`, `--username`, `--password`, `--authenticationD
 `--uri`, and `--quiet` shape the Mongo shell invocation. `--eval` remains
 available as an escape hatch when you need to append raw JavaScript assignments.
 
+If the JavaScript you need to append begins with `--` and also matches a Variety CLI flag name, use the inline form `--eval=...` so the parser does not treat it as another option.
+
 When you invoke `variety` with no CLI arguments, the documented compatibility environment variables remain supported:
 
 | Variable | Description |

--- a/cli/options.js
+++ b/cli/options.js
@@ -101,6 +101,21 @@ const FLAG_ALIASES = {
   'secondary-ok': 'secondaryOk',
   'show-array-elements': 'showArrayElements',
 };
+const KNOWN_OPTION_NAMES = new Set([
+  ...ANALYSIS_OPTION_NAMES,
+  'authenticationDatabase',
+  'eval',
+  'help',
+  'host',
+  'password',
+  'plugin',
+  'port',
+  'quiet',
+  'secondaryOk',
+  'uri',
+  'username',
+  'version',
+]);
 
 /**
  * @param {NodeJS.ProcessEnv} env
@@ -258,6 +273,27 @@ const parseMongoUri = (optionName, rawValue) => {
 };
 
 /**
+ * @param {string} rawOptionName
+ * @returns {string}
+ */
+const normalizeOptionName = (rawOptionName) => {
+  return FLAG_ALIASES[rawOptionName] || rawOptionName;
+};
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+const isKnownOptionToken = (value) => {
+  if (!value.startsWith('--')) {
+    return false;
+  }
+
+  const rawOptionName = value.slice(2).split('=', 2)[0] || '';
+  return rawOptionName.length > 0 && KNOWN_OPTION_NAMES.has(normalizeOptionName(rawOptionName));
+};
+
+/**
  * @param {string[]} argv
  * @param {number} currentIndex
  * @param {string | undefined} inlineValue
@@ -272,6 +308,36 @@ const readOptionValue = (argv, currentIndex, inlineValue, optionName) => {
   const nextValue = argv[currentIndex + 1];
   if (typeof nextValue !== 'string' || nextValue.startsWith('--')) {
     throw new CliUsageError(`--${optionName} requires a value.`);
+  }
+
+  return {
+    nextIndex: currentIndex + 1,
+    value: nextValue,
+  };
+};
+
+/**
+ * @param {string[]} argv
+ * @param {number} currentIndex
+ * @param {string | undefined} inlineValue
+ * @returns {ReadOptionValueResult}
+ */
+const readEvalValue = (argv, currentIndex, inlineValue) => {
+  if (typeof inlineValue !== 'undefined') {
+    return { nextIndex: currentIndex, value: inlineValue };
+  }
+
+  const nextValue = argv[currentIndex + 1];
+  if (typeof nextValue !== 'string') {
+    throw new CliUsageError('--eval requires a value.');
+  }
+
+  if (isKnownOptionToken(nextValue)) {
+    throw new CliUsageError(
+      `--eval expected JavaScript, but received Variety CLI flag ${JSON.stringify(nextValue)}. ` +
+      'If you meant the flag, place it before --eval. ' +
+      `If you meant literal JavaScript starting with --, use --eval=${nextValue}.`
+    );
   }
 
   return {
@@ -439,7 +505,7 @@ const parseCliArguments = (argv) => {
     if (typeof rawOptionName !== 'string' || rawOptionName.length === 0) {
       throw new CliUsageError(`Unknown option ${JSON.stringify(argument)}.`);
     }
-    const optionName = FLAG_ALIASES[rawOptionName] || rawOptionName;
+    const optionName = normalizeOptionName(rawOptionName);
 
     switch (optionName) {
     case 'help':
@@ -584,7 +650,7 @@ const parseCliArguments = (argv) => {
       break;
     }
     case 'eval': {
-      const result = readOptionValue(argv, index, inlineValue, optionName);
+      const result = readEvalValue(argv, index, inlineValue);
       index = result.nextIndex;
       parsed.extraEval.push(result.value);
       break;
@@ -749,6 +815,7 @@ const formatUsage = () => {
     '  --authenticationDatabase <value> Authentication database',
     '  --plugin <path[?cfg]>            Plugin file to load; repeat for multiple plugins',
     '  --eval <javascript>              Extra JavaScript appended after CLI assignments',
+    '                                   Use --eval=... when the code starts with --',
     '  --help                           Show this help',
     '  --version                        Show the Variety package version',
     '',

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -185,6 +185,46 @@ describe('bin/variety wrapper', () => {
     });
   });
 
+  it('passes through --eval values that start with -- when they are not known CLI flags', async () => {
+    const { invocation, stderr } = await runBinVariety({
+      args: [
+        'analytics/events',
+        '--eval', '--custom-eval-token',
+      ],
+    });
+
+    if (!invocation) {
+      throw new Error('Expected the fake shell invocation to be recorded.');
+    }
+    assert.deepEqual(invocation, {
+      command: 'mongosh',
+      args: [
+        'analytics',
+        '--eval',
+        'var collection = "events"; --custom-eval-token',
+        path.join(repoRoot, 'variety.js'),
+      ],
+    });
+    assert.equal(stderr, '');
+  });
+
+  it('prints a helpful usage error when --eval is followed by a known CLI flag', async () => {
+    await assert.rejects(
+      () => runBinVariety({
+        args: ['analytics/events', '--eval', '--quiet'],
+      }),
+      /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
+      (error) => {
+        assert.equal(error.code, 2);
+        assert.match(
+          String(error.stderr || ''),
+          /Error: --eval expected JavaScript, but received Variety CLI flag "--quiet".*place it before --eval.*--eval=--quiet/s
+        );
+        return true;
+      }
+    );
+  });
+
   it('prefers mongosh and preserves the documented DB plus EVAL_CMDS compatibility mode', async () => {
     const { invocation, stdout, stderr } = await runBinVariety({
       shells: ['mongosh', 'mongo'],

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -203,6 +203,25 @@ describe('CLI option parsing', () => {
     );
   });
 
+  it('passes through --eval values that start with -- when they are not known CLI flags', () => {
+    const plan = createExecutionPlan(['test/users', '--eval', '--custom-eval-token'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; --custom-eval-token');
+  });
+
+  it('accepts inline --eval values even when they look like known CLI flags', () => {
+    const plan = createExecutionPlan(['test/users', '--eval=--quiet'], {});
+    assert.equal(evalCodeOf(plan), 'var collection = "users"; --quiet');
+  });
+
+  it('rejects known CLI flags immediately after --eval with guidance', () => {
+    assert.throws(
+      () => {
+        createExecutionPlan(['test/users', '--eval', '--quiet'], {});
+      },
+      /--eval expected JavaScript, but received Variety CLI flag "--quiet".*place it before --eval.*--eval=--quiet/s
+    );
+  });
+
   it('strips only matching outer quotes in compatibility eval input', () => {
     assert.equal(stripMatchingOuterQuotes('"hello"'), 'hello');
     assert.equal(stripMatchingOuterQuotes('\'hello\''), 'hello');


### PR DESCRIPTION
## Summary
- allow `--eval VALUE` to consume leading-dash values when the token is not another known Variety CLI flag
- keep a focused usage error for ambiguous cases like `--eval --quiet`, with guidance to move the flag or use `--eval=...`
- document the inline `--eval=...` escape hatch in the CLI help and README

## Why
- issue #248 reports that `variety db/coll --eval --foo` is rejected before the value reaches the shell
- the parser treated any next token starting with `--` as a missing value, which was too strict for the `--eval` escape hatch

## Impact
- leading-dash eval snippets such as `--custom-eval-token` now pass through
- ambiguous tokens that match real Variety flags still fail fast with a more specific error and a concrete fix
- non-`--eval` option parsing stays strict

## Validation
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/cli/CliOptionsTest.js test/cases/cli/BinWrapperTest.js`
- `npm run lint`
- `npm run typecheck`
- `npm run lint:markdown`

Refs #248.