### PR TITLE
Separate shell transport options into `mongo-shell/transport-options.js` (#337)

### DIFF
--- a/.eslint.config.js
+++ b/.eslint.config.js
@@ -84,7 +84,7 @@ module.exports = (async () => {
       },
     },
     {
-      files: ['.eslint.config.js', 'bin/variety', 'build.js', 'cli/**/*.js', 'mongo-shell/launcher.js', 'test/**/*.js'],
+      files: ['.eslint.config.js', 'bin/variety', 'build.js', 'cli/**/*.js', 'mongo-shell/transport-options.js', 'mongo-shell/launcher.js', 'test/**/*.js'],
       ignores: ['test/fixtures/**/*.js'],
       rules: nodeModernizationRules,
     },

--- a/.tsconfig.checkjs.json
+++ b/.tsconfig.checkjs.json
@@ -25,6 +25,7 @@
     "cli/**/*.js",
     "core/option-validation.js",
     "core/config.js",
+    "mongo-shell/transport-options.js",
     "mongo-shell/launcher.js",
     ".eslint.config.js",
     "build.js",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,7 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 - `core/option-validation.js` — shared, table-driven option validation
   dispatcher. Registers `validateOptions` on
   `shellContext.__varietyOptionValidation` for use by `core/config.js` and any
-  future option-validation boundaries (e.g. transport options in #337). Has no
-  deps on any other layer.
+  other option-validation boundaries. Has no deps on any other layer.
 - `core/config.js` — shared analysis-option validation, default resolution,
   and engine-facing materialization. This is the reusable config boundary for
   follow-up work on callable APIs, while shell transport and launch settings
@@ -55,6 +54,12 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   separately published package).
 - `bin/variety` — the published Node entrypoint that implements the main
   CLI surface.
+- `mongo-shell/transport-options.js` — dedicated normalization and validation
+  boundary for shell transport options (`host`, `port`, `username`, `password`,
+  `authenticationDatabase`, `quiet`, `uri`). Reuses the `validateOptions`
+  dispatcher from `core/option-validation.js` with its own descriptor table.
+  The canonical definition of `ShellOptions`. Node-only; not compiled into
+  `variety.js`.
 - `mongo-shell/launcher.js` — Node-side Mongo shell invocation helpers.
   The only place that touches Node `spawnSync` for spawning `mongosh`/`mongo`.
   Future interfaces (MCP, etc.) can import from `mongo-shell/` without
@@ -68,11 +73,13 @@ layer. `core/option-validation.js` has no runtime deps on any other layer.
 `core/config.js` depends on `core/option-validation.js`. `core/engine.js`
 has no runtime deps on any other layer. `core/analyzer.js` depends on
 `core/engine.js` plus `core/formatters/`. `mongo-shell/adapter.js` depends on
-`core/config.js` and `core/analyzer.js`. `mongo-shell/launcher.js` is Node-only
-(no `core` dep). `cli/options.js` depends on `core/config.js`; `cli/main.js`
-depends on `cli/options.js` and `mongo-shell/launcher.js`. `build.js` composes
-`core/formatters/` + `core/option-validation.js` + `core/config.js` +
-`core/engine.js` + `core/analyzer.js` + `mongo-shell/adapter.js` → `variety.js`.
+`core/config.js` and `core/analyzer.js`. `mongo-shell/transport-options.js`
+depends on `core/option-validation.js`; `mongo-shell/launcher.js` has no
+`core` dep. `cli/options.js` depends on `core/config.js` and
+`mongo-shell/transport-options.js`; `cli/main.js` depends on `cli/options.js`
+and `mongo-shell/launcher.js`. `build.js` composes `core/formatters/` +
+`core/option-validation.js` + `core/config.js` + `core/engine.js` +
+`core/analyzer.js` + `mongo-shell/adapter.js` → `variety.js`.
 
 `build.js` concatenates those source files under a generated-file banner.
 Edit the sources in `core/` or `mongo-shell/adapter.js`, then run:
@@ -190,7 +197,7 @@ Node-side JavaScript such as `bin/variety`, `cli/**/*.js`, `mongo-shell/launcher
 
 #### Checked Files
 
-`npm run typecheck` runs TypeScript `checkJs` over the published Node CLI surface (`bin/variety` plus `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, and `mongo-shell/launcher.js`), `.eslint.config.js`, `build.js`, and the Node-side test code via `.tsconfig.checkjs.json`. The `test` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `test/fixtures` stay on the shared baseline.
+`npm run typecheck` runs TypeScript `checkJs` over the published Node CLI surface (`bin/variety` plus `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, `mongo-shell/transport-options.js`, and `mongo-shell/launcher.js`), `.eslint.config.js`, `build.js`, and the Node-side test code via `.tsconfig.checkjs.json`. The `test` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `test/fixtures` stay on the shared baseline.
 
 #### Extra Strictness
 

--- a/cli/options.js
+++ b/cli/options.js
@@ -8,18 +8,10 @@ const {
   ANALYSIS_OPTION_NAMES,
   validateAnalysisOptions,
 } = varietyConfigModule;
+const transportOptionsModule = /** @type {typeof import('../mongo-shell/transport-options.js')} */ (require('../mongo-shell/transport-options.js'));
+const { validateShellOptions } = transportOptionsModule;
 
-/**
- * @typedef {{
- *   authenticationDatabase?: string,
- *   host?: string,
- *   password?: string,
- *   port?: number,
- *   quiet?: boolean,
- *   uri?: string,
- *   username?: string,
- * }} ShellOptions
- */
+/** @typedef {import('../mongo-shell/transport-options.js').ShellOptions} ShellOptions */
 
 /** @typedef {NonNullable<Parameters<typeof validateAnalysisOptions>[0]>} AnalysisOptionsInput */
 
@@ -672,6 +664,13 @@ const parseCliArguments = (argv) => {
 
   try {
     parsed.varietyOptions = validateAnalysisOptions(parsed.varietyOptions);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new CliUsageError(errorMessage);
+  }
+
+  try {
+    parsed.shellOptions = validateShellOptions(parsed.shellOptions);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new CliUsageError(errorMessage);

--- a/cli/options.js
+++ b/cli/options.js
@@ -72,7 +72,6 @@ class CliUsageError extends Error {
 }
 
 const COMPATIBILITY_ENV_KEYS = ['DB', 'EVAL_CMDS', 'VARIETYJS_DIR'];
-const MONGODB_URI_PREFIXES = ['mongodb://', 'mongodb+srv://'];
 /** @type {Record<string, string>} */
 const FLAG_ALIASES = {
   'array-escape': 'arrayEscape',
@@ -248,20 +247,6 @@ const parseNonEmptyString = (optionName, rawValue) => {
   }
 
   return rawValue;
-};
-
-/**
- * @param {string} optionName
- * @param {string} rawValue
- * @returns {string}
- */
-const parseMongoUri = (optionName, rawValue) => {
-  const value = parseNonEmptyString(optionName, rawValue);
-  if (!MONGODB_URI_PREFIXES.some((prefix) => value.startsWith(prefix))) {
-    throw new CliUsageError(`--${optionName} must start with "mongodb://" or "mongodb+srv://".`);
-  }
-
-  return value;
 };
 
 /**
@@ -611,7 +596,7 @@ const parseCliArguments = (argv) => {
     case 'uri': {
       const result = readOptionValue(argv, index, inlineValue, optionName);
       index = result.nextIndex;
-      parsed.shellOptions.uri = parseMongoUri(optionName, result.value);
+      parsed.shellOptions.uri = parseNonEmptyString(optionName, result.value);
       break;
     }
     case 'port': {

--- a/cli/options.js
+++ b/cli/options.js
@@ -438,27 +438,6 @@ const resolveShellOptions = (shellOptions, target) => {
     return resolved;
   }
 
-  const conflictingFlags = [];
-  if (Object.hasOwn(resolved, 'host')) {
-    conflictingFlags.push('--host');
-  }
-  if (typeof resolved.port === 'number') {
-    conflictingFlags.push('--port');
-  }
-  if (Object.hasOwn(resolved, 'username')) {
-    conflictingFlags.push('--username');
-  }
-  if (Object.hasOwn(resolved, 'password')) {
-    conflictingFlags.push('--password');
-  }
-  if (Object.hasOwn(resolved, 'authenticationDatabase')) {
-    conflictingFlags.push('--authenticationDatabase');
-  }
-
-  if (conflictingFlags.length > 0) {
-    throw new CliUsageError(`--uri cannot be combined with ${conflictingFlags.join(', ')}.`);
-  }
-
   resolved.uri = resolveMongoUriForTarget(resolved.uri, target);
   return resolved;
 };

--- a/core/option-validation.js
+++ b/core/option-validation.js
@@ -10,7 +10,7 @@
   'use strict';
 
   /**
-   * @typedef {'boolean' | 'nonNegativeInteger' | 'object' | 'string' | 'stringArray'} OptionKind
+   * @typedef {'boolean' | 'nonNegativeInteger' | 'object' | 'positiveInteger' | 'string' | 'stringArray'} OptionKind
    */
 
   /**
@@ -123,6 +123,18 @@
   };
 
   /**
+   * @param {string} name
+   * @param {unknown} value
+   * @returns {number}
+   */
+  const validatePositiveIntegerOption = (name, value) => {
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer.`);
+    }
+    return value;
+  };
+
+  /**
    * Validates a set of named options against a descriptor table, dispatching each
    * present key to the appropriate validator by kind. Unknown keys are ignored;
    * undefined-valued keys are skipped (treated as absent).
@@ -149,6 +161,9 @@
         break;
       case 'nonNegativeInteger':
         result[name] = validateNonNegativeIntegerOption(name, value);
+        break;
+      case 'positiveInteger':
+        result[name] = validatePositiveIntegerOption(name, value);
         break;
       case 'object':
         result[name] = validateObjectOption(name, value);

--- a/mongo-shell/launcher.js
+++ b/mongo-shell/launcher.js
@@ -6,17 +6,7 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-/**
- * @typedef {{
- *   authenticationDatabase?: string,
- *   host?: string,
- *   password?: string,
- *   port?: number,
- *   quiet?: boolean,
- *   uri?: string,
- *   username?: string,
- * }} ShellOptions
- */
+/** @typedef {import('./transport-options.js').ShellOptions} ShellOptions */
 
 /**
  * @typedef {{

--- a/mongo-shell/launcher.js
+++ b/mongo-shell/launcher.js
@@ -5,6 +5,8 @@
 const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const transportOptionsModule = /** @type {typeof import('./transport-options.js')} */ (require('./transport-options.js'));
