### PR TITLE
Work around mongod 8.x SIGSEGV on kernel 6.19 (SERVER-121912)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
     services:
       mongodb:
         image: mongo:${{ matrix.mongodb-version }}
+        # SERVER-121912 tcmalloc-google / kernel 6.19 rseq workaround — see docker/init.sh:25
+        env:
+          GLIBC_TUNABLES: glibc.pthread.rseq=1
         ports:
           - 27017:27017
         options: >-
@@ -153,6 +156,9 @@ jobs:
     services:
       mongodb:
         image: mongo:8.2
+        # SERVER-121912 tcmalloc-google / kernel 6.19 rseq workaround — see docker/init.sh:25
+        env:
+          GLIBC_TUNABLES: glibc.pthread.rseq=1
         ports:
           - 27017:27017
         options: >-

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -22,25 +22,24 @@ echo "======================================"
 # setting ulimit here ensures the limit is not suppressed at the process level.
 ulimit -c unlimited 2>/dev/null || true
 
-# Work around the tcmalloc-google / Linux kernel 6.19 rseq ABI incompatibility
-# that causes mongod 8.0+ to crash with SIGSEGV mid-run (MongoDB SERVER-121912).
+# Work around a tcmalloc-google crash on Linux kernel 6.19+ (MongoDB SERVER-121912).
 # tcmalloc-google (introduced in mongod 8.0) implements per-CPU caches via
-# restartable sequences (rseq). Kernel 6.19 changed the rseq ABI in a way that
-# tcmalloc-google's implementation does not handle correctly, producing a SIGSEGV
-# roughly 30 seconds into any workload that drives significant memory allocation.
-# mongod 7.x uses the old tcmalloc allocator (no rseq) and is not affected.
+# restartable sequences (rseq), but relies on rseq behavior the spec does not
+# guarantee. Linux kernel 6.19+ exposed this violation, causing mongod 8.0+ to
+# crash with SIGSEGV roughly 30 seconds into any workload that drives significant
+# memory allocation. mongod 7.x uses the old tcmalloc (no rseq) and is unaffected.
 #
 # Fix: setting glibc.pthread.rseq=1 causes glibc to register the per-thread rseq
-# struct before tcmalloc-google does, using the correct kernel 6.19 ABI. When
-# tcmalloc-google then attempts its own registration, the kernel rejects it —
-# rseq is a per-thread singleton — and tcmalloc falls back to per-thread caches,
-# which do not use rseq. The crash is prevented.
-# Note: =0 (disabling glibc's rseq) does not help because tcmalloc-google
-# bypasses glibc and calls the rseq syscall directly.
+# struct before tcmalloc-google does. When tcmalloc-google then attempts its own
+# registration, the kernel rejects it — rseq is a per-thread singleton — and
+# tcmalloc falls back to per-thread caches, which do not use rseq. The crash is
+# prevented. Note: =0 (disabling glibc's rseq) does not help because tcmalloc-
+# google bypasses glibc and calls the rseq syscall directly.
 #
 # This line can be removed once MongoDB ships a corrected tcmalloc-google in all
 # affected release lines. Track: https://jira.mongodb.org/browse/SERVER-121912
-# Source: https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8392408&focusedId=8392408&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8392408
+# Root-cause analysis: https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8392408&focusedId=8392408&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8392408
+# Workaround source:  https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8395283&focusedId=8395283&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8395283
 export GLIBC_TUNABLES="${GLIBC_TUNABLES:+${GLIBC_TUNABLES}:}glibc.pthread.rseq=1"
 # Start MongoDB quietly. Newer server releases removed --nojournal.
 MONGOD_LOG=/tmp/variety-mongod.log

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -22,6 +22,26 @@ echo "======================================"
 # setting ulimit here ensures the limit is not suppressed at the process level.
 ulimit -c unlimited 2>/dev/null || true
 
