### PR TITLE
Resolve `shellDb` once in `prepareShellExecution`, thread through helpers (#347)

### DIFF
--- a/mongo-shell/adapter.js
+++ b/mongo-shell/adapter.js
@@ -62,8 +62,7 @@
     log('Version 1.5.2, released 30 September 2025');
   };
 
-  const applySecondaryReadPreference = (context) => {
-    const shellDb = getShellDb(context);
+  const applySecondaryReadPreference = (shellDb, context) => {
     if (typeof context.secondaryOk !== 'undefined') {
       if (context.secondaryOk === true) {
         shellDb.getMongo().setReadPref('secondary');
@@ -71,8 +70,7 @@
     }
   };
 
-  const validateShellStartup = (context, countMatchingDocuments) => {
-    const shellDb = getShellDb(context);
+  const validateShellStartup = (shellDb, context, countMatchingDocuments) => {
     const selectedDatabaseName = shellDb.getName();
     const knownDatabases = shellDb.adminCommand('listDatabases').databases;
     const knownDatabaseNames = [];
@@ -177,9 +175,9 @@
     const countMatchingDocuments = createCountMatchingDocuments(shellDb);
 
     logBanner(log);
-    applySecondaryReadPreference(context);
+    applySecondaryReadPreference(shellDb, context);
 
-    const collectionName = validateShellStartup(context, countMatchingDocuments);
+    const collectionName = validateShellStartup(shellDb, context, countMatchingDocuments);
     const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
     const pluginsRunner = createPluginsRunner(context, log);
 

--- a/variety.js
+++ b/variety.js
@@ -1179,8 +1179,7 @@ Please see https://github.com/variety/variety for details. */
     log('Version 1.5.2, released 30 September 2025');
   };
 
-  const applySecondaryReadPreference = (context) => {
-    const shellDb = getShellDb(context);
+  const applySecondaryReadPreference = (shellDb, context) => {
     if (typeof context.secondaryOk !== 'undefined') {
       if (context.secondaryOk === true) {
         shellDb.getMongo().setReadPref('secondary');
@@ -1188,8 +1187,7 @@ Please see https://github.com/variety/variety for details. */
     }
   };
 
-  const validateShellStartup = (context, countMatchingDocuments) => {
-    const shellDb = getShellDb(context);
+  const validateShellStartup = (shellDb, context, countMatchingDocuments) => {
     const selectedDatabaseName = shellDb.getName();
     const knownDatabases = shellDb.adminCommand('listDatabases').databases;
     const knownDatabaseNames = [];
@@ -1294,9 +1292,9 @@ Please see https://github.com/variety/variety for details. */
     const countMatchingDocuments = createCountMatchingDocuments(shellDb);
 
     logBanner(log);
-    applySecondaryReadPreference(context);
+    applySecondaryReadPreference(shellDb, context);
 
-    const collectionName = validateShellStartup(context, countMatchingDocuments);
+    const collectionName = validateShellStartup(shellDb, context, countMatchingDocuments);
     const config = resolveShellConfig(context, collectionName, countMatchingDocuments, log);
     const pluginsRunner = createPluginsRunner(context, log);
 


### PR DESCRIPTION
## Summary

- Resolves `getShellDb(context)` once at the top of `prepareShellExecution` and passes the handle as the first parameter to `applySecondaryReadPreference` and `validateShellStartup`
- Matches the existing `createCountMatchingDocuments(shellDb)` convention (shellDb-first)
- No behaviour change; `variety.js` rebuilt

Closes #347.

## Test plan

- [x] `Mongo shell adapter validation` suite passes (sets secondary read pref, plugin lifecycle, startup enumeration, global cleanup)
- [x] `Secondary reads` container test passes
- [x] All linters and typecheck pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)