### PR TITLE
Speed up YAML linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ Otherwise `npm run lint:pre-commit` runs all of the following in parallel via [n
 - `npm run lint` — ESLint (JavaScript, including fenced code blocks in Markdown)
 - `npm run lint:json` — `@prantlf/jsonlint` (JSON files)
 - `npm run lint:markdown` — markdownlint (Markdown files)
-- `npm run lint:yaml` — js-yaml (YAML files)
+- `npm run lint:yaml` — `scripts/lint-yaml.js` using `js-yaml` (YAML files)
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`); requires `hadolint` on `PATH` (`dnf install hadolint` / `brew install hadolint`)
 - `npm run lint:shell` — shellcheck (shell scripts); requires `shellcheck` on `PATH` (`dnf install ShellCheck` / `brew install shellcheck`)
 - `npm run lint:spdx` — verifies `SPDX-License-Identifier: MIT` headers in all tracked source files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ Otherwise `npm run lint:pre-commit` runs all of the following in parallel via [n
 - `npm run lint` — ESLint (JavaScript, including fenced code blocks in Markdown)
 - `npm run lint:json` — `@prantlf/jsonlint` (JSON files)
 - `npm run lint:markdown` — markdownlint (Markdown files)
-- `npm run lint:yaml` — `scripts/lint-yaml.js` using `js-yaml` (YAML files)
+- `npm run lint:yaml` — `scripts/lint-yaml.js` using `js-yaml` (git-tracked YAML files)
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`); requires `hadolint` on `PATH` (`dnf install hadolint` / `brew install hadolint`)
 - `npm run lint:shell` — shellcheck (shell scripts); requires `shellcheck` on `PATH` (`dnf install ShellCheck` / `brew install shellcheck`)
 - `npm run lint:spdx` — verifies `SPDX-License-Identifier: MIT` headers in all tracked source files

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint:fix": "./node_modules/.bin/eslint --config .eslint.config.js . --fix",
     "lint:json": "find . \\( -name '*.json' ! -name 'package-lock.json' \\) -not -path '*/node_modules/*' -not -path './.git/*' -not -path './.worktrees/*' -print0 | xargs -0 ./node_modules/@prantlf/jsonlint/lib/cli.js -q",
     "lint:markdown": "./node_modules/.bin/markdownlint '**/*.md' '**/*.markdown' --ignore node_modules --ignore .worktrees",
-    "lint:yaml": "find . \\( -name '*.yml' -o -name '*.yaml' \\) -not -path '*/node_modules/*' -not -path './.git/*' -not -path './.worktrees/*' -print0 | xargs -0 -n1 ./node_modules/.bin/js-yaml > /dev/null",
+    "lint:yaml": "node scripts/lint-yaml.js",
     "lint:dockerfile": "hadolint docker/Dockerfile.template",
     "lint:shell": "shellcheck docker/init.sh test/bin/test-in-container.sh",
     "lint:spdx": "node scripts/check-spdx.js",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint:fix": "./node_modules/.bin/eslint --config .eslint.config.js . --fix",
     "lint:json": "find . \\( -name '*.json' ! -name 'package-lock.json' \\) -not -path '*/node_modules/*' -not -path './.git/*' -not -path './.worktrees/*' -print0 | xargs -0 ./node_modules/@prantlf/jsonlint/lib/cli.js -q",
     "lint:markdown": "./node_modules/.bin/markdownlint '**/*.md' '**/*.markdown' --ignore node_modules --ignore .worktrees",
-    "lint:yaml": "node scripts/lint-yaml.js",
+    "lint:yaml": "git ls-files -z -- '*.yml' '*.yaml' | node scripts/lint-yaml.js",
     "lint:dockerfile": "hadolint docker/Dockerfile.template",
     "lint:shell": "shellcheck docker/init.sh test/bin/test-in-container.sh",
     "lint:spdx": "node scripts/check-spdx.js",

--- a/scripts/lint-yaml.js
+++ b/scripts/lint-yaml.js
@@ -8,45 +8,12 @@ const path = require('path');
 const yaml = require('js-yaml');
 
 const ROOT = process.cwd();
-const YAML_EXTENSIONS = new Set(['.yml', '.yaml']);
-const IGNORED_DIRECTORY_NAMES = new Set(['.git', '.worktrees', 'node_modules']);
-const IGNORED_RELATIVE_DIRECTORIES = new Set(['.claude/worktrees']);
 
