### PR TITLE
Add internal MongoDB Node driver adapter

### DIFF
--- a/.eslint.config.js
+++ b/.eslint.config.js
@@ -84,7 +84,7 @@ module.exports = (async () => {
       },
     },
     {
-      files: ['.eslint.config.js', 'bin/variety', 'build.js', 'cli/**/*.js', 'mongo-shell/transport-options.js', 'mongo-shell/launcher.js', 'test/**/*.js'],
+      files: ['.eslint.config.js', 'bin/variety', 'build.js', 'cli/**/*.js', 'mongo-driver/**/*.js', 'mongo-shell/transport-options.js', 'mongo-shell/launcher.js', 'test/**/*.js'],
       ignores: ['test/fixtures/**/*.js'],
       rules: nodeModernizationRules,
     },

--- a/.tsconfig.checkjs.json
+++ b/.tsconfig.checkjs.json
@@ -25,6 +25,7 @@
     "cli/**/*.js",
     "core/option-validation.js",
     "core/config.js",
+    "mongo-driver/**/*.js",
     "mongo-shell/transport-options.js",
     "mongo-shell/launcher.js",
     ".eslint.config.js",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
 
 ## Repo Layout and the `variety.js` Build
 
-`variety.js` at the repo root is a generated file, assembled from seven sources in this order:
+The repo is organized around these sources and layers. The generated `variety.js`
+bundle is assembled from the shell-compatible sources among them, in build order:
 
 - `core/formatters/ascii.js` — built-in ASCII table formatter. Self-contained
   IIFE; registers an `ascii` factory on `shellContext.__varietyFormatters`.
