### PR TITLE
Tighten the exported surface of core/engine.js (#334)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,10 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   tolerates shell/runtime helpers when they are available. Intentionally
   exports only `analyzeDocuments`, `createAnalysisState`, `ingestDocument`,
   `finalizeResults`, and `varietyTypeOf`; implementation helpers stay
-  file-local. This reducer/finalization engine is used by both the
-  shell-facing analyzer and Node-side tests, and is the future `@variety/core`
-  package boundary.
+  file-local, while `varietyTypeOf` remains public as the direct
+  type-classification entrypoint used by focused tests and future callers.
+  This reducer/finalization engine is used by both the shell-facing analyzer
+  and Node-side tests, and is the future `@variety/core` package boundary.
 - `core/analyzer.js` — shell-adjacent orchestration that traverses the cursor,
   optionally persists results, dispatches to formatters, and exposes `run()`
   on top of `core/engine.js`. Depends on `core/formatters/` and `core/engine.js`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,12 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   remain entrypoint concerns. Depends on `core/option-validation.js`.
 - `core/engine.js` — reusable analysis logic that keeps persistence,
   formatter dispatch, and output side effects out of the engine. It still
-  tolerates shell/runtime helpers when they are available. Exports the
-  reducer/finalization engine used by both the shell-facing analyzer and
-  Node-side tests. This is the future `@variety/core` package boundary.
+  tolerates shell/runtime helpers when they are available. Intentionally
+  exports only `analyzeDocuments`, `createAnalysisState`, `ingestDocument`,
+  `finalizeResults`, and `varietyTypeOf`; implementation helpers stay
+  file-local. This reducer/finalization engine is used by both the
+  shell-facing analyzer and Node-side tests, and is the future `@variety/core`
+  package boundary.
 - `core/analyzer.js` — shell-adjacent orchestration that traverses the cursor,
   optionally persists results, dispatches to formatters, and exposes `run()`
   on top of `core/engine.js`. Depends on `core/formatters/` and `core/engine.js`.

--- a/core/analyzer.js
+++ b/core/analyzer.js
@@ -16,6 +16,18 @@
     throw new Error('Expected core/engine.js to register __varietyEngine.');
   }
 
+  const shellToJson = (value) => {
+    if (typeof tojson === 'function') {
+      return tojson(value);
+    }
+
+    if (shellContext.EJSON && typeof shellContext.EJSON.stringify === 'function') {
+      return shellContext.EJSON.stringify(value);
+    }
+
+    return JSON.stringify(value);
+  };
+
   const persistResults = (config, varietyResults, deps) => {
     const {db, connect, log} = deps;
 
@@ -75,7 +87,7 @@
     formatResults(config, pluginsRunner, varietyResults, print);
   };
 
-  const impl = Object.assign({}, engine, { run });
+  const impl = Object.assign({}, engine, { run, shellToJson });
   shellContext.__varietyImpl = impl;
 
   if (typeof module !== 'undefined' && module && module.exports) {

--- a/core/engine.js
+++ b/core/engine.js
@@ -395,26 +395,11 @@
   };
 
   const engine = {
-    createAnalysisState,
-    createKeyMap,
-    shellToJson,
-    getBinDataSubtype,
-    getBinDataHex,
-    getVectorDtypeByte,
-    getVectorDtypeLabel,
-    getRawBsonTypeName,
-    normalizeBsonTypeName,
-    getSpecialTypeName,
-    varietyTypeOf,
-    serializeDoc,
-    analyseDocument,
-    mergeDocument,
-    convertResults,
-    ingestDocument,
-    buildResultFilter,
-    compareResults,
-    finalizeResults,
     analyzeDocuments,
+    createAnalysisState,
+    ingestDocument,
+    finalizeResults,
+    varietyTypeOf,
   };
 
   shellContext.__varietyEngine = engine;

--- a/core/engine.js
+++ b/core/engine.js
@@ -10,6 +10,10 @@
 
   const createKeyMap = () => Object.create(null);
 