-function isIgnoredDirectory(relativePath, entryName) {
-  if (IGNORED_DIRECTORY_NAMES.has(entryName)) {
-    return true;
-  }
-  if (IGNORED_RELATIVE_DIRECTORIES.has(relativePath)) {
-    return true;
-  }
-  return false;
-}
-
-function findYamlFiles(relativeDirectory = '') {
-  const absoluteDirectory = path.join(ROOT, relativeDirectory);
-  const entries = fs.readdirSync(absoluteDirectory, { withFileTypes: true })
-    .sort((left, right) => left.name.localeCompare(right.name));
-  const files = [];
-
-  for (const entry of entries) {
-    const relativePath = relativeDirectory
-      ? path.posix.join(relativeDirectory, entry.name)
-      : entry.name;
-
-    if (entry.isDirectory()) {
-      if (isIgnoredDirectory(relativePath, entry.name)) {
-        continue;
-      }
-      files.push(...findYamlFiles(relativePath));
-      continue;
-    }
-
-    if (entry.isFile() && YAML_EXTENSIONS.has(path.extname(entry.name))) {
-      files.push(relativePath);
-    }
-  }
-
-  return files;
+function findYamlFiles() {
+  return fs.readFileSync(0, 'utf8')
+    .split('\0')
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function reportFailure(file, error) {
@@ -59,7 +26,7 @@ function reportFailure(file, error) {
 let failures = 0;
 for (const file of findYamlFiles()) {
   try {
-    yaml.loadAll(fs.readFileSync(path.join(ROOT, file), 'utf8'), () => {}, {});
+    yaml.loadAll(fs.readFileSync(path.join(ROOT, file), 'utf8'), () => {});
   } catch (error) {
     reportFailure(file, error);
     failures++;

--- a/scripts/lint-yaml.js
+++ b/scripts/lint-yaml.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = process.cwd();
+const YAML_EXTENSIONS = new Set(['.yml', '.yaml']);
+const IGNORED_DIRECTORY_NAMES = new Set(['.git', '.worktrees', 'node_modules']);
+const IGNORED_RELATIVE_DIRECTORIES = new Set(['.claude/worktrees']);
+
+function isIgnoredDirectory(relativePath, entryName) {
+  if (IGNORED_DIRECTORY_NAMES.has(entryName)) {
+    return true;
+  }
+  if (IGNORED_RELATIVE_DIRECTORIES.has(relativePath)) {
+    return true;
+  }
+  return false;
+}
+
+function findYamlFiles(relativeDirectory = '') {
+  const absoluteDirectory = path.join(ROOT, relativeDirectory);
+  const entries = fs.readdirSync(absoluteDirectory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const files = [];
+
+  for (const entry of entries) {
+    const relativePath = relativeDirectory
+      ? path.posix.join(relativeDirectory, entry.name)
+      : entry.name;
+
+    if (entry.isDirectory()) {
+      if (isIgnoredDirectory(relativePath, entry.name)) {
+        continue;
+      }
+      files.push(...findYamlFiles(relativePath));
+      continue;
+    }
+
+    if (entry.isFile() && YAML_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(relativePath);
+    }
+  }
+
+  return files;
+}
+
+function reportFailure(file, error) {
+  const message = typeof error.toString === 'function'
+    ? error.toString()
+    : (error.message || String(error));
+  console.error(`${file}: ${message}`);
+}
+
+let failures = 0;
+for (const file of findYamlFiles()) {
+  try {
+    yaml.loadAll(fs.readFileSync(path.join(ROOT, file), 'utf8'), () => {}, {});
+  } catch (error) {
+    reportFailure(file, error);
+    failures++;
+  }
+}
+
+if (failures > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- replace the per-file `xargs -n1 ./node_modules/.bin/js-yaml` pipeline with a one-process `scripts/lint-yaml.js` runner
- feed that runner from `git ls-files -z -- '*.yml' '*.yaml'` so YAML linting stays scoped to git-tracked files instead of a filesystem deny-list
- preserve `js-yaml` parser diagnostics while prefixing failures with the YAML file path and continuing through all files

## Why
The previous `lint:yaml` command started a fresh Node process for every YAML file. In this checkout that also meant linting YAML files from nested worktrees, which made `npm run lint:yaml` much slower than the actual parsing work justified. Using `git ls-files` also keeps the file-selection behavior aligned with other repo-owned tooling like `scripts/check-spdx.js`.

## Scope
This PR intentionally stays scoped to YAML linting. JSON and Markdown still use their existing file-enumeration paths and can be handled separately.

## Impact
- `npm run lint:yaml` now stays within one Node process
- YAML linting now targets git-tracked YAML files
- failure output remains actionable and now includes the filename
- contributor docs now point to the repo-owned YAML lint runner and its tracked-file semantics

## Validation
- `npm run lint:yaml`
- `node /home/j/variety/node_modules/eslint/bin/eslint.js --config .eslint.config.js scripts/lint-yaml.js`
- `npm run lint:spdx`
- `git diff --check`
- targeted failure check in a temp git repo with tracked `good.yml` and `bad.yml`
- local timing check: `npm run lint:yaml` dropped from about `17.8s` to about `0.29s` in this checkout