### PR TITLE
Use service containers for modern MongoDB CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,48 @@ jobs:
     needs: changes
     if: needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:${{ matrix.mongodb-version }}
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: ['8.2', '8.0', '7.0', '5.0']
+        mongodb-version: ['8.2', '8.0', '7.0']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+        env:
+          HUSKY: '0'
+      - name: Start Mongo shell client
+        run: |
+          # The mongodb service has already pulled this image; avoid a duplicate registry pull.
+          docker run --detach --rm --pull never \
+            --name variety-mongosh-client \
+            --network host \
+            --volume "$PWD:$PWD" \
+            --workdir "$PWD" \
+            mongo:${{ matrix.mongodb-version }} \
+            tail -f /dev/null
+      - run: npm run test:mocha
+        env:
+          MONGO_SHELL_COMMAND: ./test/bin/mongosh-in-service-container.sh
+
+  test-legacy:
+    name: Test (Node 22, MongoDB 5.0)
+    needs: changes
+    if: needs.changes.outputs.only-markdown != 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -102,16 +140,26 @@ jobs:
       - run: mkdir -p docker/Dockerfiles
       - run: npm run test:container
         env:
-          MONGODB_VERSION: ${{ matrix.mongodb-version }}
+          MONGODB_VERSION: '5.0'
           NODEJS_VERSION: '22'
           DOCKER_BUILD_CACHE: gha
-          DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-${{ matrix.mongodb-version }}-node-22
+          DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-5.0-node-22
 
   test-smoke:
     name: Smoke Test (Node 24, MongoDB 8.2)
     needs: changes
     if: needs.changes.outputs.only-markdown != 'true'
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:8.2
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -121,21 +169,23 @@ jobs:
       - run: npm ci
         env:
           HUSKY: '0'
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - name: Expose GitHub Actions cache runtime
-        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
-      - run: mkdir -p docker/Dockerfiles
-      - run: npm run test:container
+      - name: Start Mongo shell client
+        run: |
+          # The mongodb service has already pulled this image; avoid a duplicate registry pull.
+          docker run --detach --rm --pull never \
+            --name variety-mongosh-client \
+            --network host \
+            --volume "$PWD:$PWD" \
+            --workdir "$PWD" \
+            mongo:8.2 \
+            tail -f /dev/null
+      - run: npm run test:mocha
         env:
-          MONGODB_VERSION: '8.2'
-          NODEJS_VERSION: '24'
-          DOCKER_BUILD_CACHE: gha
-          DOCKER_BUILD_CACHE_SCOPE: variety-test-${{ runner.os }}-${{ runner.arch }}-mongodb-8.2-node-24
+          MONGO_SHELL_COMMAND: ./test/bin/mongosh-in-service-container.sh
 
   required-ci-gate:
     name: Required CI Gate