+const { validateShellOptions } = transportOptionsModule;
 
 /** @typedef {import('./transport-options.js').ShellOptions} ShellOptions */
 
@@ -94,7 +96,7 @@ const buildShellInvocation = (plan, env) => {
   const command = selectMongoShell(env);
   const args = [];
   /** @type {ShellOptions} */
-  const shellOptions = plan.shellOptions || {};
+  const shellOptions = validateShellOptions(plan.shellOptions);
 
   if (shellOptions.host) {
     args.push('--host', shellOptions.host);

--- a/mongo-shell/transport-options.js
+++ b/mongo-shell/transport-options.js
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+'use strict';
+
+const optionValidationModule = /** @type {typeof import('../core/option-validation.js')} */ (require('../core/option-validation.js'));
+const { validateOptions } = optionValidationModule;
+
+/**
+ * @typedef {{
+ *   authenticationDatabase?: string,
+ *   host?: string,
+ *   password?: string,
+ *   port?: number,
+ *   quiet?: boolean,
+ *   uri?: string,
+ *   username?: string,
+ * }} ShellOptions
+ */
+
+/**
+ * @typedef {'boolean' | 'nonNegativeInteger' | 'object' | 'positiveInteger' | 'string' | 'stringArray'} OptionKind
+ */
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   kind: OptionKind,
+ *   allowNull?: boolean,
+ *   requireNonEmpty?: boolean,
+ * }} OptionDescriptor
+ */
+
+/** @type {OptionDescriptor[]} */
+const SHELL_OPTION_DESCRIPTORS = [
+  { name: 'host',                   kind: 'string' },
+  { name: 'port',                   kind: 'positiveInteger' },
+  { name: 'username',               kind: 'string' },
+  { name: 'password',               kind: 'string' },
+  { name: 'authenticationDatabase', kind: 'string' },
+  { name: 'quiet',                  kind: 'boolean' },
+  { name: 'uri',                    kind: 'string',  requireNonEmpty: true },
+];
+
+/**
+ * @param {ShellOptions | undefined} input
+ * @returns {ShellOptions}
+ */
+const validateShellOptions = (input) => {
+  if (typeof input === 'undefined') {
+    return {};
+  }
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Shell options must be an object.');
+  }
+
+  return /** @type {ShellOptions} */ (validateOptions(/** @type {Record<string, unknown>} */ (input), SHELL_OPTION_DESCRIPTORS));
+};
+
+module.exports = {
+  SHELL_OPTION_DESCRIPTORS,
+  validateShellOptions,
+};