+  // Keep a local copy here for getBinDataHex()'s fallback path. The analyzer
+  // also carries its own shellToJson helper for logging, but this engine copy
+  // stays file-local so tightening the public engine surface does not have to
+  // expose shell-adjacent helpers again.
   const shellToJson = (value) => {
     if (typeof tojson === 'function') {
       return tojson(value);
@@ -142,7 +146,9 @@
 
   // varietyTypeOf must remain a regular function (not an arrow function) because
   // the no-argument guard below relies on the function's own `arguments` object,
-  // which arrow functions do not have.
+  // which arrow functions do not have. It remains part of the intentional
+  // engine API so direct callers can exercise the type-classification logic
+  // without going through a full document-analysis pass.
   const varietyTypeOf = function(config, thing) {
     if (arguments.length < 2) { throw new Error('varietyTypeOf() requires an argument'); }
 

--- a/test/cases/analysis/EngineExportSurfaceTest.js
+++ b/test/cases/analysis/EngineExportSurfaceTest.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert/strict';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const enginePath = fileURLToPath(new URL('../../../core/engine.js', import.meta.url));
+const rawImpl = /** @type {unknown} */ (require(enginePath));
+
+describe('Engine export surface', () => {
+  it('exports only the intentional core engine API (#334)', () => {
+    const exportedNames = Object.keys(/** @type {Record<string, unknown>} */ (rawImpl)).sort();
+
+    assert.deepEqual(exportedNames, [
+      'analyzeDocuments',
+      'createAnalysisState',
+      'finalizeResults',
+      'ingestDocument',
+      'varietyTypeOf',
+    ]);
+  });
+});

--- a/variety.js
+++ b/variety.js
@@ -1090,26 +1090,11 @@ Please see https://github.com/variety/variety for details. */
   };
 
   const engine = {
-    createAnalysisState,
-    createKeyMap,
-    shellToJson,
-    getBinDataSubtype,
-    getBinDataHex,
-    getVectorDtypeByte,
-    getVectorDtypeLabel,
-    getRawBsonTypeName,
-    normalizeBsonTypeName,
-    getSpecialTypeName,
-    varietyTypeOf,
-    serializeDoc,
-    analyseDocument,
-    mergeDocument,
-    convertResults,
-    ingestDocument,
-    buildResultFilter,
-    compareResults,
-    finalizeResults,
     analyzeDocuments,
+    createAnalysisState,
+    ingestDocument,
+    finalizeResults,
+    varietyTypeOf,
   };
 
   shellContext.__varietyEngine = engine;
@@ -1137,6 +1122,18 @@ Please see https://github.com/variety/variety for details. */
   if (!engine) {
     throw new Error('Expected core/engine.js to register __varietyEngine.');
   }
+
+  const shellToJson = (value) => {
+    if (typeof tojson === 'function') {
+      return tojson(value);
+    }
+
+    if (shellContext.EJSON && typeof shellContext.EJSON.stringify === 'function') {
+      return shellContext.EJSON.stringify(value);
+    }
+
+    return JSON.stringify(value);
+  };
 
   const persistResults = (config, varietyResults, deps) => {
     const {db, connect, log} = deps;
@@ -1197,7 +1194,7 @@ Please see https://github.com/variety/variety for details. */
     formatResults(config, pluginsRunner, varietyResults, print);
   };
 
-  const impl = Object.assign({}, engine, { run });
+  const impl = Object.assign({}, engine, { run, shellToJson });
   shellContext.__varietyImpl = impl;
 
   if (typeof module !== 'undefined' && module && module.exports) {

--- a/variety.js
+++ b/variety.js
@@ -705,6 +705,10 @@ Please see https://github.com/variety/variety for details. */
 
   const createKeyMap = () => Object.create(null);
 
+  // Keep a local copy here for getBinDataHex()'s fallback path. The analyzer
+  // also carries its own shellToJson helper for logging, but this engine copy
+  // stays file-local so tightening the public engine surface does not have to
+  // expose shell-adjacent helpers again.
   const shellToJson = (value) => {
     if (typeof tojson === 'function') {
       return tojson(value);
@@ -837,7 +841,9 @@ Please see https://github.com/variety/variety for details. */
 
   // varietyTypeOf must remain a regular function (not an arrow function) because
   // the no-argument guard below relies on the function's own `arguments` object,
-  // which arrow functions do not have.
+  // which arrow functions do not have. It remains part of the intentional
+  // engine API so direct callers can exercise the type-classification logic
+  // without going through a full document-analysis pass.
   const varietyTypeOf = function(config, thing) {
     if (arguments.length < 2) { throw new Error('varietyTypeOf() requires an argument'); }
 


### PR DESCRIPTION
Closes #334.

## Summary
- narrow `core/engine.js` exports to the intentional engine API: `analyzeDocuments`, `createAnalysisState`, `ingestDocument`, `finalizeResults`, and `varietyTypeOf`
- add an explicit analysis test that locks the engine export surface so helper re-exports do not creep back in
- document the intentional engine boundary in `CONTRIBUTING.md` and keep the shell-facing `impl.shellToJson` path working from `core/analyzer.js`

## Why
- `core/engine.js` was still exporting a broad extraction-era surface that made the future engine boundary look more public than intended
- this keeps implementation helpers file-local while preserving the reducer/finalization API used by the analyzer and engine-focused tests

## Validation
- `npm run build`
- `node build.js --check`
- `/home/j/variety/node_modules/.bin/tsc --project .tsconfig.checkjs.json`
- `/home/j/variety/node_modules/.bin/eslint --config .eslint.config.js core/engine.js core/analyzer.js test/cases/analysis/EngineExportSurfaceTest.js`
- `npm run test:container`
  - the container lane reached `125 passing` before four late-suite Mongo connectivity/timeouts in `ContinuousLoggingTest`, `PersistenceTest`, and `PluginTest` (`MongoServerSelectionError: connect ECONNREFUSED 127.0.0.1:27017`)