-    needs: [changes, lint, test, test-smoke]
+    needs: [changes, lint, test, test-legacy, test-smoke]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +195,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          TEST_LEGACY_RESULT: ${{ needs.test-legacy.result }}
           SMOKE_RESULT: ${{ needs.test-smoke.result }}
         run: |
           {
@@ -155,6 +206,7 @@ jobs:
             echo "| Detect changes | $CHANGES_RESULT |"
             echo "| Lint | $LINT_RESULT |"
             echo "| Test matrix | $TEST_RESULT |"
+            echo "| Legacy test | $TEST_LEGACY_RESULT |"
             echo "| Smoke test | $SMOKE_RESULT |"
             echo
             echo "only-markdown: \`$ONLY_MARKDOWN\`"
@@ -171,8 +223,8 @@ jobs:
           fi
 
           if [ "$ONLY_MARKDOWN" = "true" ]; then
-            if [ "$TEST_RESULT" != "skipped" ] || [ "$SMOKE_RESULT" != "skipped" ]; then
-              echo "Markdown-only changes should skip test jobs; got test=$TEST_RESULT smoke=$SMOKE_RESULT." >&2
+            if [ "$TEST_RESULT" != "skipped" ] || [ "$TEST_LEGACY_RESULT" != "skipped" ] || [ "$SMOKE_RESULT" != "skipped" ]; then
+              echo "Markdown-only changes should skip test jobs; got test=$TEST_RESULT legacy=$TEST_LEGACY_RESULT smoke=$SMOKE_RESULT." >&2
               exit 1
             fi
 
@@ -182,6 +234,11 @@ jobs:
 
           if [ "$TEST_RESULT" != "success" ]; then
             echo "Test matrix did not succeed." >&2
+            exit 1
+          fi
+
+          if [ "$TEST_LEGACY_RESULT" != "success" ]; then
+            echo "Legacy test did not succeed." >&2
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ The built `variety.js` is committed to the repository so that `mongosh variety.j
 
 ## Testing
 
-`npm test` runs ESLint plus the default Docker-backed integration test lane. If you already have MongoDB listening on `localhost:27017` and want to run only the mocha suite directly, use:
+`npm test` runs ESLint plus the default Docker-backed integration test lane. If you already have MongoDB listening on `localhost:27017` and a MongoDB shell (`mongosh` or the legacy `mongo`) on `PATH`, you can run only the mocha suite directly with:
 
 ```
 npm run test:mocha
@@ -123,7 +123,7 @@ npm run test:container
 The script downloads one of [the official MongoDB images](https://hub.docker.com/_/mongo/) (based on your provided version),
 starts the database, executes the test suite against it (inside the container) and stops the DB.
 
-The Docker harness prefers `mongosh` when it is available and falls back to the legacy `mongo` shell for older images.
+The Docker harness prefers `mongosh` when it is available and falls back to the legacy `mongo` shell for older images. When `node_modules` is already present in the mounted worktree, the container reuses it; otherwise it installs dependencies inside the container before running Mocha.
 
 Dockerized tests default to MongoDB 8.2 on Node.js 22. You can override `MONGODB_VERSION` and `NODEJS_VERSION` when you want to try another supported combination:
 
@@ -134,24 +134,25 @@ MONGODB_VERSION=5.0 npm run test:container
 MONGODB_VERSION=8.2 NODEJS_VERSION=24 npm run test:container
 ```
 
-GitHub Actions runs a MongoDB matrix on Node.js 22: `8.2` (current stable), `8.0` (current major baseline), `7.0` (previous stable), and `5.0` (which ships only the legacy `mongo` shell, exercising that code path). A single Node.js 24 smoke test also runs against MongoDB 8.2. MongoDB 6.0+ no longer ships the legacy `mongo` shell, so `5.0` is the newest version available for `mongo`-shell coverage.
+GitHub Actions runs a MongoDB matrix on Node.js 22: `8.2` (current stable), `8.0` (current major baseline), `7.0` (previous stable), and `5.0` (which ships only the legacy `mongo` shell, exercising that code path). The modern `8.2`, `8.0`, and `7.0` lanes run Mocha on the hosted Node.js runner against a MongoDB service container. Each modern lane also starts a mounted `mongo:<version>` shell-client container and sets `MONGO_SHELL_COMMAND` to `test/bin/mongosh-in-service-container.sh`, so shell-backed tests can execute the checked-out `variety.js` without building a custom test image. The MongoDB 5.0 lane keeps using `npm run test:container` for legacy `mongo` shell coverage. A single Node.js 24 smoke test runs against MongoDB 8.2 using the same service-container pattern. MongoDB 6.0+ no longer ships the legacy `mongo` shell, so `5.0` is the newest version available for `mongo`-shell coverage.
 
-In GitHub Actions, Dockerized test jobs opt into Docker Buildx's GitHub
-Actions cache for the generated test images. Cache scopes are separated by
-runner OS/architecture, MongoDB version, and Node.js version. This cache is
-only an optimization: cache misses, unavailable cache support, or cache-backed
-build failures fall back to a clean `docker build --no-cache` rebuild so CI
-behavior remains predictable. Local `npm run test:container` runs keep the clean
-rebuild behavior by default.
+In GitHub Actions, the remaining Dockerized MongoDB 5.0 test job opts into
+Docker Buildx's GitHub Actions cache for the generated test image. Cache scopes
+are separated by runner OS/architecture, MongoDB version, and Node.js version.
+This cache is only an optimization: cache misses, unavailable cache support, or
+cache-backed build failures fall back to a clean `docker build --no-cache`
+rebuild so CI behavior remains predictable. Local `npm run test:container` runs
+keep the clean rebuild behavior by default.
 
 **Required CI Gate and markdown-only pull requests:** The `changes` job detects
 pull requests that only modify existing `.md` files. For those PRs, CI still
-runs markdown linting, but the Dockerized test matrix and Node.js 24 smoke test
-are skipped at the job level so GitHub shows those jobs as skipped rather than
-successful. The always-running `Required CI Gate` job is the branch-protection
-status that should be required instead of the individual test-matrix and smoke
-test statuses: it passes only when either full CI passed, or the change is
-markdown-only and the test jobs were intentionally skipped. This replaces the
+runs markdown linting, but the service-backed test matrix, Dockerized legacy
+test, and Node.js 24 smoke test are skipped at the job level so GitHub shows
+those jobs as skipped rather than successful. The always-running `Required CI Gate`
+job is the branch-protection status that should be required instead of
+the individual test-matrix, legacy-test, and smoke-test statuses: it passes only
+when either full CI passed, or the change is markdown-only and the test jobs
+were intentionally skipped. This replaces the
 workaround from #295, which satisfied required matrix check names by reporting
 green test jobs even when the test commands did not run.
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -20,10 +20,16 @@ cd "$VARIETY_DOCKERDIR" || exit
 # NVM is already sourced; redirect HOME so npm and mongosh keep their caches
 # and shell history out of /data/db, which mongod owns at runtime.
 # Keep it out of the mounted repo so shell logs do not pollute the worktree.
+# If dependencies must be installed in-container, keep that install hook-free.
+export HUSKY=0
 export HOME=/tmp/variety-home
 mkdir -p "$HOME"
 
-npm install || { echo "npm install failed"; exit 1; }
+if [ -x node_modules/.bin/mocha ]; then
+  echo "Using mounted node_modules"
+else
+  npm install || { echo "npm install failed"; exit 1; }
+fi
 
 mongo_ping() {
   if command -v mongosh > /dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint:markdown": "./node_modules/.bin/markdownlint '**/*.md' '**/*.markdown' --ignore 'node_modules/**' --ignore '.claude/worktrees/**' --ignore '.worktrees/**' --ignore 'worktrees/**'",
     "lint:yaml": "git ls-files -z -- '*.yml' '*.yaml' | node scripts/lint-yaml.js",
     "lint:dockerfile": "hadolint docker/Dockerfile.template",
-    "lint:shell": "shellcheck docker/init.sh test/bin/test-in-container.sh",
+    "lint:shell": "shellcheck docker/init.sh test/bin/test-in-container.sh test/bin/mongosh-in-service-container.sh",
     "lint:spdx": "node scripts/check-spdx.js",
     "lint:pre-commit": "run-p verify:build lint typecheck",
     "typecheck": "./node_modules/.bin/tsc --project .tsconfig.checkjs.json",

--- a/test/bin/mongosh-in-service-container.sh
+++ b/test/bin/mongosh-in-service-container.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: © 2026 James Cropcho <numerate_penniless652@dralias.com>
+set -e
+
+CONTAINER=${MONGO_SHELL_CONTAINER:-variety-mongosh-client}
+WORKDIR=${MONGO_SHELL_WORKDIR:-$PWD}
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo "Error: docker is required to run mongosh from the service-container test client" >&2
+  exit 1
+fi
+
+exec docker exec --workdir "$WORKDIR" "$CONTAINER" mongosh "$@"

--- a/test/helpers/MongoShellRunner.js
+++ b/test/helpers/MongoShellRunner.js
@@ -27,16 +27,20 @@ const toOutputText = (value) => value ? String(value) : '';
  */
 const findMongoShellCommand = async () => {
   if (!mongoShellCommandPromise) {
-    mongoShellCommandPromise = execFile('sh', ['-lc', `
-      if command -v mongosh >/dev/null 2>&1; then
-        printf mongosh
-      elif command -v mongo >/dev/null 2>&1; then
-        printf mongo
-      else
-        printf 'Neither mongosh nor mongo is available in PATH.' >&2
-        exit 127
-      fi
-    `]).then((result) => toOutputText(result.stdout).trim());
+    if (process.env['MONGO_SHELL_COMMAND']) {
+      mongoShellCommandPromise = Promise.resolve(process.env['MONGO_SHELL_COMMAND']);
+    } else {
+      mongoShellCommandPromise = execFile('sh', ['-lc', `
+        if command -v mongosh >/dev/null 2>&1; then
+          printf mongosh
+        elif command -v mongo >/dev/null 2>&1; then
+          printf mongo
+        else
+          printf 'Neither mongosh nor mongo is available in PATH.' >&2
+          exit 127
+        fi
+      `]).then((result) => toOutputText(result.stdout).trim());
+    }
   }
 
   return mongoShellCommandPromise;


### PR DESCRIPTION
## Summary
- run the MongoDB 8.2/8.0/7.0 matrix lanes and Node 24 smoke test against GitHub Actions MongoDB services instead of building custom test images
- add a mounted Docker mongosh client wrapper plus MONGO_SHELL_COMMAND override for shell-backed tests
- keep MongoDB 5.0 on the legacy container path; that lane now reuses mounted node_modules when available and falls back to an in-container npm install with HUSKY disabled when not
- document the service-client image reuse assumption and update CONTRIBUTING.md for the new CI layout

## Validation
- npm run lint:yaml
- npm run lint:shell
- npm run lint:markdown
- npm run lint:eslint
- npm run lint:json
- npm run lint:spdx
- npm run typecheck
- git diff --check
- MONGO_SHELL_COMMAND=/bin/echo smoke check for the shell override
- MONGODB_VERSION=5.0 npm run test:container (136 passing)
- git commit hook ran npm run lint:pre-commit successfully