--- a/mongo-shell/transport-options.js
+++ b/mongo-shell/transport-options.js
@@ -5,6 +5,9 @@
 const optionValidationModule = /** @type {typeof import('../core/option-validation.js')} */ (require('../core/option-validation.js'));
 const { validateOptions } = optionValidationModule;
 
+const MONGODB_URI_PREFIXES = ['mongodb://', 'mongodb+srv://'];
+const URI_CONFLICTING_KEYS = ['host', 'port', 'username', 'password', 'authenticationDatabase'];
+
 /**
  * @typedef {{
  *   authenticationDatabase?: string,
@@ -41,6 +44,9 @@ const SHELL_OPTION_DESCRIPTORS = [
   { name: 'uri',                    kind: 'string',  requireNonEmpty: true },
 ];
 
+/** @type {Set<string>} */
+const KNOWN_SHELL_OPTION_KEYS = new Set(SHELL_OPTION_DESCRIPTORS.map((d) => d.name));
+
 /**
  * @param {ShellOptions | undefined} input
  * @returns {ShellOptions}
@@ -54,7 +60,26 @@ const validateShellOptions = (input) => {
     throw new Error('Shell options must be an object.');
   }
 
-  return /** @type {ShellOptions} */ (validateOptions(/** @type {Record<string, unknown>} */ (input), SHELL_OPTION_DESCRIPTORS));
+  for (const key of Object.keys(input)) {
+    if (!KNOWN_SHELL_OPTION_KEYS.has(key)) {
+      throw new Error(`Unknown shell option: ${JSON.stringify(key)}.`);
+    }
+  }
+
+  const validated = /** @type {ShellOptions} */ (validateOptions(/** @type {Record<string, unknown>} */ (input), SHELL_OPTION_DESCRIPTORS));
+
+  if (typeof validated.uri === 'string') {
+    if (!MONGODB_URI_PREFIXES.some((prefix) => /** @type {string} */ (validated.uri).startsWith(prefix))) {
+      throw new Error('uri must start with "mongodb://" or "mongodb+srv://".');
+    }
+
+    const conflicting = URI_CONFLICTING_KEYS.filter((key) => Object.hasOwn(validated, key));
+    if (conflicting.length > 0) {
+      throw new Error(`uri cannot be combined with ${conflicting.join(', ')}.`);
+    }
+  }
+
+  return validated;
 };
 
 module.exports = {

--- a/test/cases/cli/BinWrapperTest.js
+++ b/test/cases/cli/BinWrapperTest.js
@@ -492,7 +492,7 @@ describe('bin/variety wrapper', () => {
       /** @param {NodeJS.ErrnoException & { stderr?: string | Buffer }} error */
       (error) => {
         assert.equal(error.code, 2);
-        assert.match(String(error.stderr || ''), /--uri cannot be combined with --host/);
+        assert.match(String(error.stderr || ''), /uri cannot be combined with host/);
         return true;
       }
     );

--- a/test/cases/cli/CliOptionsTest.js
+++ b/test/cases/cli/CliOptionsTest.js
@@ -294,7 +294,7 @@ describe('CLI option parsing', () => {
           '--host', 'localhost',
         ], {});
       },
-      /--uri cannot be combined with --host/
+      /uri cannot be combined with host/
     );
 
     assert.throws(
@@ -307,7 +307,7 @@ describe('CLI option parsing', () => {
           '--authenticationDatabase', 'admin',
         ], {});
       },