+# Work around the tcmalloc-google / Linux kernel 6.19 rseq ABI incompatibility
+# that causes mongod 8.0+ to crash with SIGSEGV mid-run (MongoDB SERVER-121912).
+# tcmalloc-google (introduced in mongod 8.0) implements per-CPU caches via
+# restartable sequences (rseq). Kernel 6.19 changed the rseq ABI in a way that
+# tcmalloc-google's implementation does not handle correctly, producing a SIGSEGV
+# roughly 30 seconds into any workload that drives significant memory allocation.
+# mongod 7.x uses the old tcmalloc allocator (no rseq) and is not affected.
+#
+# Fix: setting glibc.pthread.rseq=1 causes glibc to register the per-thread rseq
+# struct before tcmalloc-google does, using the correct kernel 6.19 ABI. When
+# tcmalloc-google then attempts its own registration, the kernel rejects it —
+# rseq is a per-thread singleton — and tcmalloc falls back to per-thread caches,
+# which do not use rseq. The crash is prevented.
+# Note: =0 (disabling glibc's rseq) does not help because tcmalloc-google
+# bypasses glibc and calls the rseq syscall directly.
+#
+# This line can be removed once MongoDB ships a corrected tcmalloc-google in all
+# affected release lines. Track: https://jira.mongodb.org/browse/SERVER-121912
+# Source: https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8392408&focusedId=8392408&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8392408
+export GLIBC_TUNABLES="${GLIBC_TUNABLES:+${GLIBC_TUNABLES}:}glibc.pthread.rseq=1"
 # Start MongoDB quietly. Newer server releases removed --nojournal.
 MONGOD_LOG=/tmp/variety-mongod.log
 mongod --logpath "$MONGOD_LOG" &


### PR DESCRIPTION
## Background

Closes #368. The full investigation — reproduction, bisect, and root-cause identification — is in that issue. This PR contains only the fix.

`npm run test:container` crashed with a mongod SIGSEGV mid-run on MongoDB 8.x whenever the host runs Linux kernel 6.19. The crash was silent: mongod accepted connections normally, ran for ~30 seconds, then died with exit code 139 and no backtrace in its own log. The watchdog added in #372 made it observable, which enabled the investigation in #368.

## Root cause

MongoDB 8.0 switched from the old `tcmalloc` allocator to `tcmalloc-google`, which uses per-CPU caches backed by restartable sequences (rseq). `tcmalloc-google` relies on rseq behavior the spec does not guarantee; Linux kernel 6.19+ exposed this violation (see commit `39a167560a61`, "rseq: Optimize event setting"), causing mongod to crash with SIGSEGV during any workload that drives significant memory allocation — which the full Mocha suite reliably does in the single-container topology.

mongod 7.x uses the old `tcmalloc` (no rseq) and is not affected. The version boundary was confirmed by bisect:

| mongod | Result |
|--------|--------|
| 7.0.31 (`tcmalloc`) | 142 passing |
| 8.0.20 (`tcmalloc-google`) | SIGSEGV ~30s in |
| 8.2.6 (`tcmalloc-google`) | SIGSEGV ~30s in |
| 8.2.7 (`tcmalloc-google`) | SIGSEGV ~30s in |

## Why the fix works

Setting `GLIBC_TUNABLES=…:glibc.pthread.rseq=1` in mongod's process environment before launch causes glibc to register the per-thread rseq struct first. When `tcmalloc-google` subsequently attempts its own rseq registration, the kernel rejects it — rseq is a per-thread singleton — and tcmalloc falls back to per-thread caches, which do not use rseq. The crash is prevented.

Setting `=0` instead (disabling glibc's rseq registration) does **not** help: `tcmalloc-google` bypasses glibc and issues the `rseq` syscall directly, so glibc stepping aside makes no difference.

Root-cause analysis: [SERVER-121912 comment 8392408](https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8392408&focusedId=8392408&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8392408). Workaround source: [SERVER-121912 comment 8395283](https://jira.mongodb.org/browse/SERVER-121912?focusedCommentId=8395283&focusedId=8395283&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8395283).

## When this can be removed

Once MongoDB ships a corrected `tcmalloc-google` across all affected release lines, the `GLIBC_TUNABLES` line in `docker/init.sh` and the two `env:` entries in `.github/workflows/ci.yml` can be deleted. Track [SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912) for upstream progress. (MongoDB 8.3 added an explicit startup guard that refuses to start on kernel 6.19, but 8.3 is not yet in the test matrix.)

## Test results

Verified on kernel `6.19.14-200.fc43.x86_64` with this branch:

| mongod | Before | After |
|--------|--------|-------|
| 8.0.20 | SIGSEGV | 142 passing |
| 8.2.7 | SIGSEGV | 142 passing |
| 7.0.31 | 142 passing (unaffected) | 142 passing |