@@ -68,6 +69,13 @@ As an additional (not required) dependency, [Docker](https://www.docker.com/) or
   The only place that touches Node `spawnSync` for spawning `mongosh`/`mongo`.
   Future interfaces (MCP, etc.) can import from `mongo-shell/` without
   reaching into `cli/`.
+- `mongo-driver/adapter.js` — internal MongoDB Node driver adapter that runs
+  Variety analysis directly against a `Collection` or `Db` without shelling out.
+  Reuses `core/config.js` and `core/engine.js`, preserves driver-native BSON
+  values, and rejects formatter, persistence, plugin, and shell-only options so
+  this boundary stays analysis-only for now. Node-only; not compiled into
+  `variety.js`. A future `@variety/node` or `@variety/mcp-server` package could
+  grow on top of this layer.
 - `cli/main.js`, `cli/options.js` — Node-side CLI parsing and compatibility
   handling. Depends on `core` and `mongo-shell/`; this is the future
   `@variety/cli` package boundary.
@@ -79,7 +87,8 @@ has no runtime deps on any other layer. `core/analyzer.js` depends on
 `core/engine.js` plus `core/formatters/`. `mongo-shell/adapter.js` depends on
 `core/config.js` and `core/analyzer.js`. `mongo-shell/transport-options.js`
 depends on `core/option-validation.js`; `mongo-shell/launcher.js` has no
-`core` dep. `cli/options.js` depends on `core/config.js` and
+`core` dep. `mongo-driver/adapter.js` depends on `core/config.js` and
+`core/engine.js`. `cli/options.js` depends on `core/config.js` and
 `mongo-shell/transport-options.js`; `cli/main.js` depends on `cli/options.js`
 and `mongo-shell/launcher.js`. `build.js` composes `core/formatters/` +
 `core/option-validation.js` + `core/config.js` + `core/engine.js` +
@@ -102,7 +111,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 npm run test:mocha
 ```
 
-The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern under `test/cases/` — `test/cases/analysis/`, `test/cases/cli/`, `test/cases/formatters/`, `test/cases/persistence/`, and `test/cases/plugins/` — with shared helpers under `test/helpers/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, so the command-line translation layer can be validated without a live MongoDB shell install. Analysis tests include deterministic property-based fuzzing with `fast-check` to exercise generated Mongo-like documents against core analyzer invariants.
+The test suite under `test/` runs as native ESM through its own `test/package.json`, while the repository root intentionally stays CommonJS so the CLI entrypoint and config files keep their current behavior. Tests are grouped by concern under `test/cases/` — `test/cases/analysis/`, `test/cases/cli/`, `test/cases/formatters/`, `test/cases/mongo-driver/`, `test/cases/persistence/`, and `test/cases/plugins/` — with shared helpers under `test/helpers/` and static inputs under `test/fixtures/`. That Mocha lane also includes focused CLI tests that execute `bin/variety` and stub `mongosh` / `mongo`, plus MongoDB Node driver adapter tests that exercise the private programmatic boundary without shelling out. Analysis tests include deterministic property-based fuzzing with `fast-check` to exercise generated Mongo-like documents against core analyzer invariants.
 
 If you have Docker or Podman installed and don't want to test against your own MongoDB instance,
 you can execute tests against dockerized MongoDB:
@@ -179,7 +188,7 @@ Otherwise `npm run lint:pre-commit` runs all of the following in parallel via [n
 - `npm run lint:dockerfile` — hadolint (`docker/Dockerfile.template`); requires `hadolint` on `PATH` (`dnf install hadolint` / `brew install hadolint`)
 - `npm run lint:shell` — shellcheck (shell scripts); requires `shellcheck` on `PATH` (`dnf install ShellCheck` / `brew install shellcheck`)
 - `npm run lint:spdx` — verifies `SPDX-License-Identifier: MIT` headers in all tracked source files
-- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `bin/variety`, `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, `.eslint.config.js`, `build.js`, and Node-side test code under `test`
+- `npm run typecheck` — TypeScript `checkJs`/JSDoc validation for `bin/variety`, `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, `mongo-driver/**/*.js`, `.eslint.config.js`, `build.js`, and Node-side test code under `test`
 
 All checks run to completion even when one fails, so all errors surface in a single commit attempt.
 
@@ -193,7 +202,7 @@ Markdownlint allows only one inline HTML element, `<br />`, for intentional line
 
 #### Node-side Modernization
 
-Node-side JavaScript such as `bin/variety`, `cli/**/*.js`, `mongo-shell/launcher.js`, `.eslint.config.js`, `build.js`, and the test suite under `test/` (excluding shell-executed fixtures under `test/fixtures/`) opts into a stricter modernization set: `const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects.
+Node-side JavaScript such as `bin/variety`, `cli/**/*.js`, `mongo-driver/**/*.js`, `mongo-shell/launcher.js`, `.eslint.config.js`, `build.js`, and the test suite under `test/` (excluding shell-executed fixtures under `test/fixtures/`) opts into a stricter modernization set: `const`, template literals, object shorthand, `Object.hasOwn`, and throwing `Error` objects.
 
 #### Legacy Shell Compatibility
 
@@ -203,7 +212,7 @@ Node-side JavaScript such as `bin/variety`, `cli/**/*.js`, `mongo-shell/launcher
 
 #### Checked Files
 
-`npm run typecheck` runs TypeScript `checkJs` over the published Node CLI surface (`bin/variety` plus `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, `mongo-shell/transport-options.js`, and `mongo-shell/launcher.js`), `.eslint.config.js`, `build.js`, and the Node-side test code via `.tsconfig.checkjs.json`. The `test` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `test/fixtures` stay on the shared baseline.
+`npm run typecheck` runs TypeScript `checkJs` over the published Node CLI surface (`bin/variety` plus `cli/**/*.js`, `core/option-validation.js`, `core/config.js`, `mongo-driver/**/*.js`, `mongo-shell/transport-options.js`, and `mongo-shell/launcher.js`), `.eslint.config.js`, `build.js`, and the Node-side test code via `.tsconfig.checkjs.json`. The `test` tree also uses type-aware `typescript-eslint` rules, while shell-executed fixtures under `test/fixtures` stay on the shared baseline.
 
 #### Extra Strictness
 

--- a/mongo-driver/adapter.js
+++ b/mongo-driver/adapter.js
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+'use strict';
+
+const path = require('path');
+const varietyConfigModule = /** @type {typeof import('../core/config.js')} */ (require('../core/config.js'));
+const {
+  materializeAnalysisConfig,
+  resolveAnalysisOptions,
+  validateAnalysisOptions,
+} = varietyConfigModule;
+
+/** @typedef {import('mongodb').Db} MongoDb */
+/** @typedef {import('mongodb').Document} MongoDocument */
+/** @typedef {import('mongodb').Collection<MongoDocument>} MongoCollection */
+/** @typedef {NonNullable<Parameters<typeof validateAnalysisOptions>[0]>} AnalysisOptionsInput */
+/** @typedef {ReturnType<typeof materializeAnalysisConfig>} MaterializedAnalysisConfig */
+
+/**
+ * @typedef {{
+ *   _id: { key: string },
+ *   value: { types: Record<string, number> },
+ *   totalOccurrences: number,
+ *   percentContaining: number,
+ *   lastValue?: unknown,
+ *   examples?: unknown[],
+ * }} VarietyResultRow
+ */
+
+/**
+ * @typedef {{
+ *   createAnalysisState: () => Record<string, unknown>,
+ *   ingestDocument: (
+ *     config: MaterializedAnalysisConfig,
+ *     accumulator: Record<string, unknown>,
+ *     object: MongoDocument,
+ *     log: (message: string) => void
+ *   ) => Record<string, unknown>,
+ *   finalizeResults: (
+ *     config: MaterializedAnalysisConfig,
+ *     interimResults: Record<string, unknown>,
+ *     documentsCount: number
+ *   ) => VarietyResultRow[],
+ * }} VarietyEngineApi
+ */
+
+const engine = /** @type {VarietyEngineApi} */ (
+  /** @type {unknown} */ (require(path.join(__dirname, '..', 'core', 'engine.js')))
+);
+
+const SUPPORTED_ANALYSIS_OPTION_NAMES = new Set([
+  'query',
+  'limit',
+  'maxDepth',
+  'sort',
+  'excludeSubkeys',
+  'arrayEscape',
+  'showArrayElements',
+  'compactArrayTypes',
+  'lastValue',
+  'maxExamples',
+]);
+
+/** @type {Record<string, string>} */
+const UNSUPPORTED_OPTION_REASONS = {
+  collection: 'select the target collection via the function argument instead.',
+  hideFrequencyColumns: 'ASCII formatter layout does not apply to structured Node-driver results.',
+  logKeysContinuously: 'continuous shell logging is outside this analysis-only adapter.',
+  outputFormat: 'formatter selection belongs to shell and CLI entrypoints.',
+  persistResults: 'result persistence is deferred and not yet supported here.',
+  plugins: 'plugin loading is deferred pending a normalized plugin-definition model.',
+  resultsCollection: 'result persistence is deferred and not yet supported here.',
+  resultsDatabase: 'result persistence is deferred and not yet supported here.',
+  resultsPass: 'result persistence is deferred and not yet supported here.',
+  resultsUser: 'result persistence is deferred and not yet supported here.',
+  secondaryOk: 'secondaryOk is a Mongo shell runtime option, not a Node-driver analysis option.',
+};
+
+/**
+ * @param {AnalysisOptionsInput | undefined} input
+ * @returns {Record<string, unknown>}
+ */
+const ensureOptionsObject = (input) => {
+  if (typeof input === 'undefined') {
+    return {};
+  }
+
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('MongoDB Node driver analysis options must be an object.');
+  }
+
+  return input;
+};
+
+/**
+ * @param {Record<string, unknown>} source
+ * @returns {void}
+ */
+const assertSupportedOptions = (source) => {
+  for (const key of Object.keys(source)) {
+    if (typeof source[key] === 'undefined') {
+      continue;
+    }
+
+    if (Object.hasOwn(UNSUPPORTED_OPTION_REASONS, key)) {
+      throw new Error(`The MongoDB Node driver adapter does not support ${JSON.stringify(key)}; ${UNSUPPORTED_OPTION_REASONS[key]}`);
+    }
+
+    if (!SUPPORTED_ANALYSIS_OPTION_NAMES.has(key)) {
+      throw new Error(`Unknown MongoDB Node driver analysis option: ${JSON.stringify(key)}.`);
+    }
+  }
+};
+
+/**
+ * @param {MongoCollection | unknown} collection
+ * @returns {MongoCollection}
+ */
+const ensureCollection = (collection) => {
+  if (
+    !collection ||
+    typeof collection !== 'object' ||
+    typeof /** @type {{ countDocuments?: unknown }} */ (collection).countDocuments !== 'function' ||
+    typeof /** @type {{ find?: unknown }} */ (collection).find !== 'function' ||
+    typeof /** @type {{ collectionName?: unknown }} */ (collection).collectionName !== 'string' ||
+    /** @type {{ collectionName: string }} */ (collection).collectionName.length === 0
+  ) {
+    throw new Error('Expected a MongoDB Collection with collectionName, countDocuments(), and find().');
+  }
+
+  return /** @type {MongoCollection} */ (collection);
+};
+
+/**
+ * @param {MongoDb | unknown} db
+ * @returns {MongoDb}
+ */
+const ensureDb = (db) => {
+  if (!db || typeof db !== 'object' || typeof /** @type {{ collection?: unknown }} */ (db).collection !== 'function') {
+    throw new Error('Expected a MongoDB Db with collection().');
+  }
+
+  return /** @type {MongoDb} */ (db);
+};
+
+/**
+ * @param {string | unknown} collectionName
+ * @returns {string}
+ */
+const ensureCollectionName = (collectionName) => {
+  if (typeof collectionName !== 'string' || collectionName.length === 0) {
+    throw new Error('collectionName must be a non-empty string.');
+  }
+
+  return collectionName;
+};
+
+/**
+ * @param {MongoCollection} collection
+ * @param {Record<string, unknown>} query
+ * @param {number} [limit]
+ * @returns {Promise<number>}
+ */
+const countMatchingDocuments = async (collection, query, limit) => {
+  const options = (typeof limit === 'number' && limit > 0) ? { limit } : undefined;
+  return collection.countDocuments(query, options);
+};
+
+/**
+ * @param {AnalysisOptionsInput} validatedOptions
+ * @returns {Record<string, unknown>}
+ */
+const readQuery = (validatedOptions) => {
+  return Object.hasOwn(validatedOptions, 'query')
+    ? /** @type {Record<string, unknown>} */ (validatedOptions.query)
+    : {};
+};
+
+/**
+ * @param {MongoCollection} collection
+ * @param {AnalysisOptionsInput} validatedOptions
+ * @returns {Promise<MaterializedAnalysisConfig>}
+ */
+const resolveDriverConfig = async (collection, validatedOptions) => {
+  const query = readQuery(validatedOptions);
+  const limit = Object.hasOwn(validatedOptions, 'limit')
+    ? /** @type {number} */ (validatedOptions.limit)
+    : await countMatchingDocuments(collection, query);
+
+  const resolvedOptions = resolveAnalysisOptions(
+    Object.assign({}, validatedOptions, { limit }),
+    { collectionName: collection.collectionName }
+  );
+
+  return materializeAnalysisConfig(resolvedOptions);
+};
+
+/**
+ * @param {MongoCollection} collection
+ * @param {MaterializedAnalysisConfig} config
+ * @returns {AsyncIterable<MongoDocument>}
+ */
+const buildCursor = (collection, config) => {
+  let cursor = collection.find(config.query).sort(/** @type {import('mongodb').Sort} */ (config.sort));
+  if (config.limit > 0) {
+    cursor = cursor.limit(config.limit);
+  }
+  return cursor;
+};
+
+/**
+ * @param {MongoCollection} collection
+ * @param {AnalysisOptionsInput} [options]
+ * @returns {Promise<VarietyResultRow[]>}
+ */
+const analyzeCollection = async (collection, options) => {
+  const typedCollection = ensureCollection(collection);
+  const source = ensureOptionsObject(options);
+  assertSupportedOptions(source);
+  const validatedOptions = /** @type {AnalysisOptionsInput} */ (validateAnalysisOptions(source));
+  const config = await resolveDriverConfig(typedCollection, validatedOptions);
+  const interimResults = engine.createAnalysisState();
+
+  for await (const document of buildCursor(typedCollection, config)) {
+    engine.ingestDocument(config, interimResults, document, () => {});
+  }
+
+  const documentsCount = await countMatchingDocuments(typedCollection, config.query, config.limit);
+  return /** @type {VarietyResultRow[]} */ (engine.finalizeResults(config, interimResults, documentsCount));
+};
+
+/**
+ * @param {MongoDb} db
+ * @param {string} collectionName
+ * @param {AnalysisOptionsInput} [options]
+ * @returns {Promise<VarietyResultRow[]>}
+ */
+const analyzeDbCollection = async (db, collectionName, options) => {
+  const typedDb = ensureDb(db);
+  const typedCollectionName = ensureCollectionName(collectionName);
+  return analyzeCollection(typedDb.collection(typedCollectionName), options);
+};
+
+module.exports = {
+  analyzeCollection,
+  analyzeDbCollection,
+};

--- a/mongo-driver/adapter.js
+++ b/mongo-driver/adapter.js
@@ -209,8 +209,8 @@ const buildCursor = (collection, config) => {
  */
 const analyzeCollection = async (collection, options) => {
   const typedCollection = ensureCollection(collection);
-  if (typeof options === 'undefined' || isPlainOptionsObject(options)) {
-    assertSupportedOptions(options ?? {});
+  if (isPlainOptionsObject(options)) {
+    assertSupportedOptions(options);
   }
   const validatedOptions = /** @type {AnalysisOptionsInput} */ (validateAnalysisOptions(options));
   const config = await resolveDriverConfig(typedCollection, validatedOptions);

--- a/mongo-driver/adapter.js
+++ b/mongo-driver/adapter.js
@@ -48,6 +48,8 @@ const engine = /** @type {VarietyEngineApi} */ (
   /** @type {unknown} */ (require(path.join(__dirname, '..', 'core', 'engine.js')))
 );
 
+// Keep this analysis-only allowlist in sync with core/config.js when new shared
+// options become meaningful for direct MongoDB Node driver callers.
 const SUPPORTED_ANALYSIS_OPTION_NAMES = new Set([
   'query',
   'limit',
@@ -74,22 +76,6 @@ const UNSUPPORTED_OPTION_REASONS = {
   resultsPass: 'result persistence is deferred and not yet supported here.',
   resultsUser: 'result persistence is deferred and not yet supported here.',
   secondaryOk: 'secondaryOk is a Mongo shell runtime option, not a Node-driver analysis option.',
-};
-
-/**
- * @param {AnalysisOptionsInput | undefined} input
- * @returns {Record<string, unknown>}
- */
-const ensureOptionsObject = (input) => {
-  if (typeof input === 'undefined') {
-    return {};
-  }
-
-  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('MongoDB Node driver analysis options must be an object.');
-  }
-
-  return input;
 };
 
 /**
@@ -215,17 +201,18 @@ const buildCursor = (collection, config) => {
  */
 const analyzeCollection = async (collection, options) => {
   const typedCollection = ensureCollection(collection);
-  const source = ensureOptionsObject(options);
+  const validatedOptions = /** @type {AnalysisOptionsInput} */ (validateAnalysisOptions(options));
+  const source = typeof options === 'undefined' ? {} : /** @type {Record<string, unknown>} */ (options);
   assertSupportedOptions(source);
-  const validatedOptions = /** @type {AnalysisOptionsInput} */ (validateAnalysisOptions(source));
   const config = await resolveDriverConfig(typedCollection, validatedOptions);
   const interimResults = engine.createAnalysisState();
+  let documentsCount = 0;
 
   for await (const document of buildCursor(typedCollection, config)) {
     engine.ingestDocument(config, interimResults, document, () => {});
+    documentsCount += 1;
   }
 
-  const documentsCount = await countMatchingDocuments(typedCollection, config.query, config.limit);
   return /** @type {VarietyResultRow[]} */ (engine.finalizeResults(config, interimResults, documentsCount));
 };
 

--- a/mongo-driver/adapter.js
+++ b/mongo-driver/adapter.js
@@ -79,6 +79,14 @@ const UNSUPPORTED_OPTION_REASONS = {
 };
 
 /**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+const isPlainOptionsObject = (value) => {
+  return value !== null && !Array.isArray(value) && typeof value === 'object';
+};
+
+/**
  * @param {Record<string, unknown>} source
  * @returns {void}
  */
@@ -201,9 +209,10 @@ const buildCursor = (collection, config) => {
  */
 const analyzeCollection = async (collection, options) => {
   const typedCollection = ensureCollection(collection);
+  if (typeof options === 'undefined' || isPlainOptionsObject(options)) {
+    assertSupportedOptions(options ?? {});
+  }
   const validatedOptions = /** @type {AnalysisOptionsInput} */ (validateAnalysisOptions(options));
-  const source = typeof options === 'undefined' ? {} : /** @type {Record<string, unknown>} */ (options);
-  assertSupportedOptions(source);
   const config = await resolveDriverConfig(typedCollection, validatedOptions);
   const interimResults = engine.createAnalysisState();
   let documentsCount = 0;

--- a/test/cases/mongo-driver/AdapterTest.js
+++ b/test/cases/mongo-driver/AdapterTest.js
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+import assert from 'assert/strict';
+import { createRequire } from 'module';
+import { BSONSymbol } from 'mongodb';
+import sampleData from '../../fixtures/seed-data.js';
+import AnalysisResultsValidator from '../../helpers/AnalysisResultsValidator.js';
+import VarietyHarness from '../../helpers/VarietyHarness.js';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const driverAdapterModule = /** @type {typeof import('../../../mongo-driver/adapter.js')} */ (require('../../../mongo-driver/adapter.js'));
+const { analyzeCollection, analyzeDbCollection } = driverAdapterModule;
+
+const test = new VarietyHarness('test', 'users');
+
+/**
+ * @returns {import('mongodb').Collection<import('mongodb').Document>}
+ */
+const getConnectedCollection = () => {
+  if (!test.coll) {
+    throw new Error('Collection connection is not available.');
+  }
+
+  return test.coll;
+};
+
+/**
+ * @param {import('mongodb').Document[]} documents
+ * @returns {import('mongodb').Collection<import('mongodb').Document>}
+ */
+const createFakeCollection = (documents) => {
+  const state = {
+    limit: 0,
+  };
+
+  return /** @type {import('mongodb').Collection<import('mongodb').Document>} */ ({
+    collectionName: 'fake',
+    countDocuments(/** @type {Record<string, unknown>} */ query, options) {
+      assert.deepEqual(query, {});
+      const limit = options && typeof options.limit === 'number' ? options.limit : documents.length;
+      return Promise.resolve(Math.min(limit, documents.length));
+    },
+    find(/** @type {Record<string, unknown>} */ query) {
+      assert.deepEqual(query, {});
+
+      return {
+        sort(/** @type {Record<string, unknown>} */ sortSpec) {
+          assert.deepEqual(sortSpec, { _id: -1 });
+          return this;
+        },
+        limit(/** @type {number} */ limit) {
+          state.limit = limit;
+          return this;
+        },
+        async *[Symbol.asyncIterator]() {
+          const resultDocuments = state.limit > 0 ? documents.slice(0, state.limit) : documents;
+          for (const document of resultDocuments) {
+            await Promise.resolve();
+            yield document;
+          }
+        },
+      };
+    },
+  });
+};
+
+describe('MongoDB Node driver adapter', () => {
+
+  beforeEach(() => test.init(sampleData));
+  afterEach(() => test.cleanUp());
+
+  it('analyzes a MongoDB Collection directly and returns structured results', async () => {
+    const results = new AnalysisResultsValidator(
+      await analyzeCollection(getConnectedCollection(), { lastValue: true })
+    );
+
+    results.validateResultsCount(7);
+    results.validate('_id', 5, 100.0, { ObjectId: 5 });
+    results.validate('name', 5, 100.0, { String: 5 }, 'Jim');
+    results.validate('bio', 3, 60.0, { String: 3 }, 'Ça va?');
+    results.validate('birthday', 2, 40.0, { Date: 2 }, '1984-03-14T00:00:00.000Z');
+    results.validate('pets', 2, 40.0, { String: 1, Array: 1 }, 'egret');
+    results.validate('someBinData', 1, 20.0, { 'BinData-generic': 1 });
+    results.validate('someWeirdLegacyKey', 1, 20.0, { String: 1 }, 'I like Ike!');
+  });
+
+  it('analyzes a Db plus collectionName and keeps limited-percent semantics', async () => {
+    const results = new AnalysisResultsValidator(
+      await analyzeDbCollection(test.getDb('test'), 'users', {
+        limit: 2,
+        query: { bio: { $exists: true } },
+        sort: { name: 1 },
+      })
+    );
+
+    results.validateResultsCount(4);
+    results.validate('_id', 2, 100.0, { ObjectId: 2 });
+    results.validate('name', 2, 100.0, { String: 2 });
+    results.validate('bio', 2, 100.0, { String: 2 });
+    results.validate('birthday', 1, 50.0, { Date: 1 });
+  });
+
+  it('preserves driver-native BSON wrappers yielded by the cursor', async () => {
+    const results = new AnalysisResultsValidator(
+      await analyzeCollection(createFakeCollection([{ symbol: new BSONSymbol('mysymbol') }]))
+    );
+
+    results.validateResultsCount(1);
+    results.validate('symbol', 1, 100.0, { BSONSymbol: 1 });
+  });
+
+  it('rejects formatter, persistence, plugin, and shell-only options clearly', async () => {
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), { outputFormat: 'json' }),
+      /does not support "outputFormat"/
+    );
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), { persistResults: true }),
+      /does not support "persistResults"/
+    );
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), /** @type {any} */ ({ plugins: './csv-plugin.js' })),
+      /does not support "plugins"/
+    );
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), /** @type {any} */ ({ secondaryOk: true })),
+      /does not support "secondaryOk"/
+    );
+  });
+
+  it('rejects unknown option keys before starting analysis', async () => {
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), /** @type {any} */ ({ banana: true })),
+      /Unknown MongoDB Node driver analysis option: "banana"/
+    );
+  });
+});

--- a/test/cases/mongo-driver/AdapterTest.js
+++ b/test/cases/mongo-driver/AdapterTest.js
@@ -110,6 +110,14 @@ describe('MongoDB Node driver adapter', () => {
     results.validate('symbol', 1, 100.0, { BSONSymbol: 1 });
   });
 
+  it('returns empty results for an empty cursor', async () => {
+    const results = new AnalysisResultsValidator(
+      await analyzeCollection(createFakeCollection([]))
+    );
+
+    results.validateResultsCount(0);
+  });
+
   it('rejects formatter, persistence, plugin, and shell-only options clearly', async () => {
     await assert.rejects(
       analyzeCollection(createFakeCollection([]), { outputFormat: 'json' }),

--- a/test/cases/mongo-driver/AdapterTest.js
+++ b/test/cases/mongo-driver/AdapterTest.js
@@ -137,6 +137,13 @@ describe('MongoDB Node driver adapter', () => {
     );
   });
 
+  it('rejects unsupported options before validating their values', async () => {
+    await assert.rejects(
+      analyzeCollection(createFakeCollection([]), /** @type {any} */ ({ outputFormat: 123 })),
+      /does not support "outputFormat"/
+    );
+  });
+
   it('rejects unknown option keys before starting analysis', async () => {
     await assert.rejects(
       analyzeCollection(createFakeCollection([]), /** @type {any} */ ({ banana: true })),


### PR DESCRIPTION
## Summary
- add a private `mongo-driver/adapter.js` boundary that analyzes a MongoDB Node driver `Collection` or `Db` without shelling out
- keep the first adapter scope analysis-only by rejecting formatter, persistence, plugin, and shell-only options clearly
- add focused `mongo-driver` tests plus contributor docs for the new internal boundary

## Why
- continue the #263 groundwork after #332, #339, and #346 without committing to a public package/export shape yet
- prove the Node-driver path can reuse the shared config and engine layers while preserving driver-native BSON behavior
- keep this PR narrowly useful even if the eventual public API shape changes later

## Validation
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run lint:markdown`
- `npm run lint:spdx`
- pre-commit hook: `npm run lint:pre-commit`
- focused container-backed test using the existing local Variety test image:
  - `./node_modules/.bin/mocha --reporter spec --timeout 15000 test/cases/mongo-driver/AdapterTest.js`

Refs #263 (@JamesCropcho).