-      /--uri cannot be combined with --username, --password, --authenticationDatabase/
+      /uri cannot be combined with username, password, authenticationDatabase/
     );
   });
 

--- a/variety.js
+++ b/variety.js
@@ -180,7 +180,7 @@ Please see https://github.com/variety/variety for details. */
   'use strict';
 
   /**
-   * @typedef {'boolean' | 'nonNegativeInteger' | 'object' | 'string' | 'stringArray'} OptionKind
+   * @typedef {'boolean' | 'nonNegativeInteger' | 'object' | 'positiveInteger' | 'string' | 'stringArray'} OptionKind
    */
 
   /**
@@ -293,6 +293,18 @@ Please see https://github.com/variety/variety for details. */
   };
 
   /**
+   * @param {string} name
+   * @param {unknown} value
+   * @returns {number}
+   */
+  const validatePositiveIntegerOption = (name, value) => {
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer.`);
+    }
+    return value;
+  };
+
+  /**
    * Validates a set of named options against a descriptor table, dispatching each
    * present key to the appropriate validator by kind. Unknown keys are ignored;
    * undefined-valued keys are skipped (treated as absent).
@@ -319,6 +331,9 @@ Please see https://github.com/variety/variety for details. */
         break;
       case 'nonNegativeInteger':
         result[name] = validateNonNegativeIntegerOption(name, value);
+        break;
+      case 'positiveInteger':
+        result[name] = validatePositiveIntegerOption(name, value);
         break;
       case 'object':
         result[name] = validateObjectOption(name, value);


### PR DESCRIPTION
Closes #337.

## Summary

- **`core/option-validation.js`** — adds `positiveInteger` kind to the `OptionKind` union and a `validatePositiveIntegerOption` helper, so port validation fits the same table-driven pattern as every other option kind.
- **`mongo-shell/transport-options.js`** (new) — dedicated normalization and validation boundary for shell transport options (`host`, `port`, `username`, `password`, `authenticationDatabase`, `quiet`, `uri`). Declares `ShellOptions` as the canonical typedef, defines `SHELL_OPTION_DESCRIPTORS`, and exposes `validateShellOptions`, which:
  - rejects unknown keys (programmatic callers cannot silently misspell a transport option),
  - delegates type checks to the shared `validateOptions` dispatcher,
  - enforces the `mongodb://` / `mongodb+srv://` URI prefix,
  - enforces URI vs host/auth-flag exclusivity (`uri` cannot be combined with `host`, `port`, `username`, `password`, or `authenticationDatabase`).
  Node-only; not compiled into `variety.js`.
- **`mongo-shell/launcher.js`** — removes the now-redundant local `ShellOptions` typedef (replaced by a `@typedef` import); calls `validateShellOptions` at the top of `buildShellInvocation` so any non-CLI caller going through the standard launch path gets canonical validation automatically.
- **`cli/options.js`** — removes the local inline `ShellOptions` typedef and `parseMongoUri` (URI-shape validation is now exclusively owned by the transport module); imports `validateShellOptions` from `mongo-shell/transport-options.js` and calls it at the end of `parseCliArguments`; `resolveShellOptions` is stripped to only the target-dependent DB-path injection — the one piece that genuinely belongs in CLI land.
- **`.tsconfig.checkjs.json`**, **`.eslint.config.js`** — `transport-options.js` added to typecheck targets and the Node modernization lint set.
- **`CONTRIBUTING.md`** — repo layout, dependency directions, and typecheck description updated.

## Design

The transport module sits in `mongo-shell/` rather than `cli/` because transport options are launcher concerns, not CLI concerns. The dependency arrow is: `cli/options.js` → `mongo-shell/transport-options.js` → `core/option-validation.js`; `mongo-shell/launcher.js` → `mongo-shell/transport-options.js`. `resolveShellOptions` stays in `cli/options.js` because DB-path injection requires a resolved `target` (database name) and is therefore inherently CLI-bound. Every other transport invariant lives in the transport module.

`variety.js` and `build.js` are unchanged apart from the `positiveInteger` kind added to the shared `option-validation.js` IIFE (which was already part of the build).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (all linters including SPDX, markdownlint, shellcheck, hadolint)
- [x] `npm run verify:build` passes
- [x] 78 unit tests pass; 19 MongoDB-integration timeouts are pre-existing (`npm run test:docker` covers those in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)