### PR TITLE
Refactor shell adapter preparation flow for #264

### DIFF
--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -23,90 +23,105 @@
     resolveAnalysisOptions,
   } = configApi;
 
-  const shellIsQuiet = () => {
-    if (typeof __quiet !== 'undefined' && __quiet) {
+  const shellIsQuiet = (context) => {
+    if (typeof context.__quiet !== 'undefined' && context.__quiet) {
       return true;
     }
 
-    return typeof process !== 'undefined' &&
-      process &&
-      process.argv &&
-      process.argv.includes('--quiet');
+    return typeof context.process !== 'undefined' &&
+      context.process &&
+      context.process.argv &&
+      context.process.argv.includes('--quiet');
   };
 
-  const log = (message) => {
-    if (!shellIsQuiet()) {
-      print(message);
-    }
-  };
-
-  const countMatchingDocuments = (collectionName, query, limit) => {
-    const coll = db.getCollection(collectionName);
-    const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
-    return coll.countDocuments(query, options);
-  };
-
-  log('Variety: A MongoDB Schema Analyzer');
-  log('Version 1.5.2, released 30 September 2025');
-
-  if (typeof secondaryOk !== 'undefined') {
-    if (secondaryOk === true) {
-      db.getMongo().setReadPref('secondary');
-    }
-  }
-
-  const selectedDatabaseName = db.getName();
-  const knownDatabases = db.adminCommand('listDatabases').databases;
-  const knownDatabaseNames = [];
-  if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
-    // Keep validation scoped to the selected database. Issue #145
-    // (@pkgajulapalli) hit a startup failure while enumerating collections for
-    // an unrelated database.
-    knownDatabases.forEach((database) => {
-      if (typeof database.name === 'string' && database.name.length > 0) {
-        knownDatabaseNames.push(database.name);
+  const createLogger = (context) => {
+    return (message) => {
+      if (!shellIsQuiet(context)) {
+        context.print(message);
       }
-    });
+    };
+  };
 
-    if (!knownDatabaseNames.includes(selectedDatabaseName)) {
-      throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+  const createCountMatchingDocuments = (context) => {
+    return (collectionName, query, limit) => {
+      const coll = context.db.getCollection(collectionName);
+      const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
+      return coll.countDocuments(query, options);
+    };
+  };
+
+  const logBanner = (log) => {
+    log('Variety: A MongoDB Schema Analyzer');
+    log('Version 1.5.2, released 30 September 2025');
+  };
+
+  const applySecondaryReadPreference = (context) => {
+    if (typeof context.secondaryOk !== 'undefined') {
+      if (context.secondaryOk === true) {
+        context.db.getMongo().setReadPref('secondary');
+      }
+    }
+  };
+
+  const validateShellStartup = (context, countMatchingDocuments) => {
+    const selectedDatabaseName = context.db.getName();
+    const knownDatabases = context.db.adminCommand('listDatabases').databases;
+    const knownDatabaseNames = [];
+    if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
+      // Keep validation scoped to the selected database. Issue #145
+      // (@pkgajulapalli) hit a startup failure while enumerating collections for
+      // an unrelated database.
+      knownDatabases.forEach((database) => {
+        if (typeof database.name === 'string' && database.name.length > 0) {
+          knownDatabaseNames.push(database.name);
+        }
+      });
+
+      if (!knownDatabaseNames.includes(selectedDatabaseName)) {
+        throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+            `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
+      }
+    }
+
+    const collectionNames = context.db.getCollectionNames();
+    const collNames = collectionNames.join(', ');
+    if (collectionNames.length === 0) {
+      throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
           `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
     }
-  }
 
-  const collectionNames = db.getCollectionNames();
-  const collNames = collectionNames.join(', ');
-  if (collectionNames.length === 0) {
-    throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
-        `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
-  }
+    const collectionName = context.collection;
+    if (typeof collectionName === 'undefined') {
+      throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
+          `Possible collection options for database specified: ${collNames}.\n` +
+          'Please see https://github.com/variety/variety for details.');
+    }
 
-  if (typeof collection === 'undefined') {
-    throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
-        `Possible collection options for database specified: ${collNames}.\n` +
-        'Please see https://github.com/variety/variety for details.');
-  }
+    if (countMatchingDocuments(collectionName, {}) === 0) {
+      throw new Error(`The collection specified (${collectionName}) in the database specified (${context.db.getName()}) does not exist or is empty.\n` +
+          `Possible collection options for database specified: ${collNames}.`);
+    }
 
-  if (countMatchingDocuments(collection, {}) === 0) {
-    throw new Error(`The collection specified (${collection}) in the database specified (${db.getName()}) does not exist or is empty.\n` +
-        `Possible collection options for database specified: ${collNames}.`);
-  }
+    return { collectionName };
+  };
 
-  const resolvedOptions = resolveAnalysisOptions(shellContext, {
-    collectionName: collection,
-    getDefaultLimit(query) {
-      return countMatchingDocuments(collection, query);
-    },
-  });
+  const resolveShellConfig = (context, collectionName, countMatchingDocuments, log) => {
+    const resolvedOptions = resolveAnalysisOptions(context, {
+      collectionName,
+      getDefaultLimit(query) {
+        return countMatchingDocuments(collectionName, query);
+      },
+    });
 
-  log(`Using collection of ${impl.shellToJson(collection)}`);
-  ANALYSIS_OPTION_NAMES.forEach((name) => {
-    log(`Using ${name} of ${impl.shellToJson(resolvedOptions[name])}`);
-  });
+    log(`Using collection of ${impl.shellToJson(collectionName)}`);
+    ANALYSIS_OPTION_NAMES.forEach((name) => {
+      log(`Using ${name} of ${impl.shellToJson(resolvedOptions[name])}`);
+    });
 
-  const config = Object.assign({ collection }, materializeAnalysisConfig(resolvedOptions));
+    return Object.assign({ collection: collectionName }, materializeAnalysisConfig(resolvedOptions));
+  };
 
-  const createPluginsRunner = (context) => {
+  const createPluginsRunner = (context, log) => {
     const parsePath = (val) => val.slice(-3) !== '.js' ? `${val}.js` : val;
     const parseConfig = (val) => {
       const cfg = {};
@@ -125,7 +140,7 @@
           const path = parsePath(definition.split('|')[0]);
           const cfg = parseConfig(definition.split('|')[1] || '');
           context.module = {exports: {}};
-          load(path);
+          context.load(path);
           const plugin = context.module.exports;
           delete context.module;
           plugin.path = path;
@@ -146,16 +161,37 @@
     };
   };
 
-  const pluginsRunner = createPluginsRunner(shellContext);
-  pluginsRunner.execute('onConfig', config);
+  const prepareShellExecution = (context) => {
+    const log = createLogger(context);
+    const countMatchingDocuments = createCountMatchingDocuments(context);
 
-  impl.run(config, pluginsRunner, {
-    db,
-    connect: typeof connect !== 'undefined' ? connect : undefined,
-    log,
-    print,
-    countMatchingDocuments,
-  });
+    logBanner(log);
+    applySecondaryReadPreference(context);
+
+    const { collectionName } = validateShellStartup(context, countMatchingDocuments);
+    const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
+    const pluginsRunner = createPluginsRunner(context, log);
+    pluginsRunner.execute('onConfig', config);
+
+    return {
+      config,
+      deps: {
+        db: context.db,
+        connect: typeof context.connect !== 'undefined' ? context.connect : undefined,
+        log,
+        print: context.print,
+        countMatchingDocuments,
+      },
+      pluginsRunner,
+    };
+  };
+
+  const executePreparedShellExecution = (preparedExecution) => {
+    impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
+  };
+
+  const preparedExecution = prepareShellExecution(shellContext);
+  executePreparedShellExecution(preparedExecution);
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.

--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -23,28 +23,35 @@
     resolveAnalysisOptions,
   } = configApi;
 
+  const getShellProcess = (context) => typeof process !== 'undefined' ? process : context.process;
+  const getShellPrint = (context) => typeof print !== 'undefined' ? print : context.print;
+  const getShellDb = (context) => typeof db !== 'undefined' ? db : context.db;
+  const getShellConnect = (context) => typeof connect !== 'undefined' ? connect : context.connect;
+  const getShellLoad = (context) => typeof load !== 'undefined' ? load : context.load;
+
   const shellIsQuiet = (context) => {
     if (typeof context.__quiet !== 'undefined' && context.__quiet) {
       return true;
     }
 
-    return typeof context.process !== 'undefined' &&
-      context.process &&
-      context.process.argv &&
-      context.process.argv.includes('--quiet');
+    const shellProcess = getShellProcess(context);
+    return shellProcess &&
+      shellProcess.argv &&
+      shellProcess.argv.includes('--quiet');
   };
 
   const createLogger = (context) => {
+    const shellPrint = getShellPrint(context);
     return (message) => {
       if (!shellIsQuiet(context)) {
-        context.print(message);
+        shellPrint(message);
       }
     };
   };
 
-  const createCountMatchingDocuments = (context) => {
+  const createCountMatchingDocuments = (shellDb) => {
     return (collectionName, query, limit) => {
-      const coll = context.db.getCollection(collectionName);
+      const coll = shellDb.getCollection(collectionName);
       const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
       return coll.countDocuments(query, options);
     };
@@ -56,16 +63,18 @@
   };
 
   const applySecondaryReadPreference = (context) => {
+    const shellDb = getShellDb(context);
     if (typeof context.secondaryOk !== 'undefined') {
       if (context.secondaryOk === true) {
-        context.db.getMongo().setReadPref('secondary');
+        shellDb.getMongo().setReadPref('secondary');
       }
     }
   };
 
   const validateShellStartup = (context, countMatchingDocuments) => {
-    const selectedDatabaseName = context.db.getName();
-    const knownDatabases = context.db.adminCommand('listDatabases').databases;
+    const shellDb = getShellDb(context);
+    const selectedDatabaseName = shellDb.getName();
+    const knownDatabases = shellDb.adminCommand('listDatabases').databases;
     const knownDatabaseNames = [];
     if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
       // Keep validation scoped to the selected database. Issue #145
@@ -83,7 +92,7 @@
       }
     }
 
-    const collectionNames = context.db.getCollectionNames();
+    const collectionNames = shellDb.getCollectionNames();
     const collNames = collectionNames.join(', ');
     if (collectionNames.length === 0) {
       throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
@@ -98,11 +107,11 @@
     }
 
     if (countMatchingDocuments(collectionName, {}) === 0) {
-      throw new Error(`The collection specified (${collectionName}) in the database specified (${context.db.getName()}) does not exist or is empty.\n` +
+      throw new Error(`The collection specified (${collectionName}) in the database specified (${shellDb.getName()}) does not exist or is empty.\n` +
           `Possible collection options for database specified: ${collNames}.`);
     }
 
-    return { collectionName };
+    return collectionName;
   };
 
   const resolveShellConfig = (context, collectionName, countMatchingDocuments, log) => {
@@ -122,6 +131,7 @@
   };
 
   const createPluginsRunner = (context, log) => {
+    const shellLoad = getShellLoad(context);
     const parsePath = (val) => val.slice(-3) !== '.js' ? `${val}.js` : val;
     const parseConfig = (val) => {
       const cfg = {};
@@ -140,7 +150,7 @@
           const path = parsePath(definition.split('|')[0]);
           const cfg = parseConfig(definition.split('|')[1] || '');
           context.module = {exports: {}};
-          context.load(path);
+          shellLoad(path);
           const plugin = context.module.exports;
           delete context.module;
           plugin.path = path;
@@ -162,36 +172,35 @@
   };
 
   const prepareShellExecution = (context) => {
+    const shellDb = getShellDb(context);
     const log = createLogger(context);
-    const countMatchingDocuments = createCountMatchingDocuments(context);
+    const countMatchingDocuments = createCountMatchingDocuments(shellDb);
 
     logBanner(log);
     applySecondaryReadPreference(context);
 
-    const { collectionName } = validateShellStartup(context, countMatchingDocuments);
+    const collectionName = validateShellStartup(context, countMatchingDocuments);
     const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
     const pluginsRunner = createPluginsRunner(context, log);
-    pluginsRunner.execute('onConfig', config);
 
     return {
       config,
       deps: {
-        db: context.db,
-        connect: typeof context.connect !== 'undefined' ? context.connect : undefined,
+        db: shellDb,
+        connect: getShellConnect(context),
         log,
-        print: context.print,
+        print: getShellPrint(context),
         countMatchingDocuments,
       },
       pluginsRunner,
     };
   };
 
-  const executePreparedShellExecution = (preparedExecution) => {
-    impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
-  };
-
   const preparedExecution = prepareShellExecution(shellContext);
-  executePreparedShellExecution(preparedExecution);
+  // Keep plugin onConfig dispatch with the run phase so a future callable shell
+  // API can prepare shell state without invoking plugin hooks yet.
+  preparedExecution.pluginsRunner.execute('onConfig', preparedExecution.config);
+  impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.

--- a/test/cases/mongo-shell/AdapterValidationTest.js
+++ b/test/cases/mongo-shell/AdapterValidationTest.js
@@ -17,6 +17,19 @@ const configModule = /** @type {typeof import('../../../core/config.js')} */ (re
  * @typedef {{ name: string }} FakeDatabaseInfo
  * @typedef {{ databases?: FakeDatabaseInfo[] }} FakeListDatabasesResult
  * @typedef {{
+ *   countMatchingDocuments(collectionName: string, query: Record<string, unknown>, limit?: number): number,
+ *   db: FakeDb,
+ *   log(message: string): void,
+ *   print(message?: string): void,
+ * }} FakeRunDeps
+ * @typedef {{ execute(methodName: string, ...args: unknown[]): unknown[] }} FakePluginsRunner
+ * @typedef {{
+ *   formatResults(results: unknown[]): string,
+ *   init(pluginConfig: Record<string, string>): void,
+ *   onConfig(config: { collection: string }): void,
+ *   path?: string,
+ * }} FakeLoadedPlugin
+ * @typedef {{
  *   adminCommand(command: string): FakeListDatabasesResult,
  *   getCollection(name: string): FakeCollection,
  *   getCollectionNames(): string[],
@@ -101,6 +114,86 @@ describe('Mongo shell adapter validation', () => {
     assert.equal(analyzerRan, true);
   });
 
+  it('runs plugin lifecycle hooks during preparation before invoking the analyzer', () => {
+    /** @type {string[]} */
+    const events = [];
+    /** @type {string[]} */
+    const sisterDbCalls = [];
+
+    /** @type {{
+     *   __varietyConfig: typeof import('../../../core/config.js'),
+     *   __varietyEngine: { marker: string },
+     *   __varietyFormatters: { ascii: { marker: string } },
+     *   __varietyImpl: {
+     *     run(config: { collection: string }, pluginsRunner: FakePluginsRunner, deps: FakeRunDeps): void,
+     *     shellToJson: typeof JSON.stringify,
+     *   },
+     *   collection: string,
+     *   db: FakeDb,
+     *   load(path: string): void,
+     *   module?: { exports: FakeLoadedPlugin },
+     *   plugins: string,
+     *   print(message?: string): void,
+     * }} */
+    const context = {
+      __varietyConfig: configModule,
+      __varietyEngine: { marker: 'engine' },
+      __varietyFormatters: { ascii: { marker: 'formatter' } },
+      __varietyImpl: {
+        run(config, pluginsRunner, deps) {
+          events.push('run');
+          assert.equal(config.collection, 'users');
+          assert.equal(typeof deps.countMatchingDocuments, 'function');
+          assert.equal(typeof deps.log, 'function');
+          assert.equal(deps.db, context.db);
+          assert.equal(typeof deps.print, 'function');
+          assert.deepEqual(
+            pluginsRunner.execute('formatResults', [{ _id: { key: 'users.name' } }]),
+            ['formatted output']
+          );
+        },
+        shellToJson: JSON.stringify,
+      },
+      collection: 'users',
+      db: createDb(sisterDbCalls),
+      /**
+       * @param {string} path
+      */
+      load(path) {
+        events.push(`load:${path}`);
+        if (!context.module) {
+          throw new Error('Expected the adapter to install a CommonJS module shim before load().');
+        }
+        context.module.exports = {
+          formatResults() {
+            events.push('formatResults');
+            return 'formatted output';
+          },
+          init(pluginConfig) {
+            events.push(`init:${JSON.stringify(pluginConfig)}`);
+          },
+          onConfig(config) {
+            events.push(`onConfig:${config.collection}`);
+          },
+        };
+      },
+      plugins: 'test-plugin|delimiter=;&mode=full',
+      print: () => {},
+    };
+
+    vm.createContext(context);
+    vm.runInContext(adapterSource, context, { filename: adapterPath });
+
+    assert.deepEqual(sisterDbCalls, []);
+    assert.deepEqual(events, [
+      'load:test-plugin.js',
+      'init:{"delimiter":";","mode":"full"}',
+      'onConfig:users',
+      'run',
+      'formatResults',
+    ]);
+  });
+
   it('does not enumerate collections for unrelated databases during startup', () => {
     /** @type {unknown[]} */
     const runConfigs = [];
@@ -138,5 +231,32 @@ describe('Mongo shell adapter validation', () => {
     assert.equal(typedConfig.limit, 1);
     assert.deepEqual(typedConfig.excludeSubkeys, { 'meta.tags.': true });
     assert.equal(typedConfig.resultsCollection, 'usersKeys');
+  });
+
+  it('cleans up shell handoff globals after successful execution', () => {
+    /** @type {string[]} */
+    const sisterDbCalls = [];
+
+    const context = {
+      __varietyConfig: configModule,
+      __varietyEngine: { marker: 'engine' },
+      __varietyFormatters: { ascii: { marker: 'formatter' } },
+      __varietyImpl: {
+        run() {},
+        shellToJson: JSON.stringify,
+      },
+      collection: 'users',
+      db: createDb(sisterDbCalls),
+      print: () => {},
+    };
+
+    vm.createContext(context);
+    vm.runInContext(adapterSource, context, { filename: adapterPath });
+
+    assert.deepEqual(sisterDbCalls, []);
+    assert.equal(Object.hasOwn(context, '__varietyConfig'), false);
+    assert.equal(Object.hasOwn(context, '__varietyEngine'), false);
+    assert.equal(Object.hasOwn(context, '__varietyImpl'), false);
+    assert.equal(Object.hasOwn(context, '__varietyFormatters'), false);
   });
 });

--- a/variety.js
+++ b/variety.js
@@ -1140,28 +1140,35 @@ Please see https://github.com/variety/variety for details. */
     resolveAnalysisOptions,
   } = configApi;
 
+  const getShellProcess = (context) => typeof process !== 'undefined' ? process : context.process;
+  const getShellPrint = (context) => typeof print !== 'undefined' ? print : context.print;
+  const getShellDb = (context) => typeof db !== 'undefined' ? db : context.db;
+  const getShellConnect = (context) => typeof connect !== 'undefined' ? connect : context.connect;
+  const getShellLoad = (context) => typeof load !== 'undefined' ? load : context.load;
+
   const shellIsQuiet = (context) => {
     if (typeof context.__quiet !== 'undefined' && context.__quiet) {
       return true;
     }
 
-    return typeof context.process !== 'undefined' &&
-      context.process &&
-      context.process.argv &&
-      context.process.argv.includes('--quiet');
+    const shellProcess = getShellProcess(context);
+    return shellProcess &&
+      shellProcess.argv &&
+      shellProcess.argv.includes('--quiet');
   };
 
   const createLogger = (context) => {
+    const shellPrint = getShellPrint(context);
     return (message) => {
       if (!shellIsQuiet(context)) {
-        context.print(message);
+        shellPrint(message);
       }
     };
   };
 
-  const createCountMatchingDocuments = (context) => {
+  const createCountMatchingDocuments = (shellDb) => {
     return (collectionName, query, limit) => {
-      const coll = context.db.getCollection(collectionName);
+      const coll = shellDb.getCollection(collectionName);
       const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
       return coll.countDocuments(query, options);
     };
@@ -1173,16 +1180,18 @@ Please see https://github.com/variety/variety for details. */
   };
 
   const applySecondaryReadPreference = (context) => {
+    const shellDb = getShellDb(context);
     if (typeof context.secondaryOk !== 'undefined') {
       if (context.secondaryOk === true) {
-        context.db.getMongo().setReadPref('secondary');
+        shellDb.getMongo().setReadPref('secondary');
       }
     }
   };
 
   const validateShellStartup = (context, countMatchingDocuments) => {
-    const selectedDatabaseName = context.db.getName();
-    const knownDatabases = context.db.adminCommand('listDatabases').databases;
+    const shellDb = getShellDb(context);
+    const selectedDatabaseName = shellDb.getName();
+    const knownDatabases = shellDb.adminCommand('listDatabases').databases;
     const knownDatabaseNames = [];
     if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
       // Keep validation scoped to the selected database. Issue #145
@@ -1200,7 +1209,7 @@ Please see https://github.com/variety/variety for details. */
       }
     }
 
-    const collectionNames = context.db.getCollectionNames();
+    const collectionNames = shellDb.getCollectionNames();
     const collNames = collectionNames.join(', ');
     if (collectionNames.length === 0) {
       throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
@@ -1215,11 +1224,11 @@ Please see https://github.com/variety/variety for details. */
     }
 
     if (countMatchingDocuments(collectionName, {}) === 0) {
-      throw new Error(`The collection specified (${collectionName}) in the database specified (${context.db.getName()}) does not exist or is empty.\n` +
+      throw new Error(`The collection specified (${collectionName}) in the database specified (${shellDb.getName()}) does not exist or is empty.\n` +
           `Possible collection options for database specified: ${collNames}.`);
     }
 
-    return { collectionName };
+    return collectionName;
   };
 
   const resolveShellConfig = (context, collectionName, countMatchingDocuments, log) => {
@@ -1239,6 +1248,7 @@ Please see https://github.com/variety/variety for details. */
   };
 
   const createPluginsRunner = (context, log) => {
+    const shellLoad = getShellLoad(context);
     const parsePath = (val) => val.slice(-3) !== '.js' ? `${val}.js` : val;
     const parseConfig = (val) => {
       const cfg = {};
@@ -1257,7 +1267,7 @@ Please see https://github.com/variety/variety for details. */
           const path = parsePath(definition.split('|')[0]);
           const cfg = parseConfig(definition.split('|')[1] || '');
           context.module = {exports: {}};
-          context.load(path);
+          shellLoad(path);
           const plugin = context.module.exports;
           delete context.module;
           plugin.path = path;
@@ -1279,36 +1289,35 @@ Please see https://github.com/variety/variety for details. */
   };
 
   const prepareShellExecution = (context) => {
+    const shellDb = getShellDb(context);
     const log = createLogger(context);
-    const countMatchingDocuments = createCountMatchingDocuments(context);
+    const countMatchingDocuments = createCountMatchingDocuments(shellDb);
 
     logBanner(log);
     applySecondaryReadPreference(context);
 
-    const { collectionName } = validateShellStartup(context, countMatchingDocuments);
+    const collectionName = validateShellStartup(context, countMatchingDocuments);
     const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
     const pluginsRunner = createPluginsRunner(context, log);
-    pluginsRunner.execute('onConfig', config);
 
     return {
       config,
       deps: {
-        db: context.db,
-        connect: typeof context.connect !== 'undefined' ? context.connect : undefined,
+        db: shellDb,
+        connect: getShellConnect(context),
         log,
-        print: context.print,
+        print: getShellPrint(context),
         countMatchingDocuments,
       },
       pluginsRunner,
     };
   };
 
-  const executePreparedShellExecution = (preparedExecution) => {
-    impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
-  };
-
   const preparedExecution = prepareShellExecution(shellContext);
-  executePreparedShellExecution(preparedExecution);
+  // Keep plugin onConfig dispatch with the run phase so a future callable shell
+  // API can prepare shell state without invoking plugin hooks yet.
+  preparedExecution.pluginsRunner.execute('onConfig', preparedExecution.config);
+  impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.

--- a/variety.js
+++ b/variety.js
@@ -1140,90 +1140,105 @@ Please see https://github.com/variety/variety for details. */
     resolveAnalysisOptions,
   } = configApi;
 
-  const shellIsQuiet = () => {
-    if (typeof __quiet !== 'undefined' && __quiet) {
+  const shellIsQuiet = (context) => {
+    if (typeof context.__quiet !== 'undefined' && context.__quiet) {
       return true;
     }
 
-    return typeof process !== 'undefined' &&
-      process &&
-      process.argv &&
-      process.argv.includes('--quiet');
+    return typeof context.process !== 'undefined' &&
+      context.process &&
+      context.process.argv &&
+      context.process.argv.includes('--quiet');
   };
 
-  const log = (message) => {
-    if (!shellIsQuiet()) {
-      print(message);
-    }
-  };
-
-  const countMatchingDocuments = (collectionName, query, limit) => {
-    const coll = db.getCollection(collectionName);
-    const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
-    return coll.countDocuments(query, options);
-  };
-
-  log('Variety: A MongoDB Schema Analyzer');
-  log('Version 1.5.2, released 30 September 2025');
-
-  if (typeof secondaryOk !== 'undefined') {
-    if (secondaryOk === true) {
-      db.getMongo().setReadPref('secondary');
-    }
-  }
-
-  const selectedDatabaseName = db.getName();
-  const knownDatabases = db.adminCommand('listDatabases').databases;
-  const knownDatabaseNames = [];
-  if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
-    // Keep validation scoped to the selected database. Issue #145
-    // (@pkgajulapalli) hit a startup failure while enumerating collections for
-    // an unrelated database.
-    knownDatabases.forEach((database) => {
-      if (typeof database.name === 'string' && database.name.length > 0) {
-        knownDatabaseNames.push(database.name);
+  const createLogger = (context) => {
+    return (message) => {
+      if (!shellIsQuiet(context)) {
+        context.print(message);
       }
-    });
+    };
+  };
 
-    if (!knownDatabaseNames.includes(selectedDatabaseName)) {
-      throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+  const createCountMatchingDocuments = (context) => {
+    return (collectionName, query, limit) => {
+      const coll = context.db.getCollection(collectionName);
+      const options = (typeof limit === 'number' && limit > 0) ? {limit} : undefined;
+      return coll.countDocuments(query, options);
+    };
+  };
+
+  const logBanner = (log) => {
+    log('Variety: A MongoDB Schema Analyzer');
+    log('Version 1.5.2, released 30 September 2025');
+  };
+
+  const applySecondaryReadPreference = (context) => {
+    if (typeof context.secondaryOk !== 'undefined') {
+      if (context.secondaryOk === true) {
+        context.db.getMongo().setReadPref('secondary');
+      }
+    }
+  };
+
+  const validateShellStartup = (context, countMatchingDocuments) => {
+    const selectedDatabaseName = context.db.getName();
+    const knownDatabases = context.db.adminCommand('listDatabases').databases;
+    const knownDatabaseNames = [];
+    if (typeof knownDatabases !== 'undefined') { // not authorized user receives error response (json) without databases key
+      // Keep validation scoped to the selected database. Issue #145
+      // (@pkgajulapalli) hit a startup failure while enumerating collections for
+      // an unrelated database.
+      knownDatabases.forEach((database) => {
+        if (typeof database.name === 'string' && database.name.length > 0) {
+          knownDatabaseNames.push(database.name);
+        }
+      });
+
+      if (!knownDatabaseNames.includes(selectedDatabaseName)) {
+        throw new Error(`The database specified (${selectedDatabaseName}) does not exist.\n` +
+            `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
+      }
+    }
+
+    const collectionNames = context.db.getCollectionNames();
+    const collNames = collectionNames.join(', ');
+    if (collectionNames.length === 0) {
+      throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
           `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
     }
-  }
 
-  const collectionNames = db.getCollectionNames();
-  const collNames = collectionNames.join(', ');
-  if (collectionNames.length === 0) {
-    throw new Error(`The database specified (${selectedDatabaseName}) is empty.\n` +
-        `Possible database options are: ${knownDatabaseNames.join(', ')}.`);
-  }
+    const collectionName = context.collection;
+    if (typeof collectionName === 'undefined') {
+      throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
+          `Possible collection options for database specified: ${collNames}.\n` +
+          'Please see https://github.com/variety/variety for details.');
+    }
 
-  if (typeof collection === 'undefined') {
-    throw new Error('You have to supply a \'collection\' variable, à la --eval \'var collection = "animals"\'.\n' +
-        `Possible collection options for database specified: ${collNames}.\n` +
-        'Please see https://github.com/variety/variety for details.');
-  }
+    if (countMatchingDocuments(collectionName, {}) === 0) {
+      throw new Error(`The collection specified (${collectionName}) in the database specified (${context.db.getName()}) does not exist or is empty.\n` +
+          `Possible collection options for database specified: ${collNames}.`);
+    }
 
-  if (countMatchingDocuments(collection, {}) === 0) {
-    throw new Error(`The collection specified (${collection}) in the database specified (${db.getName()}) does not exist or is empty.\n` +
-        `Possible collection options for database specified: ${collNames}.`);
-  }
+    return { collectionName };
+  };
 
-  const resolvedOptions = resolveAnalysisOptions(shellContext, {
-    collectionName: collection,
-    getDefaultLimit(query) {
-      return countMatchingDocuments(collection, query);
-    },
-  });
+  const resolveShellConfig = (context, collectionName, countMatchingDocuments, log) => {
+    const resolvedOptions = resolveAnalysisOptions(context, {
+      collectionName,
+      getDefaultLimit(query) {
+        return countMatchingDocuments(collectionName, query);
+      },
+    });
 
-  log(`Using collection of ${impl.shellToJson(collection)}`);
-  ANALYSIS_OPTION_NAMES.forEach((name) => {
-    log(`Using ${name} of ${impl.shellToJson(resolvedOptions[name])}`);
-  });
+    log(`Using collection of ${impl.shellToJson(collectionName)}`);
+    ANALYSIS_OPTION_NAMES.forEach((name) => {
+      log(`Using ${name} of ${impl.shellToJson(resolvedOptions[name])}`);
+    });
 
-  const config = Object.assign({ collection }, materializeAnalysisConfig(resolvedOptions));
+    return Object.assign({ collection: collectionName }, materializeAnalysisConfig(resolvedOptions));
+  };
 
-  const createPluginsRunner = (context) => {
+  const createPluginsRunner = (context, log) => {
     const parsePath = (val) => val.slice(-3) !== '.js' ? `${val}.js` : val;
     const parseConfig = (val) => {
       const cfg = {};
@@ -1242,7 +1257,7 @@ Please see https://github.com/variety/variety for details. */
           const path = parsePath(definition.split('|')[0]);
           const cfg = parseConfig(definition.split('|')[1] || '');
           context.module = {exports: {}};
-          load(path);
+          context.load(path);
           const plugin = context.module.exports;
           delete context.module;
           plugin.path = path;
@@ -1263,16 +1278,37 @@ Please see https://github.com/variety/variety for details. */
     };
   };
 
-  const pluginsRunner = createPluginsRunner(shellContext);
-  pluginsRunner.execute('onConfig', config);
+  const prepareShellExecution = (context) => {
+    const log = createLogger(context);
+    const countMatchingDocuments = createCountMatchingDocuments(context);
 
-  impl.run(config, pluginsRunner, {
-    db,
-    connect: typeof connect !== 'undefined' ? connect : undefined,
-    log,
-    print,
-    countMatchingDocuments,
-  });
+    logBanner(log);
+    applySecondaryReadPreference(context);
+
+    const { collectionName } = validateShellStartup(context, countMatchingDocuments);
+    const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
+    const pluginsRunner = createPluginsRunner(context, log);
+    pluginsRunner.execute('onConfig', config);
+
+    return {
+      config,
+      deps: {
+        db: context.db,
+        connect: typeof context.connect !== 'undefined' ? context.connect : undefined,
+        log,
+        print: context.print,
+        countMatchingDocuments,
+      },
+      pluginsRunner,
+    };
+  };
+
+  const executePreparedShellExecution = (preparedExecution) => {
+    impl.run(preparedExecution.config, preparedExecution.pluginsRunner, preparedExecution.deps);
+  };
+
+  const preparedExecution = prepareShellExecution(shellContext);
+  executePreparedShellExecution(preparedExecution);
 
   // Clean up the implementation handoffs so repeated loads remain idempotent
   // and no ad hoc internals leak onto globalThis after execution.


### PR DESCRIPTION
## Summary
- split the shell adapter into explicit preparation and execution steps inside `mongo-shell/adapter.js`
- keep `variety.js` execute-on-load behavior unchanged while moving shell-state gathering behind the new internal seam
- add VM coverage for plugin lifecycle ordering and post-run cleanup of shell handoff globals

## Why
- build toward #264 without jumping ahead to a public interactive shell API
- keep the shell boundary easier to reuse for the later Node.js work in #263 and the planned parity follow-up
- preserve the current shell-specific plugin and transport behavior from #339 rather than folding in #337 or #338

## Impact
- no intended user-facing behavior change
- `variety.js` still executes immediately when loaded
- creates a two-step internal shell flow that later work can reuse without making it public yet

## Validation
- `npm run build`
- `npm run verify:build`
- `npm run lint`
- `npm run typecheck`
- `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/mongo-shell/AdapterValidationTest.js`
- focused container-backed smoke test:
  - MongoDB 8.2 / Node.js 22 image built with Podman
  - `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/mongo-shell/SecondaryReadsTest.js` passed inside the container

Refs #264. Original shell-loading question from @abrin: #131.
